### PR TITLE
Add SQL script runner + sidebar-toggle crash fix

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -7,6 +7,31 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		490E96B62FA4217200DDF37F /* SqlPlusDirective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B52FA4217200DDF37F /* SqlPlusDirective.swift */; };
+		490E96B82FA4217700DDF37F /* ScriptError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B72FA4217700DDF37F /* ScriptError.swift */; };
+		490E96BA2FA4225300DDF37F /* ScriptLexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B92FA4225300DDF37F /* ScriptLexer.swift */; };
+		490E96BC2FA422AF00DDF37F /* ScriptLexerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96BB2FA422AF00DDF37F /* ScriptLexerTests.swift */; };
+		490E96BE2FA4239500DDF37F /* OffsetMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96BD2FA4239500DDF37F /* OffsetMap.swift */; };
+		490E96C02FA423B000DDF37F /* SubstitutionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96BF2FA423B000DDF37F /* SubstitutionResolver.swift */; };
+		490E96C22FA423CE00DDF37F /* SubstitutionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96C12FA423CE00DDF37F /* SubstitutionResolverTests.swift */; };
+		490E96C42FA4246E00DDF37F /* ScriptRunnerEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96C32FA4246E00DDF37F /* ScriptRunnerEvent.swift */; };
+		490E96C62FA4247700DDF37F /* ConnectionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96C52FA4247700DDF37F /* ConnectionExecutor.swift */; };
+		490E96C82FA4248800DDF37F /* ScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96C72FA4248800DDF37F /* ScriptRunner.swift */; };
+		490E96CA2FA424A500DDF37F /* ScriptRunnerDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96C92FA424A500DDF37F /* ScriptRunnerDriverTests.swift */; };
+		490E96CC2FA4250C00DDF37F /* ScriptOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96CB2FA4250C00DDF37F /* ScriptOutput.swift */; };
+		490E96CE2FA4253D00DDF37F /* MiniGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96CD2FA4253D00DDF37F /* MiniGridView.swift */; };
+		490E96D02FA4255F00DDF37F /* ScriptOutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96CF2FA4255F00DDF37F /* ScriptOutputView.swift */; };
+		490E96D22FA4256F00DDF37F /* ScriptOutputModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96D12FA4256F00DDF37F /* ScriptOutputModelTests.swift */; };
+		490E96D42FA4260600DDF37F /* OracleScriptExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96D32FA4260600DDF37F /* OracleScriptExecutor.swift */; };
+		490E96D62FA426F500DDF37F /* ScriptRunnerLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96D52FA426F500DDF37F /* ScriptRunnerLiveTests.swift */; };
+		490E96D82FA4288400DDF37F /* SubstitutionInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96D72FA4288400DDF37F /* SubstitutionInputView.swift */; };
+		490E96DA2FA4296000DDF37F /* SqlPlusEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96D92FA4296000DDF37F /* SqlPlusEnvironment.swift */; };
+		490E96DC2FA4296F00DDF37F /* SqlPlusInterpreter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96DB2FA4296F00DDF37F /* SqlPlusInterpreter.swift */; };
+		490E96DE2FA4298800DDF37F /* ScriptLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96DD2FA4298800DDF37F /* ScriptLoader.swift */; };
+		490E96E02FA429E100DDF37F /* SqlPlusInterpreterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96DF2FA429E100DDF37F /* SqlPlusInterpreterTests.swift */; };
+		490E96E22FA429FB00DDF37F /* ScriptLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E12FA429FB00DDF37F /* ScriptLoaderTests.swift */; };
+		490E96E42FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E32FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift */; };
+		490E96E62FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E52FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift */; };
 		49438678273753A000D7D464 /* ResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49438677273753A000D7D464 /* ResultViewModel.swift */; };
 		4944594C28D51D31007AB2BF /* SBMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944594B28D51D31007AB2BF /* SBMainView.swift */; };
 		4944594E28D539D2007AB2BF /* SBVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944594D28D539D2007AB2BF /* SBVM.swift */; };
@@ -138,6 +163,31 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		490E96B52FA4217200DDF37F /* SqlPlusDirective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SqlPlusDirective.swift; sourceTree = "<group>"; };
+		490E96B72FA4217700DDF37F /* ScriptError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptError.swift; sourceTree = "<group>"; };
+		490E96B92FA4225300DDF37F /* ScriptLexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptLexer.swift; sourceTree = "<group>"; };
+		490E96BB2FA422AF00DDF37F /* ScriptLexerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptLexerTests.swift; sourceTree = "<group>"; };
+		490E96BD2FA4239500DDF37F /* OffsetMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetMap.swift; sourceTree = "<group>"; };
+		490E96BF2FA423B000DDF37F /* SubstitutionResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubstitutionResolver.swift; sourceTree = "<group>"; };
+		490E96C12FA423CE00DDF37F /* SubstitutionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubstitutionResolverTests.swift; sourceTree = "<group>"; };
+		490E96C32FA4246E00DDF37F /* ScriptRunnerEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunnerEvent.swift; sourceTree = "<group>"; };
+		490E96C52FA4247700DDF37F /* ConnectionExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionExecutor.swift; sourceTree = "<group>"; };
+		490E96C72FA4248800DDF37F /* ScriptRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunner.swift; sourceTree = "<group>"; };
+		490E96C92FA424A500DDF37F /* ScriptRunnerDriverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunnerDriverTests.swift; sourceTree = "<group>"; };
+		490E96CB2FA4250C00DDF37F /* ScriptOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptOutput.swift; sourceTree = "<group>"; };
+		490E96CD2FA4253D00DDF37F /* MiniGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniGridView.swift; sourceTree = "<group>"; };
+		490E96CF2FA4255F00DDF37F /* ScriptOutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptOutputView.swift; sourceTree = "<group>"; };
+		490E96D12FA4256F00DDF37F /* ScriptOutputModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptOutputModelTests.swift; sourceTree = "<group>"; };
+		490E96D32FA4260600DDF37F /* OracleScriptExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OracleScriptExecutor.swift; sourceTree = "<group>"; };
+		490E96D52FA426F500DDF37F /* ScriptRunnerLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunnerLiveTests.swift; sourceTree = "<group>"; };
+		490E96D72FA4288400DDF37F /* SubstitutionInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubstitutionInputView.swift; sourceTree = "<group>"; };
+		490E96D92FA4296000DDF37F /* SqlPlusEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SqlPlusEnvironment.swift; sourceTree = "<group>"; };
+		490E96DB2FA4296F00DDF37F /* SqlPlusInterpreter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SqlPlusInterpreter.swift; sourceTree = "<group>"; };
+		490E96DD2FA4298800DDF37F /* ScriptLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptLoader.swift; sourceTree = "<group>"; };
+		490E96DF2FA429E100DDF37F /* SqlPlusInterpreterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SqlPlusInterpreterTests.swift; sourceTree = "<group>"; };
+		490E96E12FA429FB00DDF37F /* ScriptLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptLoaderTests.swift; sourceTree = "<group>"; };
+		490E96E32FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunnerDirectivesLiveTests.swift; sourceTree = "<group>"; };
+		490E96E52FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarToggleCrashRegressionTests.swift; sourceTree = "<group>"; };
 		49438677273753A000D7D464 /* ResultViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultViewModel.swift; sourceTree = "<group>"; };
 		4944594B28D51D31007AB2BF /* SBMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBMainView.swift; sourceTree = "<group>"; };
 		4944594D28D539D2007AB2BF /* SBVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBVM.swift; sourceTree = "<group>"; };
@@ -281,6 +331,32 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		490E96B32FA4211C00DDF37F /* Script */ = {
+			isa = PBXGroup;
+			children = (
+				490E96B52FA4217200DDF37F /* SqlPlusDirective.swift */,
+				490E96B72FA4217700DDF37F /* ScriptError.swift */,
+				490E96B92FA4225300DDF37F /* ScriptLexer.swift */,
+				490E96BD2FA4239500DDF37F /* OffsetMap.swift */,
+				490E96BF2FA423B000DDF37F /* SubstitutionResolver.swift */,
+				490E96D92FA4296000DDF37F /* SqlPlusEnvironment.swift */,
+				490E96DB2FA4296F00DDF37F /* SqlPlusInterpreter.swift */,
+				490E96DD2FA4298800DDF37F /* ScriptLoader.swift */,
+			);
+			path = Script;
+			sourceTree = "<group>";
+		};
+		490E96B42FA4216800DDF37F /* Script */ = {
+			isa = PBXGroup;
+			children = (
+				490E96BB2FA422AF00DDF37F /* ScriptLexerTests.swift */,
+				490E96C12FA423CE00DDF37F /* SubstitutionResolverTests.swift */,
+				490E96DF2FA429E100DDF37F /* SqlPlusInterpreterTests.swift */,
+				490E96E12FA429FB00DDF37F /* ScriptLoaderTests.swift */,
+			);
+			path = Script;
+			sourceTree = "<group>";
+		};
 		4944594A28D51CE5007AB2BF /* SessionBrowser */ = {
 			isa = PBXGroup;
 			children = (
@@ -342,6 +418,7 @@
 				AA0000F10000000000000000 /* FullRefreshReproTests.swift */,
 				49D0ECF22F9C1E070047540A /* Editor */,
 				49D0ED042F9C34410047540A /* Results */,
+				490E96B42FA4216800DDF37F /* Script */,
 			);
 			path = MacintoraTests;
 			sourceTree = "<group>";
@@ -426,6 +503,7 @@
 				49B55F3D270ADD8D00CFB3C7 /* Macintora.entitlements */,
 				49B55F39270ADD8D00CFB3C7 /* Preview Content */,
 				49D0ECE92F9C1D480047540A /* Editor */,
+				490E96B32FA4211C00DDF37F /* Script */,
 			);
 			path = Macintora;
 			sourceTree = "<group>";
@@ -456,6 +534,14 @@
 				4947FEA5286FA39D00AEBE60 /* TableViewWithPasteboard.swift */,
 				4999469327E1777700C62AB7 /* LogView.swift */,
 				4947FEA9286FA73B00AEBE60 /* RunnableSQL.swift */,
+				490E96C32FA4246E00DDF37F /* ScriptRunnerEvent.swift */,
+				490E96C52FA4247700DDF37F /* ConnectionExecutor.swift */,
+				490E96C72FA4248800DDF37F /* ScriptRunner.swift */,
+				490E96CB2FA4250C00DDF37F /* ScriptOutput.swift */,
+				490E96CD2FA4253D00DDF37F /* MiniGridView.swift */,
+				490E96CF2FA4255F00DDF37F /* ScriptOutputView.swift */,
+				490E96D32FA4260600DDF37F /* OracleScriptExecutor.swift */,
+				490E96D72FA4288400DDF37F /* SubstitutionInputView.swift */,
 			);
 			path = Results;
 			sourceTree = "<group>";
@@ -485,6 +571,10 @@
 			isa = PBXGroup;
 			children = (
 				49D0ED052F9C346B0047540A /* ResultViewModelIntegrationTests.swift */,
+				490E96C92FA424A500DDF37F /* ScriptRunnerDriverTests.swift */,
+				490E96D12FA4256F00DDF37F /* ScriptOutputModelTests.swift */,
+				490E96D52FA426F500DDF37F /* ScriptRunnerLiveTests.swift */,
+				490E96E32FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift */,
 			);
 			path = Results;
 			sourceTree = "<group>";
@@ -523,6 +613,7 @@
 			isa = PBXGroup;
 			children = (
 				BB0000020000000000000000 /* MacintoraUITests.swift */,
+				490E96E52FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift */,
 			);
 			path = MacintoraUITests;
 			sourceTree = "<group>";
@@ -669,9 +760,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				490E96D62FA426F500DDF37F /* ScriptRunnerLiveTests.swift in Sources */,
+				490E96C22FA423CE00DDF37F /* SubstitutionResolverTests.swift in Sources */,
 				49D0ECF42F9C1E1E0047540A /* EditorSelectionBridgeTests.swift in Sources */,
 				4982889F28B41F3A00A28B04 /* MacintoraTests.swift in Sources */,
 				AA0000130000000000000000 /* TnsParserTests.swift in Sources */,
+				490E96BC2FA422AF00DDF37F /* ScriptLexerTests.swift in Sources */,
+				490E96CA2FA424A500DDF37F /* ScriptRunnerDriverTests.swift in Sources */,
 				AA0000150000000000000000 /* OracleEndpointTests.swift in Sources */,
 				AA0000170000000000000000 /* DisplayRowTests.swift in Sources */,
 				AA0000190000000000000000 /* AppDBErrorTests.swift in Sources */,
@@ -679,10 +774,14 @@
 				AA00001B0000000000000000 /* MainDocumentSaveTests.swift in Sources */,
 				AA00001D0000000000000000 /* DocumentFlowTests.swift in Sources */,
 				AA0000380000000000000000 /* SavedConnectionTests.swift in Sources */,
+				490E96D22FA4256F00DDF37F /* ScriptOutputModelTests.swift in Sources */,
 				AA00003A0000000000000000 /* JDBCURLParserTests.swift in Sources */,
+				490E96E22FA429FB00DDF37F /* ScriptLoaderTests.swift in Sources */,
 				AA00003C0000000000000000 /* KeychainServiceTests.swift in Sources */,
+				490E96E42FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift in Sources */,
 				AA00003E0000000000000000 /* ConnectionStoreTests.swift in Sources */,
 				AA0001020000000000000000 /* SessionRestorerTests.swift in Sources */,
+				490E96E02FA429E100DDF37F /* SqlPlusInterpreterTests.swift in Sources */,
 				AA0000400000000000000000 /* ConnectionDetailsCodableTests.swift in Sources */,
 				AA0000C00000000000000000 /* LegacyDocumentMigrationTests.swift in Sources */,
 				AA0000F00000000000000000 /* FullRefreshReproTests.swift in Sources */,
@@ -701,6 +800,7 @@
 				498288F728B7DCB000A28B04 /* DBIndexDetailView.swift in Sources */,
 				49D0ECF12F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift in Sources */,
 				49F481F0294A84A1005DC77F /* PersistencePreview.swift in Sources */,
+				490E96DC2FA4296F00DDF37F /* SqlPlusInterpreter.swift in Sources */,
 				498288C928B7DC5700A28B04 /* DBCacheIndex+CoreDataProperties.swift in Sources */,
 				498288CC28B7DC5700A28B04 /* DBCacheObject+CoreDataClass.swift in Sources */,
 				49EAEFA728C83685008F0B80 /* DBCacheTrigger+CoreDataProperties.swift in Sources */,
@@ -709,6 +809,7 @@
 				498288F528B7DCB000A28B04 /* DBCacheListEntryView.swift in Sources */,
 				498288E928B7DCB000A28B04 /* WindowModifier.swift in Sources */,
 				4947FEAC2870F8E400AEBE60 /* BindVarInputView.swift in Sources */,
+				490E96C02FA423B000DDF37F /* SubstitutionResolver.swift in Sources */,
 				498288CD28B7DC5700A28B04 /* Item+CoreDataClass.swift in Sources */,
 				498288C428B7DC5700A28B04 /* DBCacheSource+CoreDataClass.swift in Sources */,
 				498288F928B7DCB000A28B04 /* DBCacheVM.swift in Sources */,
@@ -720,12 +821,16 @@
 				49B55F60270ADFE300CFB3C7 /* MainModel.swift in Sources */,
 				498288EC28B7DCB000A28B04 /* SwiftUIWindow.swift in Sources */,
 				498288AC28B7DBE500A28B04 /* DatabaseCacheModel.xcdatamodeld in Sources */,
+				490E96CE2FA4253D00DDF37F /* MiniGridView.swift in Sources */,
 				49438678273753A000D7D464 /* ResultViewModel.swift in Sources */,
 				498288FD28B7DCB000A28B04 /* TableIndexListView.swift in Sources */,
+				490E96DE2FA4298800DDF37F /* ScriptLoader.swift in Sources */,
 				498288C628B7DC5700A28B04 /* ConnDatabase+CoreDataProperties.swift in Sources */,
+				490E96BE2FA4239500DDF37F /* OffsetMap.swift in Sources */,
 				49B55F32270ADD8B00CFB3C7 /* MacintoraApp.swift in Sources */,
 				498288EA28B7DCB000A28B04 /* HorizontalLabelStyle.swift in Sources */,
 				498288C228B7DC5700A28B04 /* DBCacheIndexColumn+CoreDataClass.swift in Sources */,
+				490E96B62FA4217200DDF37F /* SqlPlusDirective.swift in Sources */,
 				4944594C28D51D31007AB2BF /* SBMainView.swift in Sources */,
 				498288C828B7DC5700A28B04 /* DBCacheTableColumn+CoreDataClass.swift in Sources */,
 				498288FB28B7DCB000A28B04 /* FormattedView.swift in Sources */,
@@ -747,8 +852,10 @@
 				49EAEFAB28C9331C008F0B80 /* SourceView.swift in Sources */,
 				49C62C2427E010AE00DE69E4 /* ConnectionListView.swift in Sources */,
 				498288F228B7DCB000A28B04 /* DBCacheSearchCriteria.swift in Sources */,
+				490E96C82FA4248800DDF37F /* ScriptRunner.swift in Sources */,
 				498288C128B7DC5700A28B04 /* DBCacheIndex+CoreDataClass.swift in Sources */,
 				496FF1A12775259900CC0AD2 /* ResultViewWrapper.swift in Sources */,
+				490E96BA2FA4225300DDF37F /* ScriptLexer.swift in Sources */,
 				4944595028D68EFE007AB2BF /* SessionView.swift in Sources */,
 				498288C528B7DC5700A28B04 /* DBCacheTable+CoreDataProperties.swift in Sources */,
 				498288FE28B7DCB000A28B04 /* Persistence.swift in Sources */,
@@ -761,7 +868,9 @@
 				49EB5E0C29528995003A0E23 /* DBCacheMainView.swift in Sources */,
 				49EAEFA528C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift in Sources */,
 				AA00000D0000000000000000 /* TnsEntry.swift in Sources */,
+				490E96C42FA4246E00DDF37F /* ScriptRunnerEvent.swift in Sources */,
 				AA0000030000000000000000 /* TnsParser.swift in Sources */,
+				490E96CC2FA4250C00DDF37F /* ScriptOutput.swift in Sources */,
 				AA0000050000000000000000 /* OracleEndpoint.swift in Sources */,
 				AA0000070000000000000000 /* AppDBError.swift in Sources */,
 				AA0000090000000000000000 /* DisplayRow.swift in Sources */,
@@ -769,13 +878,19 @@
 				AA00000F0000000000000000 /* OracleEventLoopGroup.swift in Sources */,
 				AA0000110000000000000000 /* BindValue.swift in Sources */,
 				AA0000A00000000000000000 /* SavedConnection.swift in Sources */,
+				490E96D42FA4260600DDF37F /* OracleScriptExecutor.swift in Sources */,
 				AA0000320000000000000000 /* JDBCURLParser.swift in Sources */,
 				AA0000340000000000000000 /* KeychainService.swift in Sources */,
 				AA0000360000000000000000 /* ConnectionStore.swift in Sources */,
 				AA0000B00000000000000000 /* ConnectionStoreEnvironment.swift in Sources */,
+				490E96DA2FA4296000DDF37F /* SqlPlusEnvironment.swift in Sources */,
 				AA0000B20000000000000000 /* ConnectionsManagerView.swift in Sources */,
 				AA0000B40000000000000000 /* ConnectionEditorForm.swift in Sources */,
 				AA0000B70000000000000000 /* TnsImportPrompt.swift in Sources */,
+				490E96C62FA4247700DDF37F /* ConnectionExecutor.swift in Sources */,
+				490E96B82FA4217700DDF37F /* ScriptError.swift in Sources */,
+				490E96D82FA4288400DDF37F /* SubstitutionInputView.swift in Sources */,
+				490E96D02FA4255F00DDF37F /* ScriptOutputView.swift in Sources */,
 				49D0ECED2F9C1D9D0047540A /* EditorLanguage.swift in Sources */,
 				49D0ECEB2F9C1D970047540A /* EditorSelectionBridge.swift in Sources */,
 				49D0ED202F9C40000047540A /* EditorTheme.swift in Sources */,
@@ -788,6 +903,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BB0000010000000000000000 /* MacintoraUITests.swift in Sources */,
+				490E96E62FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		490E96E22FA429FB00DDF37F /* ScriptLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E12FA429FB00DDF37F /* ScriptLoaderTests.swift */; };
 		490E96E42FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E32FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift */; };
 		490E96E62FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E52FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift */; };
+		490E96E82FA43A8E00DDF37F /* ScriptBindPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E72FA43A8E00DDF37F /* ScriptBindPromptView.swift */; };
+		490E96EA2FA43C6300DDF37F /* ScriptRunnerUXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96E92FA43C6300DDF37F /* ScriptRunnerUXTests.swift */; };
 		49438678273753A000D7D464 /* ResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49438677273753A000D7D464 /* ResultViewModel.swift */; };
 		4944594C28D51D31007AB2BF /* SBMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944594B28D51D31007AB2BF /* SBMainView.swift */; };
 		4944594E28D539D2007AB2BF /* SBVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944594D28D539D2007AB2BF /* SBVM.swift */; };
@@ -188,6 +190,8 @@
 		490E96E12FA429FB00DDF37F /* ScriptLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptLoaderTests.swift; sourceTree = "<group>"; };
 		490E96E32FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunnerDirectivesLiveTests.swift; sourceTree = "<group>"; };
 		490E96E52FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarToggleCrashRegressionTests.swift; sourceTree = "<group>"; };
+		490E96E72FA43A8E00DDF37F /* ScriptBindPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptBindPromptView.swift; sourceTree = "<group>"; };
+		490E96E92FA43C6300DDF37F /* ScriptRunnerUXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunnerUXTests.swift; sourceTree = "<group>"; };
 		49438677273753A000D7D464 /* ResultViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultViewModel.swift; sourceTree = "<group>"; };
 		4944594B28D51D31007AB2BF /* SBMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBMainView.swift; sourceTree = "<group>"; };
 		4944594D28D539D2007AB2BF /* SBVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBVM.swift; sourceTree = "<group>"; };
@@ -542,6 +546,7 @@
 				490E96CF2FA4255F00DDF37F /* ScriptOutputView.swift */,
 				490E96D32FA4260600DDF37F /* OracleScriptExecutor.swift */,
 				490E96D72FA4288400DDF37F /* SubstitutionInputView.swift */,
+				490E96E72FA43A8E00DDF37F /* ScriptBindPromptView.swift */,
 			);
 			path = Results;
 			sourceTree = "<group>";
@@ -614,6 +619,7 @@
 			children = (
 				BB0000020000000000000000 /* MacintoraUITests.swift */,
 				490E96E52FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift */,
+				490E96E92FA43C6300DDF37F /* ScriptRunnerUXTests.swift */,
 			);
 			path = MacintoraUITests;
 			sourceTree = "<group>";
@@ -884,6 +890,7 @@
 				AA0000360000000000000000 /* ConnectionStore.swift in Sources */,
 				AA0000B00000000000000000 /* ConnectionStoreEnvironment.swift in Sources */,
 				490E96DA2FA4296000DDF37F /* SqlPlusEnvironment.swift in Sources */,
+				490E96E82FA43A8E00DDF37F /* ScriptBindPromptView.swift in Sources */,
 				AA0000B20000000000000000 /* ConnectionsManagerView.swift in Sources */,
 				AA0000B40000000000000000 /* ConnectionEditorForm.swift in Sources */,
 				AA0000B70000000000000000 /* TnsImportPrompt.swift in Sources */,
@@ -904,6 +911,7 @@
 			files = (
 				BB0000010000000000000000 /* MacintoraUITests.swift in Sources */,
 				490E96E62FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift in Sources */,
+				490E96EA2FA43C6300DDF37F /* ScriptRunnerUXTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora/Editor/EditorSelectionBridge.swift
+++ b/Macintora/Editor/EditorSelectionBridge.swift
@@ -38,4 +38,13 @@ enum EditorSelectionBridge {
     static func endRange(in string: String) -> Range<String.Index> {
         string.endIndex ..< string.endIndex
     }
+
+    /// Convert a UTF-16 offset range to a `Range<String.Index>` over `string`.
+    /// Used by Script Output's "reveal in editor" affordance, which carries
+    /// failure positions as UTF-16 offsets in the original (un-substituted)
+    /// script source.
+    static func range(forUTF16 utf16Range: Range<Int>, in string: String) -> Range<String.Index>? {
+        let ns = NSRange(location: utf16Range.lowerBound, length: utf16Range.count)
+        return range(for: ns, in: string)
+    }
 }

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -170,6 +170,9 @@ struct MacOraApp: App {
                 .frame(minWidth: 600, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity)
                 .environment(\.connectionStore, connectionStore)
                 .environment(\.keychainService, keychainService)
+                .task(id: config.fileURL) {
+                    config.document.fileURL = config.fileURL
+                }
         }
         .defaultSize(width: 1100, height: 700)
         .handlesExternalEvents(matching: ["file"])

--- a/Macintora/MainApp/MainDocumentVM.swift
+++ b/Macintora/MainApp/MainDocumentVM.swift
@@ -110,6 +110,13 @@ final class MainDocumentVM: ObservableObject, @unchecked Sendable {
     let dbName: String
     private var pingTask: Task<Void, Never>?
 
+    /// The on-disk URL of this document, propagated by `MainDocumentView`
+    /// from the SwiftUI `DocumentGroup`'s configuration. `nil` for untitled
+    /// documents. Used by `ResultsController` for document-relative
+    /// `@file.sql` resolution.
+    @MainActor
+    var fileURL: URL?
+
     private let oracleLogger: Logging.Logger = {
         var logger = Logging.Logger(label: "com.iliasazonov.macintora.oracle")
         logger.logLevel = .notice

--- a/Macintora/MainApp/MainDocumentVM.swift
+++ b/Macintora/MainApp/MainDocumentVM.swift
@@ -456,6 +456,28 @@ from dual;\n\n
         resultsController?.runSQL(RunnableSQL(sql: sql))
     }
 
+    // MARK: - Script run modes (Phase 4 engine; Phase 5 wires menus / shortcuts)
+
+    /// Run the entire document as a script.
+    @MainActor
+    func runScript() {
+        resultsController?.runScript(source: model.text, range: nil)
+    }
+
+    /// Run from `caret` to the end of the document.
+    @MainActor
+    func runScriptFromCursor(_ caret: String.Index) {
+        let source = model.text
+        guard caret <= source.endIndex else { return }
+        resultsController?.runScript(source: source, range: caret..<source.endIndex)
+    }
+
+    /// Run the explicit selection as a script.
+    @MainActor
+    func runScriptSelection(_ range: Range<String.Index>) {
+        resultsController?.runScript(source: model.text, range: range)
+    }
+
     @MainActor
     func stopRunningSQL() {
         if !(resultsController?.isExecuting ?? false) {

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -55,12 +55,20 @@ struct MainDocumentView: View {
     
     var body: some View {
         NavigationSplitView {
-            ConnectionListView(
-                connectionStatus: $document.isConnected,
-                details: $document.mainConnection.mainConnDetails,
-                connect: { document.connect(store: store, keychain: keychain) },
-                disconnect: document.disconnect
-            )
+            // Wrap in `ScrollView` to stabilise NavigationSplitView's safe-area
+            // inset propagation. Without it, toggling the sidebar drove
+            // `_NSSplitViewItemViewWrapper.updateConstraints` into an
+            // infinite loop ("more Update Constraints in Window passes than
+            // there are views in the window") which crashed the app —
+            // regression covered by `SidebarToggleCrashRegressionTests`.
+            ScrollView {
+                ConnectionListView(
+                    connectionStatus: $document.isConnected,
+                    details: $document.mainConnection.mainConnDetails,
+                    connect: { document.connect(store: store, keychain: keychain) },
+                    disconnect: document.disconnect
+                )
+            }
             .navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 420)
         } detail: {
             VStack {
@@ -78,8 +86,17 @@ struct MainDocumentView: View {
                         .frame(maxWidth: .infinity, minHeight: 120, idealHeight: 320, maxHeight: .infinity)
                         .focused($focusedView, equals: .codeEditor)
 
-                    ResultViewWrapper(resultsController: resultsController)
-                        .frame(maxWidth: .infinity, minHeight: 200, idealHeight: 280, maxHeight: .infinity)
+                    ResultViewWrapper(
+                        resultsController: resultsController,
+                        onRevealSource: { utf16Range in
+                            if let range = EditorSelectionBridge.range(forUTF16: utf16Range, in: document.model.text) {
+                                editorSelection = range
+                                focusedView = .codeEditor
+                            }
+                        }
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 200, idealHeight: 280, maxHeight: .infinity)
+                    .modifier(SubstitutionSheetModifier(controller: resultsController))
                 }
             }
         }
@@ -147,7 +164,39 @@ struct MainDocumentView: View {
                 .help("Execute current statement")
                 .accessibilityIdentifier("toolbar.run")
                 .accessibilityLabel("Run")
-                
+
+                // run script (whole file)
+                Button {
+                    if document.resultsController?.isExecuting ?? false {
+                        document.stopRunningSQL()
+                    } else {
+                        document.runScript()
+                    }
+                    focusedView = .codeEditor
+                } label: { Image(systemName: "play.square") }
+                    .disabled(document.isConnected != .connected)
+                    .keyboardShortcut("r", modifiers: [.command, .shift])
+                    .help("Run entire script")
+                    .accessibilityIdentifier("toolbar.runScript")
+                    .accessibilityLabel("Run Script")
+
+                // run from cursor / run selection
+                Button {
+                    if document.resultsController?.isExecuting ?? false {
+                        document.stopRunningSQL()
+                    } else if !editorSelection.isEmpty {
+                        document.runScriptSelection(editorSelection)
+                    } else {
+                        document.runScriptFromCursor(editorSelection.lowerBound)
+                    }
+                    focusedView = .codeEditor
+                } label: { Image(systemName: "play.square.stack") }
+                    .disabled(document.isConnected != .connected)
+                    .keyboardShortcut("r", modifiers: [.command, .option])
+                    .help(editorSelection.isEmpty ? "Run script from cursor" : "Run selection as script")
+                    .accessibilityIdentifier("toolbar.runScriptFromCursor")
+                    .accessibilityLabel("Run From Cursor")
+
                 // explain plan
                 Button {
                     if !(document.resultsController?.isExecuting ?? false) {
@@ -223,6 +272,23 @@ struct MainDocumentView: View {
 
 
 
+
+
+/// Owns the substitution-prompt sheet binding via `@Bindable` so SwiftUI can
+/// track stable identity for `pendingSubstitution`. A `Binding(get:set:)`
+/// closure-based binding here was triggering an Auto Layout invalidation
+/// loop inside the surrounding `NavigationSplitView` / `VSplitView`.
+private struct SubstitutionSheetModifier: ViewModifier {
+    @Bindable var controller: ResultsController
+
+    func body(content: Content) -> some View {
+        content.sheet(item: $controller.pendingSubstitution) { request in
+            SubstitutionInputView(request: request) { values in
+                controller.resolvePendingSubstitution(values)
+            }
+        }
+    }
+}
 
 
 struct MacOraDocumentView_Previews: PreviewProvider {

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -97,6 +97,7 @@ struct MainDocumentView: View {
                     )
                     .frame(maxWidth: .infinity, minHeight: 200, idealHeight: 280, maxHeight: .infinity)
                     .modifier(SubstitutionSheetModifier(controller: resultsController))
+                    .modifier(BindPromptSheetModifier(controller: resultsController))
                 }
             }
         }
@@ -285,6 +286,20 @@ private struct SubstitutionSheetModifier: ViewModifier {
         content.sheet(item: $controller.pendingSubstitution) { request in
             SubstitutionInputView(request: request) { values in
                 controller.resolvePendingSubstitution(values)
+            }
+        }
+    }
+}
+
+/// Same `@Bindable` pattern as `SubstitutionSheetModifier`, but for the
+/// per-unit `:bind` prompt the runner emits via `needsBinds` events.
+private struct BindPromptSheetModifier: ViewModifier {
+    @Bindable var controller: ResultsController
+
+    func body(content: Content) -> some View {
+        content.sheet(item: $controller.pendingBindRequest) { request in
+            ScriptBindPromptView(request: request) { values in
+                controller.resolvePendingBinds(values)
             }
         }
     }

--- a/Macintora/MainApp/SettingsView.swift
+++ b/Macintora/MainApp/SettingsView.swift
@@ -34,6 +34,15 @@ struct SettingsView: View {
     }
 }
 
+/// Storage keys for the Script Runner-related settings. Centralised so both
+/// `EditorSettings` (the SwiftUI form) and `ResultsController` (the
+/// consumer) reference the same `@AppStorage` keys.
+enum ScriptRunnerDefaults {
+    static let dbmsOutputInline = "scriptRunner.dbmsOutputInline"
+    static let miniGridRowCap = "scriptRunner.miniGridRowCap"
+    static let alwaysStopOnError = "scriptRunner.alwaysStopOnError"
+}
+
 struct EditorSettings: View {
     @AppStorage("formatterPath") private var formatterPath = "\(FileManager.default.homeDirectoryForCurrentUser.path)/Macintora/formatter"
     @AppStorage("shellPath") private var shellPath = "/bin/zsh"
@@ -43,6 +52,9 @@ struct EditorSettings: View {
     @AppStorage("wordWrap") private var wordWrap = false
     @AppStorage("editorTheme") private var editorThemeRaw: String = EditorTheme.default.rawValue
     @AppStorage(TimestampDisplayMode.storageKey) private var timestampDisplayModeRaw: String = TimestampDisplayMode.mixed.rawValue
+    @AppStorage(ScriptRunnerDefaults.dbmsOutputInline) private var scriptDbmsOutputInline: Bool = true
+    @AppStorage(ScriptRunnerDefaults.miniGridRowCap) private var scriptMiniGridRowCap: Int = 200
+    @AppStorage(ScriptRunnerDefaults.alwaysStopOnError) private var scriptAlwaysStopOnError: Bool = false
 
     private var editorThemeBinding: Binding<EditorTheme> {
         Binding(
@@ -91,6 +103,17 @@ struct EditorSettings: View {
                     ForEach(TimestampDisplayMode.allCases) { mode in
                         Text(mode.displayName).tag(mode)
                     }
+                }
+
+                Section("Script Runner") {
+                    Toggle("Show DBMS_OUTPUT inline", isOn: $scriptDbmsOutputInline)
+                        .help("Default value of SET SERVEROUTPUT for new scripts.")
+                    Stepper(value: $scriptMiniGridRowCap, in: 50...2000, step: 50) {
+                        Text("Mini-grid row cap: \(scriptMiniGridRowCap)")
+                    }
+                    .help("Max rows captured for inline SELECT preview. Promote to grid for more.")
+                    Toggle("Stop on first error (override WHENEVER)", isOn: $scriptAlwaysStopOnError)
+                        .help("When on, any failed unit halts the script regardless of WHENEVER SQLERROR.")
                 }
             }
             Spacer()

--- a/Macintora/Results/ConnectionExecutor.swift
+++ b/Macintora/Results/ConnectionExecutor.swift
@@ -1,0 +1,37 @@
+//
+//  ConnectionExecutor.swift
+//  Macintora
+//
+//  Protocol over the OracleNIO call path. Phase 2 ships only the protocol
+//  shape and a no-op default; Phase 4 lands the real impl that drives a
+//  live `OracleConnection`. Tests use the fake in
+//  `MacintoraTests/Results/FakeConnectionExecutor.swift`.
+//
+
+import Foundation
+
+/// What the runner hands an executor for one unit.
+struct PreparedUnit: Sendable {
+    let unit: CommandUnit
+    /// Substituted text ready to send to Oracle (terminator stripped).
+    let resolvedText: String
+    /// Bind values keyed by uppercased name (no leading `:`).
+    let binds: [String: BindValue]
+}
+
+protocol ConnectionExecutor: Sendable {
+    /// Execute one unit. Implementations run DB I/O off the main actor and
+    /// translate OracleNIO outcomes into a `UnitResult`. Throws on
+    /// cancellation or unrecoverable transport failures.
+    ///
+    /// `@concurrent` opts out of Swift 6.2 approachable concurrency's "run on
+    /// caller's actor" default — DB I/O must run on the global executor so it
+    /// doesn't pin the main actor.
+    @concurrent
+    func execute(_ prepared: PreparedUnit) async throws -> UnitResult
+
+    /// Best-effort cancellation of the current in-flight unit. Implementations
+    /// should be safe to call concurrently with `execute`.
+    @concurrent
+    func cancel() async
+}

--- a/Macintora/Results/ConnectionExecutor.swift
+++ b/Macintora/Results/ConnectionExecutor.swift
@@ -34,4 +34,10 @@ protocol ConnectionExecutor: Sendable {
     /// should be safe to call concurrently with `execute`.
     @concurrent
     func cancel() async
+
+    /// Fetch compile errors from `USER_ERRORS` for the given target. Returns
+    /// `[]` when there are none. Used to back the SQL*Plus `SHOW ERRORS`
+    /// directive.
+    @concurrent
+    func fetchCompileErrors(for target: CompileErrorTarget) async throws -> [CompileErrorRow]
 }

--- a/Macintora/Results/MiniGridView.swift
+++ b/Macintora/Results/MiniGridView.swift
@@ -1,0 +1,101 @@
+//
+//  MiniGridView.swift
+//  Macintora
+//
+//  Inline, bounded preview of rows returned by a SELECT inside the Script
+//  Output pane. Capped by `RowsPreview.defaultRowCap`. Promotion to the
+//  main grid (Phase 7) hands the rows to a `ResultViewModel`.
+//
+
+import SwiftUI
+
+struct MiniGridView: View {
+    let preview: RowsPreview
+    var onPromote: (() -> Void)? = nil
+
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 4) {
+                MiniGridTable(preview: preview)
+                if preview.truncated {
+                    Text("(showing \(preview.rows.count) row\(preview.rows.count == 1 ? "" : "s") — promote to view all)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                if let onPromote {
+                    Button("Open in full grid", systemImage: "arrow.up.right.square", action: onPromote)
+                        .controlSize(.small)
+                        .buttonStyle(.borderless)
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "tablecells")
+                    .foregroundStyle(.secondary)
+                Text(rowCountLabel(preview))
+                    .font(.callout)
+            }
+        }
+    }
+}
+
+private func rowCountLabel(_ preview: RowsPreview) -> String {
+    let n = preview.rows.count
+    let suffix = preview.truncated ? "+" : ""
+    return "\(n)\(suffix) row\(n == 1 && !preview.truncated ? "" : "s")"
+}
+
+private struct MiniGridTable: View {
+    let preview: RowsPreview
+
+    var body: some View {
+        ScrollView([.horizontal, .vertical]) {
+            VStack(alignment: .leading, spacing: 0) {
+                MiniGridHeader(columns: preview.columns)
+                Divider()
+                ForEach(0..<preview.rows.count, id: \.self) { row in
+                    MiniGridRow(values: preview.rows[row], isAlternate: row.isMultiple(of: 2))
+                    if row < preview.rows.count - 1 {
+                        Divider().opacity(0.2)
+                    }
+                }
+            }
+            .font(.system(.body, design: .monospaced))
+        }
+        .frame(maxHeight: 240)
+    }
+}
+
+private struct MiniGridHeader: View {
+    let columns: [String]
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(0..<columns.count, id: \.self) { i in
+                Text(columns[i])
+                    .bold()
+                    .frame(minWidth: 80, alignment: .leading)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.secondary.opacity(0.15))
+            }
+        }
+    }
+}
+
+private struct MiniGridRow: View {
+    let values: [String]
+    let isAlternate: Bool
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(0..<values.count, id: \.self) { i in
+                Text(values[i])
+                    .frame(minWidth: 80, alignment: .leading)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+            }
+        }
+        .background(isAlternate ? Color.clear : .secondary.opacity(0.05))
+    }
+}

--- a/Macintora/Results/OracleScriptExecutor.swift
+++ b/Macintora/Results/OracleScriptExecutor.swift
@@ -1,0 +1,143 @@
+//
+//  OracleScriptExecutor.swift
+//  Macintora
+//
+//  `ConnectionExecutor` implementation that drives a live `OracleConnection`.
+//  Mirrors the inline execution body in `ResultViewModel.populateData`, but
+//  shapes its output as a `UnitResult` (with bounded `RowsPreview` for the
+//  Script Output pane) rather than mutating the legacy view model.
+//
+//  All DB I/O runs off the main actor — methods are `nonisolated` and the
+//  oracle-nio calls are `@concurrent` already.
+//
+
+import Foundation
+import OracleNIO
+import Logging
+
+struct OracleScriptExecutor: ConnectionExecutor, Sendable {
+    let conn: OracleConnection
+    let logger: Logging.Logger
+    /// Toggle for `DBMS_OUTPUT.ENABLE` + drain. SQL*Plus `SET SERVEROUTPUT`
+    /// flips this in Phase 6; for now the runner just passes `true`.
+    let dbmsOutputEnabled: Bool
+    /// Cap on rows captured for the inline `RowsPreview`. Beyond this we set
+    /// `truncated = true` and let the user promote to the full grid.
+    let previewCap: Int
+
+    init(
+        conn: OracleConnection,
+        logger: Logging.Logger,
+        dbmsOutputEnabled: Bool = true,
+        previewCap: Int = RowsPreview.defaultRowCap
+    ) {
+        self.conn = conn
+        self.logger = logger
+        self.dbmsOutputEnabled = dbmsOutputEnabled
+        self.previewCap = previewCap
+    }
+
+    @concurrent
+    func execute(_ prepared: PreparedUnit) async throws -> UnitResult {
+        let start = ContinuousClock.now
+
+        switch prepared.unit.kind {
+        case .sqlplus:
+            // v1: directives that need DB calls (SHOW ERRORS) are handled in
+            // Phase 6; remaining ones are pure session-state mutations and
+            // get a free pass here.
+            return UnitResult(
+                outcome: .directiveAcknowledged,
+                elapsed: ContinuousClock.now - start
+            )
+
+        case .sql, .plsqlBlock:
+            return try await runStatement(prepared, start: start)
+        }
+    }
+
+    @concurrent
+    func cancel() async {
+        // No-op: cancellation propagates from the runner's parent Task into
+        // the in-flight `try await` on the row iterator.
+    }
+
+    // MARK: - Statement execution
+
+    @concurrent
+    private func runStatement(_ prepared: PreparedUnit, start: ContinuousClock.Instant) async throws -> UnitResult {
+        if dbmsOutputEnabled {
+            try? await DBMSOutput.enable(on: conn, logger: logger)
+        }
+
+        do {
+            let statement = BindValue.makeStatement(sql: prepared.resolvedText, binds: prepared.binds)
+            let stream = try await conn.execute(statement, logger: logger)
+            let columns = DisplayRowBuilder.columnLabels(for: stream.columns)
+
+            var iterator = stream.makeAsyncIterator()
+            var collected: [[String]] = []
+            var idx = 0
+            var exhausted = false
+
+            while idx < previewCap {
+                if Task.isCancelled { throw CancellationError() }
+                guard let row = try await iterator.next() else {
+                    exhausted = true
+                    break
+                }
+                let display = DisplayRowBuilder.make(from: row, id: idx, columnLabels: columns)
+                collected.append(display.values)
+                idx += 1
+            }
+
+            // If we hit the cap, peek for a single more row to mark `truncated`.
+            // We deliberately don't drain past that — the rest sits in the
+            // server cursor until the user promotes the preview.
+            var truncated = false
+            if !exhausted {
+                if (try? await iterator.next()) != nil {
+                    truncated = true
+                }
+            }
+
+            // DBMS_OUTPUT can only be drained when the cursor is exhausted; if
+            // the cursor is still mid-scan, oracle-nio serializes and would
+            // deadlock against the open cursor (see `ResultViewModel`).
+            let dbmsLines: [String]
+            if exhausted, dbmsOutputEnabled {
+                let raw = (try? await DBMSOutput.drain(on: conn, logger: logger)) ?? ""
+                dbmsLines = raw.isEmpty ? [] : raw.components(separatedBy: "\n")
+            } else {
+                dbmsLines = []
+            }
+
+            let rowCount = columns.isEmpty ? nil : collected.count
+            let preview = previewFrom(columns: columns, rows: collected, truncated: truncated)
+            return UnitResult(
+                outcome: .statementSucceeded(rowCount: rowCount, dbmsOutput: dbmsLines, preview: preview),
+                elapsed: ContinuousClock.now - start
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            let appErr = AppDBError.from(error)
+            let oraCode = parseOracleErrorCode(appErr.code)
+            return UnitResult(
+                outcome: .statementFailed(message: appErr.description, oracleErrorCode: oraCode),
+                elapsed: ContinuousClock.now - start
+            )
+        }
+    }
+
+    private func previewFrom(columns: [String], rows: [[String]], truncated: Bool) -> RowsPreview? {
+        guard !columns.isEmpty else { return nil }
+        return RowsPreview(columns: columns, rows: rows, truncated: truncated)
+    }
+}
+
+private func parseOracleErrorCode(_ code: String?) -> Int? {
+    guard let code, code.hasPrefix("ORA-") else { return nil }
+    let digits = code.dropFirst(4).trimmingCharacters(in: .whitespaces)
+    return Int(digits)
+}

--- a/Macintora/Results/OracleScriptExecutor.swift
+++ b/Macintora/Results/OracleScriptExecutor.swift
@@ -62,6 +62,38 @@ struct OracleScriptExecutor: ConnectionExecutor, Sendable {
         // the in-flight `try await` on the row iterator.
     }
 
+    @concurrent
+    func fetchCompileErrors(for target: CompileErrorTarget) async throws -> [CompileErrorRow] {
+        // USER_ERRORS for the current schema. Owner-qualified targets aren't
+        // supported by USER_ERRORS; for now we always read from the current
+        // session's user (matching SQL*Plus's SHOW ERRORS behaviour, which
+        // queries USER_ERRORS even when CREATE was schema-qualified).
+        let sql = """
+        SELECT line, position, sequence, attribute, text \
+        FROM user_errors \
+        WHERE name = :name AND type = :type \
+        ORDER BY sequence
+        """
+        var bindings = OracleBindings(capacity: 2)
+        bindings.append(target.name, context: .default, bindName: "name")
+        bindings.append(target.type, context: .default, bindName: "type")
+        let statement = OracleStatement(unsafeSQL: sql, binds: bindings)
+        let stream = try await conn.execute(statement, logger: logger)
+
+        var rows: [CompileErrorRow] = []
+        for try await row in stream {
+            let decoded = try row.decode((Int?, Int?, Int?, String?, String?).self)
+            rows.append(CompileErrorRow(
+                line: decoded.0 ?? 0,
+                position: decoded.1 ?? 0,
+                sequence: decoded.2 ?? 0,
+                attribute: decoded.3 ?? "ERROR",
+                text: decoded.4 ?? ""
+            ))
+        }
+        return rows
+    }
+
     // MARK: - Statement execution
 
     @concurrent

--- a/Macintora/Results/ResultViewWrapper.swift
+++ b/Macintora/Results/ResultViewWrapper.swift
@@ -13,16 +13,20 @@ import os
 struct ResultViewWrapper: View {
     @ObservedObject var queryResults: ResultViewModel
     var resultsController: ResultsController
+    /// Phase 5 callback: navigate from a failed Script Output entry back to
+    /// the editor using a UTF-16 range in the original script source.
+    var onRevealSource: ((Range<Int>) -> Void)? = nil
     @State private var dbTimeStr = ""
     @State private var dbTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State private var isDbTimerRunning = false
     @AppStorage("serverTimeSeconds") private var serverTimeSeconds = false
-    
+
     let dateFormatter: DateFormatter = DateFormatter()
 
-    
-    init(resultsController: ResultsController) {
+
+    init(resultsController: ResultsController, onRevealSource: ((Range<Int>) -> Void)? = nil) {
         self.resultsController = resultsController
+        self.onRevealSource = onRevealSource
         queryResults = resultsController.results["current"]!
         dateFormatter.calendar = Calendar(identifier: .iso8601)
         dateFormatter.dateFormat = serverTimeSeconds ? "yyyy-MM-dd HH:mm:ss" : "yyyy-MM-dd HH:mm"
@@ -50,26 +54,31 @@ struct ResultViewWrapper: View {
     
     var body: some View {
         VStack {
-//            let _ = log.viewCycle.debug("Redrawing ResultViewWrapper, queryResults: \(queryResults.bindVarVM)")
-            queryResultToolbar
-            GeometryReader { geo in
-                HStack {
-                    ZStack {
-                        ResultView(model: self.queryResults )
-                            .frame(maxWidth: .infinity, minHeight: 100, maxHeight: .infinity)
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
-                            .frame(minHeight: 100)
-                            .hidden(!queryResults.resultsController.isExecuting)
+            if resultsController.isScriptMode {
+                ScriptOutputView(
+                    model: resultsController.scriptOutput,
+                    onRevealSource: onRevealSource
+                )
+            } else {
+                queryResultToolbar
+                GeometryReader { geo in
+                    HStack {
+                        ZStack {
+                            ResultView(model: self.queryResults )
+                                .frame(maxWidth: .infinity, minHeight: 100, maxHeight: .infinity)
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle())
+                                .frame(minHeight: 100)
+                                .hidden(!queryResults.resultsController.isExecuting)
+                        }
+                        if queryResults.showingBindVarInputView {
+                            BindVarInputView(bindVarVM: $queryResults.bindVarVM, runAction: runWithBinds, cancelAction: {queryResults.showingBindVarInputView = false})
+                                .frame(width: queryResults.showingBindVarInputView ? geo.size.width/3 : 0, alignment: .trailing)
+                        }
+
+                        RunningLogView(attributedText: queryResults.runningLogStr)
+                            .frame(width: queryResults.showingLog ? geo.size.width/3 : 0, alignment: .trailing)
                     }
-                    if queryResults.showingBindVarInputView {
-                        BindVarInputView(bindVarVM: $queryResults.bindVarVM, runAction: runWithBinds, cancelAction: {queryResults.showingBindVarInputView = false})
-                            .frame(width: queryResults.showingBindVarInputView ? geo.size.width/3 : 0, alignment: .trailing)
-//                                .hidden(!queryResults.showingBindVarInputView)
-                    }
-                    
-                    RunningLogView(attributedText: queryResults.runningLogStr)
-                        .frame(width: queryResults.showingLog ? geo.size.width/3 : 0, alignment: .trailing)
                 }
             }
         }

--- a/Macintora/Results/ResultViewWrapper.swift
+++ b/Macintora/Results/ResultViewWrapper.swift
@@ -57,7 +57,12 @@ struct ResultViewWrapper: View {
             if resultsController.isScriptMode {
                 ScriptOutputView(
                     model: resultsController.scriptOutput,
-                    onRevealSource: onRevealSource
+                    onRevealSource: onRevealSource,
+                    onPromotePreview: { entry in
+                        if let preview = entry.preview {
+                            resultsController.promote(preview: preview, sqlText: entry.text)
+                        }
+                    }
                 )
             } else {
                 queryResultToolbar

--- a/Macintora/Results/ResultsController.swift
+++ b/Macintora/Results/ResultsController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OracleNIO
+import Logging
 
 @MainActor
 @Observable
@@ -7,6 +8,28 @@ final class ResultsController {
     weak var document: MainDocumentVM?
     var results: [String: ResultViewModel]
     var isExecuting = false
+
+    // MARK: - Script-mode plumbing
+    //
+    // Coexists with the legacy single-statement path; nothing touches these
+    // fields unless `runScript` is invoked. The UI swap (ResultViewWrapper)
+    // lands in Phase 5 alongside menu wiring.
+    /// Output stream for the in-progress / most recent script.
+    let scriptOutput = ScriptOutputModel()
+    /// Whether the user is currently looking at script output (vs the
+    /// single-statement grid + log).
+    var isScriptMode: Bool = false
+    /// Set when the runner needs values for unresolved `&` / `&&` variables;
+    /// observed by `MainDocumentView` to present `SubstitutionInputView`.
+    var pendingSubstitution: PendingSubstitutionRequest?
+    /// Session-sticky `&&` values, persisted for this document's lifetime.
+    private var sessionDefines: [String: String] = [:]
+    private var pendingResolve: (([String: String]?) -> Void)?
+
+    private var scriptRunner: ScriptRunner?
+    private var scriptRunnerTask: Task<Void, Never>?
+    private var scriptUnits: [CommandUnit] = []
+    private var scriptSource: String = ""
 
     init(document: MainDocumentVM) {
         self.document = document
@@ -19,6 +42,8 @@ final class ResultsController {
     }
 
     func runSQL(_ runnableSQL: RunnableSQL) {
+        // Single-statement path returns to legacy grid + log.
+        isScriptMode = false
         let resultVM = results["current"]!
         guard let conn = document?.conn else { return }
         resultVM.promptForBindsAndExecute(for: runnableSQL, using: conn)
@@ -39,6 +64,247 @@ final class ResultsController {
     func cancelCurrent() {
         let resultVM = results["current"]!
         resultVM.cancel()
+        cancelScript()
+    }
+
+    // MARK: - Script execution
+
+    /// Run a script. `range` selects a slice of `source`; pass `nil` to run
+    /// the whole document.
+    func runScript(source: String, range: Range<String.Index>? = nil) {
+        guard let conn = document?.conn else { return }
+
+        let scriptText: String
+        if let range {
+            scriptText = String(source[range])
+        } else {
+            scriptText = source
+        }
+
+        let units = ScriptLexer.split(scriptText).units
+        guard !units.isEmpty else {
+            scriptOutput.note(.info, text: "No statements to run.")
+            return
+        }
+
+        // Pre-scan for `&` / `&&` references; if any need values that aren't
+        // already in `sessionDefines`, show the modal and resume on submit.
+        let scan = SubstitutionResolver.scan(scriptText)
+        let missing = scan.names.subtracting(sessionDefines.keys).sorted()
+
+        if missing.isEmpty {
+            startScriptExecution(scriptText: scriptText, units: units, conn: conn)
+            return
+        }
+
+        let prefilled = sessionDefines.filter { scan.names.contains($0.key) }
+        pendingSubstitution = PendingSubstitutionRequest(
+            names: missing,
+            stickyNames: scan.stickyNames,
+            prefilled: prefilled
+        )
+        pendingResolve = { [weak self] result in
+            guard let self else { return }
+            self.pendingSubstitution = nil
+            self.pendingResolve = nil
+            guard let result else {
+                self.scriptOutput.note(.cancelled, text: "Cancelled by user.")
+                return
+            }
+            for name in scan.stickyNames {
+                if let v = result[name] { self.sessionDefines[name] = v }
+            }
+            self.startScriptExecution(scriptText: scriptText, units: units, conn: conn)
+        }
+    }
+
+    /// Resume a pending substitution prompt with `values` (or `nil` to cancel).
+    func resolvePendingSubstitution(_ values: [String: String]?) {
+        pendingResolve?(values)
+    }
+
+    private func startScriptExecution(scriptText: String, units: [CommandUnit], conn: OracleConnection) {
+        let logger = oracleLoggerForScripts()
+
+        // 1. Flatten @ / @@ includes against the document's directory.
+        let flattened: [CommandUnit]
+        do {
+            flattened = try ScriptLoader.flatten(units, documentBaseURL: documentBaseURL())
+        } catch {
+            scriptOutput.note(.warning, text: "Include resolution failed: \(error)")
+            isExecuting = false
+            return
+        }
+
+        // 2. Build env, seed with session defines.
+        let env = SqlPlusEnvironment()
+        env.defines = sessionDefines
+
+        // 3. Sequentially apply directives (mutating env) and substitute SQL
+        //    units' text using env.defines at that point. Each unit's
+        //    `originalRange` stays in the un-substituted top-level source
+        //    (or, for included units, ranges into their own file — those
+        //    won't navigate back to the editor but won't crash either).
+        var preparedUnits: [CommandUnit] = []
+        for unit in flattened {
+            switch unit.kind {
+            case .sqlplus(let directive):
+                _ = SqlPlusInterpreter.apply(directive, env: env)
+                preparedUnits.append(unit)
+            case .sql, .plsqlBlock:
+                let textToSend: String
+                if env.defineEnabled {
+                    textToSend = SubstitutionResolver.resolve(unit.text, defines: env.defines).text
+                } else {
+                    textToSend = unit.text
+                }
+                preparedUnits.append(CommandUnit(
+                    kind: unit.kind,
+                    originalRange: unit.originalRange,
+                    text: textToSend
+                ))
+            }
+        }
+
+        // 4. Configure executor + runner from final env state.
+        let stopOnError: Bool
+        if case .exit = env.whenever { stopOnError = true } else { stopOnError = false }
+
+        scriptUnits = preparedUnits
+        scriptSource = scriptText
+        isScriptMode = true
+        isExecuting = true
+        scriptOutput.beginRun(totalUnits: preparedUnits.count)
+
+        let executor = OracleScriptExecutor(
+            conn: conn,
+            logger: logger,
+            dbmsOutputEnabled: env.serverOutput
+        )
+        let runner = ScriptRunner(
+            units: preparedUnits,
+            executor: executor,
+            options: .init(stopOnError: stopOnError)
+        )
+        scriptRunner = runner
+
+        let stream = runner.start()
+        scriptRunnerTask = Task { @MainActor in
+            for await event in stream {
+                self.handleScriptEvent(event)
+            }
+            self.isExecuting = false
+        }
+    }
+
+    private func documentBaseURL() -> URL? {
+        // The document file URL isn't directly exposed on `MainDocumentVM`
+        // today; `@/@@` resolution falls back to `nil` until a future phase
+        // surfaces it. Absolute paths still work via the loader's fallback.
+        nil
+    }
+
+    /// Cancel an in-flight script. Idempotent.
+    func cancelScript() {
+        guard let runner = scriptRunner else { return }
+        Task { @MainActor in
+            await runner.cancel()
+        }
+    }
+
+    private func handleScriptEvent(_ event: ScriptRunnerEvent) {
+        switch event {
+        case .unitStarted(let index, _, _):
+            scriptOutput.setCurrentUnit(index)
+
+        case .unitFinished(let index, let result):
+            let unit = scriptUnits.indices.contains(index) ? scriptUnits[index] : nil
+            scriptOutput.append(makeEntry(unitIndex: index, unit: unit, result: result))
+
+        case .needsBinds, .needsSubstitutions:
+            // Phase 5 wires consolidated prompts; for now the runner never
+            // emits these (stubbed out).
+            break
+
+        case .cancelled:
+            scriptOutput.note(.cancelled, text: "Cancelled by user.")
+            scriptOutput.finishRun()
+            isExecuting = false
+            scriptRunner = nil
+
+        case .scriptFinished:
+            scriptOutput.finishRun()
+            isExecuting = false
+            scriptRunner = nil
+        }
+    }
+
+    private func makeEntry(unitIndex: Int, unit: CommandUnit?, result: UnitResult) -> ScriptOutputEntry {
+        let id = UUID()
+        let text = unit?.text ?? ""
+        let kind: UnitKind = unit.map { UnitKind($0.kind) } ?? .sql
+
+        switch result.outcome {
+        case .directiveAcknowledged:
+            // Specialise display for prompt/remark so the output reads
+            // naturally; everything else falls through to the generic
+            // directive entry.
+            if let unit, case .sqlplus(let directive) = unit.kind {
+                switch directive {
+                case .prompt(let message):
+                    return .prompt(.init(id: id, message: message))
+                case .remark:
+                    return .note(.init(id: id, kind: .info, text: text))
+                case .include(let path, let doubleAt):
+                    let prefix = doubleAt ? "@@" : "@"
+                    return .note(.init(id: id, kind: .warning, text: "Include not resolved: \(prefix)\(path)"))
+                default:
+                    break
+                }
+            }
+            return .directive(.init(id: id, text: text, elapsed: result.elapsed))
+
+        case .statementSucceeded(let rowCount, let dbmsOutput, let preview):
+            return .succeeded(.init(
+                id: id,
+                unitIndex: unitIndex,
+                text: text,
+                kind: kind,
+                elapsed: result.elapsed,
+                rowCount: rowCount,
+                dbmsOutput: dbmsOutput,
+                preview: preview
+            ))
+
+        case .statementFailed(let message, let oracleErrorCode):
+            let utf16Range: Range<Int>? = unit.map { unit in
+                let lo = scriptSource.utf16.distance(
+                    from: scriptSource.utf16.startIndex,
+                    to: unit.originalRange.lowerBound.samePosition(in: scriptSource.utf16) ?? scriptSource.utf16.startIndex
+                )
+                let hi = scriptSource.utf16.distance(
+                    from: scriptSource.utf16.startIndex,
+                    to: unit.originalRange.upperBound.samePosition(in: scriptSource.utf16) ?? scriptSource.utf16.endIndex
+                )
+                return lo..<hi
+            }
+            return .failed(.init(
+                id: id,
+                unitIndex: unitIndex,
+                text: text,
+                kind: kind,
+                elapsed: result.elapsed,
+                message: message,
+                oracleErrorCode: oracleErrorCode,
+                originalUTF16Range: utf16Range
+            ))
+        }
+    }
+
+    private func oracleLoggerForScripts() -> Logging.Logger {
+        var logger = Logging.Logger(label: "com.iliasazonov.macintora.script")
+        logger.logLevel = .notice
+        return logger
     }
 
     func displayError(_ error: any Error) {

--- a/Macintora/Results/ResultsController.swift
+++ b/Macintora/Results/ResultsController.swift
@@ -22,13 +22,42 @@ final class ResultsController {
     /// Set when the runner needs values for unresolved `&` / `&&` variables;
     /// observed by `MainDocumentView` to present `SubstitutionInputView`.
     var pendingSubstitution: PendingSubstitutionRequest?
+    /// Set when the runner needs `:bind` values for the current SQL/PLSQL
+    /// unit; observed by `MainDocumentView` to present a `BindVarInputView`.
+    var pendingBindRequest: PendingBindRequest?
     /// Session-sticky `&&` values, persisted for this document's lifetime.
     private var sessionDefines: [String: String] = [:]
     private var pendingResolve: (([String: String]?) -> Void)?
 
+    /// User-level "halt on first error regardless of WHENEVER" override.
+    /// Read from UserDefaults via `ScriptRunnerDefaults.alwaysStopOnError`
+    /// at runScript time; defaults to false so the script's WHENEVER
+    /// directive drives behaviour.
+    var alwaysStopOnError: Bool {
+        UserDefaults.standard.bool(forKey: ScriptRunnerDefaults.alwaysStopOnError)
+    }
+
+    /// Default initial value for the runner env's `serverOutput` flag.
+    /// `SET SERVEROUTPUT` directives in the script can flip it pre-run via
+    /// the executor's pre-scan.
+    var scriptDbmsOutputDefault: Bool {
+        if UserDefaults.standard.object(forKey: ScriptRunnerDefaults.dbmsOutputInline) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: ScriptRunnerDefaults.dbmsOutputInline)
+    }
+
+    /// Cap for inline `RowsPreview`. Falls back to `RowsPreview.defaultRowCap`
+    /// when unset.
+    var scriptMiniGridRowCap: Int {
+        let v = UserDefaults.standard.integer(forKey: ScriptRunnerDefaults.miniGridRowCap)
+        return v > 0 ? v : RowsPreview.defaultRowCap
+    }
+
     private var scriptRunner: ScriptRunner?
     private var scriptRunnerTask: Task<Void, Never>?
     private var scriptUnits: [CommandUnit] = []
+    private var scriptEnv: SqlPlusEnvironment?
     private var scriptSource: String = ""
 
     init(document: MainDocumentVM) {
@@ -136,55 +165,35 @@ final class ResultsController {
             return
         }
 
-        // 2. Build env, seed with session defines.
+        // 2. Build env, seed with session defines + user default for
+        //    serverOutput.
         let env = SqlPlusEnvironment()
         env.defines = sessionDefines
+        env.serverOutput = scriptDbmsOutputDefault
 
-        // 3. Sequentially apply directives (mutating env) and substitute SQL
-        //    units' text using env.defines at that point. Each unit's
-        //    `originalRange` stays in the un-substituted top-level source
-        //    (or, for included units, ranges into their own file — those
-        //    won't navigate back to the editor but won't crash either).
-        var preparedUnits: [CommandUnit] = []
-        for unit in flattened {
-            switch unit.kind {
-            case .sqlplus(let directive):
-                _ = SqlPlusInterpreter.apply(directive, env: env)
-                preparedUnits.append(unit)
-            case .sql, .plsqlBlock:
-                let textToSend: String
-                if env.defineEnabled {
-                    textToSend = SubstitutionResolver.resolve(unit.text, defines: env.defines).text
-                } else {
-                    textToSend = unit.text
-                }
-                preparedUnits.append(CommandUnit(
-                    kind: unit.kind,
-                    originalRange: unit.originalRange,
-                    text: textToSend
-                ))
-            }
-        }
+        // 3. Pre-scan SET SERVEROUTPUT to seed the executor's DBMS_OUTPUT
+        //    capture. (Mid-run mutation isn't honored — the executor captures
+        //    the value at construction. Tracked as a known limitation.)
+        let initialServerOutput = preScanServerOutput(units: flattened, default: env.serverOutput)
 
-        // 4. Configure executor + runner from final env state.
-        let stopOnError: Bool
-        if case .exit = env.whenever { stopOnError = true } else { stopOnError = false }
-
-        scriptUnits = preparedUnits
+        scriptUnits = flattened
+        scriptEnv = env
         scriptSource = scriptText
         isScriptMode = true
         isExecuting = true
-        scriptOutput.beginRun(totalUnits: preparedUnits.count)
+        scriptOutput.beginRun(totalUnits: flattened.count)
 
         let executor = OracleScriptExecutor(
             conn: conn,
             logger: logger,
-            dbmsOutputEnabled: env.serverOutput
+            dbmsOutputEnabled: initialServerOutput,
+            previewCap: scriptMiniGridRowCap
         )
         let runner = ScriptRunner(
-            units: preparedUnits,
+            units: flattened,
             executor: executor,
-            options: .init(stopOnError: stopOnError)
+            env: env,
+            options: .init(alwaysStopOnError: alwaysStopOnError)
         )
         scriptRunner = runner
 
@@ -193,15 +202,34 @@ final class ResultsController {
             for await event in stream {
                 self.handleScriptEvent(event)
             }
+            self.persistStickyDefines()
             self.isExecuting = false
         }
     }
 
+    private func preScanServerOutput(units: [CommandUnit], default initial: Bool) -> Bool {
+        var value = initial
+        for unit in units {
+            if case .sqlplus(.set(.serverOutput(let on))) = unit.kind {
+                value = on
+            }
+        }
+        return value
+    }
+
+    private func persistStickyDefines() {
+        guard let env = scriptEnv else { return }
+        for name in env.stickyNames {
+            if let v = env.defines[name] { sessionDefines[name] = v }
+        }
+        scriptEnv = nil
+    }
+
     private func documentBaseURL() -> URL? {
-        // The document file URL isn't directly exposed on `MainDocumentVM`
-        // today; `@/@@` resolution falls back to `nil` until a future phase
-        // surfaces it. Absolute paths still work via the loader's fallback.
-        nil
+        // `@file.sql` resolves against the document's directory. For
+        // untitled (unsaved) documents this is nil, in which case
+        // `ScriptLoader` only succeeds for absolute paths.
+        document?.fileURL?.deletingLastPathComponent()
     }
 
     /// Cancel an in-flight script. Idempotent.
@@ -221,9 +249,17 @@ final class ResultsController {
             let unit = scriptUnits.indices.contains(index) ? scriptUnits[index] : nil
             scriptOutput.append(makeEntry(unitIndex: index, unit: unit, result: result))
 
-        case .needsBinds, .needsSubstitutions:
-            // Phase 5 wires consolidated prompts; for now the runner never
-            // emits these (stubbed out).
+        case .needsBinds(let request):
+            pendingBindRequest = PendingBindRequest(
+                id: UUID(),
+                unitIndex: request.unitIndex,
+                names: request.names,
+                resume: request.resume
+            )
+
+        case .needsSubstitutions:
+            // Up-front substitution prompt is handled in `runScript`; the
+            // runner doesn't currently emit this event mid-run.
             break
 
         case .cancelled:
@@ -237,6 +273,39 @@ final class ResultsController {
             isExecuting = false
             scriptRunner = nil
         }
+    }
+
+    /// Resume a pending bind prompt with `values` (or `nil` to cancel).
+    func resolvePendingBinds(_ values: [String: BindValue]?) {
+        guard let request = pendingBindRequest else { return }
+        pendingBindRequest = nil
+        request.resume(values)
+    }
+
+    /// Copy a `RowsPreview` into the legacy `ResultViewModel`'s grid and
+    /// switch out of script mode so the user sees the full grid view.
+    /// Used by the "Open in full grid" affordance on `MiniGridView`.
+    func promote(preview: RowsPreview, sqlText: String) {
+        let resultVM = results["current"]!
+        let labels = ["#"] + preview.columns
+        let rows = preview.rows.enumerated().map { (i, values) -> DisplayRow in
+            var fields: [DisplayField] = []
+            for (colIdx, columnName) in preview.columns.enumerated() {
+                let valueString = colIdx < values.count ? values[colIdx] : ""
+                fields.append(DisplayField(
+                    name: columnName,
+                    valueString: valueString,
+                    sortKey: .text(valueString)
+                ))
+            }
+            return DisplayRow(id: i, fields: fields)
+        }
+        resultVM.objectWillChange.send()
+        resultVM.columnLabels = labels
+        resultVM.rows = rows
+        resultVM.currentSql = sqlText
+        resultVM.isFailed = false
+        isScriptMode = false
     }
 
     private func makeEntry(unitIndex: Int, unit: CommandUnit?, result: UnitResult) -> ScriptOutputEntry {
@@ -263,6 +332,9 @@ final class ResultsController {
                 }
             }
             return .directive(.init(id: id, text: text, elapsed: result.elapsed))
+
+        case .directiveCompileErrors(let target, let errors):
+            return .note(.init(id: id, kind: errors.isEmpty ? .info : .warning, text: formatCompileErrors(target: target, errors: errors)))
 
         case .statementSucceeded(let rowCount, let dbmsOutput, let preview):
             return .succeeded(.init(
@@ -305,6 +377,20 @@ final class ResultsController {
         var logger = Logging.Logger(label: "com.iliasazonov.macintora.script")
         logger.logLevel = .notice
         return logger
+    }
+
+    private func formatCompileErrors(target: CompileErrorTarget?, errors: [CompileErrorRow]) -> String {
+        guard let target else {
+            return "SHOW ERRORS: no recently compiled object."
+        }
+        let header = "Errors for \(target.type) \(target.name)"
+        if errors.isEmpty {
+            return header + "\nNo errors."
+        }
+        let body = errors.map { row in
+            "\(row.line)/\(row.position)\t\(row.attribute): \(row.text)"
+        }.joined(separator: "\n")
+        return header + "\n" + body
     }
 
     func displayError(_ error: any Error) {

--- a/Macintora/Results/ScriptBindPromptView.swift
+++ b/Macintora/Results/ScriptBindPromptView.swift
@@ -1,0 +1,60 @@
+//
+//  ScriptBindPromptView.swift
+//  Macintora
+//
+//  Sheet wrapper around `BindVarInputView` for the script runner. The runner
+//  pauses on `needsBinds` until the user submits values (or cancels); this
+//  view translates that into the existing `BindVarInputVM` UI and resolves
+//  the pending request through `ResultsController.resolvePendingBinds`.
+//
+
+import SwiftUI
+
+struct ScriptBindPromptView: View {
+    let request: PendingBindRequest
+    /// Pass `nil` to abort the script.
+    var onSubmit: ([String: BindValue]?) -> Void
+
+    @State private var bindVarVM: BindVarInputVM
+
+    init(request: PendingBindRequest, onSubmit: @escaping ([String: BindValue]?) -> Void) {
+        self.request = request
+        self.onSubmit = onSubmit
+        _bindVarVM = State(wrappedValue: BindVarInputVM(bindNames: request.names))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Bind Variables — unit \(request.unitIndex + 1)")
+                .font(.title3)
+                .bold()
+            Text("Provide typed values for the `:bind` variables in this statement.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            BindVarInputView(
+                bindVarVM: $bindVarVM,
+                runAction: { onSubmit(collectBinds()) },
+                cancelAction: { onSubmit(nil) }
+            )
+        }
+        .padding()
+        .frame(minWidth: 460, idealWidth: 520, minHeight: 200)
+    }
+
+    private func collectBinds() -> [String: BindValue] {
+        bindVarVM.bindVars.reduce(into: [:]) { partial, entry in
+            switch entry.type {
+            case .text:
+                partial[entry.name] = .text(entry.textValue)
+            case .null:
+                partial[entry.name] = .null
+            case .date:
+                if let d = entry.dateValue { partial[entry.name] = .date(d) } else { partial[entry.name] = .null }
+            case .int:
+                if let i = entry.intValue { partial[entry.name] = .int(i) } else { partial[entry.name] = .null }
+            case .decimal:
+                if let d = entry.decValue { partial[entry.name] = .decimal(d) } else { partial[entry.name] = .null }
+            }
+        }
+    }
+}

--- a/Macintora/Results/ScriptOutput.swift
+++ b/Macintora/Results/ScriptOutput.swift
@@ -1,0 +1,140 @@
+//
+//  ScriptOutput.swift
+//  Macintora
+//
+//  Observable model + value types backing the Script Output pane. One
+//  `ScriptOutputEntry` per executed unit (or per cancellation / note). The
+//  model is passive — the bridge in `ResultsController` (Phase 4) consumes
+//  `ScriptRunnerEvent`s and appends entries.
+//
+
+import Foundation
+
+@Observable @MainActor
+final class ScriptOutputModel {
+    var entries: [ScriptOutputEntry] = []
+    var isRunning: Bool = false
+    var currentUnitIndex: Int? = nil
+    var totalUnits: Int = 0
+
+    func clear() {
+        entries.removeAll()
+        currentUnitIndex = nil
+        totalUnits = 0
+    }
+
+    func beginRun(totalUnits: Int) {
+        clear()
+        isRunning = true
+        self.totalUnits = totalUnits
+    }
+
+    func finishRun() {
+        isRunning = false
+        currentUnitIndex = nil
+    }
+
+    func setCurrentUnit(_ index: Int) {
+        currentUnitIndex = index
+    }
+
+    func append(_ entry: ScriptOutputEntry) {
+        entries.append(entry)
+    }
+
+    func note(_ kind: NoteEntry.Kind, text: String) {
+        entries.append(.note(.init(id: UUID(), kind: kind, text: text)))
+    }
+}
+
+enum ScriptOutputEntry: Identifiable, Hashable, Sendable {
+    case directive(DirectiveEntry)
+    case prompt(PromptEntry)
+    case succeeded(SucceededEntry)
+    case failed(FailedEntry)
+    case note(NoteEntry)
+
+    var id: UUID {
+        switch self {
+        case .directive(let e): return e.id
+        case .prompt(let e): return e.id
+        case .succeeded(let e): return e.id
+        case .failed(let e): return e.id
+        case .note(let e): return e.id
+        }
+    }
+}
+
+struct DirectiveEntry: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let text: String
+    let elapsed: Duration
+}
+
+struct PromptEntry: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let message: String
+}
+
+struct SucceededEntry: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let unitIndex: Int
+    /// The user-visible unit text (resolved, terminator stripped).
+    let text: String
+    let kind: UnitKind
+    let elapsed: Duration
+    /// `nil` for non-DML statements (DDL / SELECT before fetch / PL/SQL).
+    let rowCount: Int?
+    let dbmsOutput: [String]
+    /// In-memory preview of returned rows for SELECTs.
+    let preview: RowsPreview?
+}
+
+struct FailedEntry: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let unitIndex: Int
+    let text: String
+    let kind: UnitKind
+    let elapsed: Duration
+    let message: String
+    let oracleErrorCode: Int?
+    /// Range in the *original* (un-substituted) script for click-to-source.
+    /// `nil` when the entry comes from a synthetic source (e.g. typed input).
+    let originalUTF16Range: Range<Int>?
+}
+
+struct NoteEntry: Identifiable, Hashable, Sendable {
+    enum Kind: Sendable { case cancelled, info, warning }
+    let id: UUID
+    let kind: Kind
+    let text: String
+}
+
+/// Lightweight echo of `CommandUnit.Kind` that drops the directive payload —
+/// the output entries don't need it after the directive has been interpreted.
+enum UnitKind: Hashable, Sendable {
+    case sql
+    case plsqlBlock
+    case sqlplus
+}
+
+extension UnitKind {
+    init(_ kind: CommandUnit.Kind) {
+        switch kind {
+        case .sql: self = .sql
+        case .plsqlBlock: self = .plsqlBlock
+        case .sqlplus: self = .sqlplus
+        }
+    }
+}
+
+/// Bounded snapshot of returned rows shown inline in the Script Output pane.
+/// Promotion to the full result grid copies these into a regular
+/// `ResultViewModel`.
+struct RowsPreview: Hashable, Sendable {
+    let columns: [String]
+    let rows: [[String]]
+    let truncated: Bool
+
+    static let defaultRowCap = 200
+}

--- a/Macintora/Results/ScriptOutputView.swift
+++ b/Macintora/Results/ScriptOutputView.swift
@@ -36,6 +36,7 @@ struct ScriptOutputView: View {
                 .padding(.vertical, 8)
             }
         }
+        .accessibilityIdentifier("scriptOutput.pane")
     }
 }
 

--- a/Macintora/Results/ScriptOutputView.swift
+++ b/Macintora/Results/ScriptOutputView.swift
@@ -1,0 +1,285 @@
+//
+//  ScriptOutputView.swift
+//  Macintora
+//
+//  SwiftUI view for the Script Output pane. Renders the `ScriptOutputModel`
+//  as a streaming list of typed entries — one per executed unit, plus
+//  cancelled/info notes. Phase 4 wires this in alongside the runner; Phase
+//  5 hooks `onRevealSource` to the editor.
+//
+
+import SwiftUI
+
+struct ScriptOutputView: View {
+    @Bindable var model: ScriptOutputModel
+    /// Phase 5 callback: navigate from a failed entry back to the editor
+    /// using a UTF-16 range in the original script source.
+    var onRevealSource: ((Range<Int>) -> Void)? = nil
+    /// Phase 7 callback: promote a SELECT preview to the main grid.
+    var onPromotePreview: ((SucceededEntry) -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScriptOutputHeader(model: model)
+            Divider()
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(model.entries) { entry in
+                        ScriptOutputRow(
+                            entry: entry,
+                            onRevealSource: onRevealSource,
+                            onPromotePreview: onPromotePreview
+                        )
+                        .padding(.horizontal)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+        }
+    }
+}
+
+private struct ScriptOutputHeader: View {
+    @Bindable var model: ScriptOutputModel
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if model.isRunning {
+                ProgressView()
+                    .controlSize(.small)
+                if let i = model.currentUnitIndex {
+                    Text("Running \(i + 1) of \(model.totalUnits)")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            } else if !model.entries.isEmpty {
+                Text("\(model.entries.count) entr\(model.entries.count == 1 ? "y" : "ies")")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Clear", systemImage: "trash") {
+                model.clear()
+            }
+            .controlSize(.small)
+            .labelStyle(.iconOnly)
+            .disabled(model.entries.isEmpty || model.isRunning)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 6)
+    }
+}
+
+private struct ScriptOutputRow: View {
+    let entry: ScriptOutputEntry
+    var onRevealSource: ((Range<Int>) -> Void)?
+    var onPromotePreview: ((SucceededEntry) -> Void)?
+
+    var body: some View {
+        switch entry {
+        case .directive(let e): DirectiveRow(entry: e)
+        case .prompt(let e): PromptRow(entry: e)
+        case .succeeded(let e):
+            SucceededRow(entry: e, onPromote: onPromotePreview.map { cb in { cb(e) } })
+        case .failed(let e):
+            FailedRow(entry: e, onRevealSource: onRevealSource)
+        case .note(let e): NoteRow(entry: e)
+        }
+    }
+}
+
+private struct DirectiveRow: View {
+    let entry: DirectiveEntry
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "gear")
+                .foregroundStyle(.secondary)
+            Text(entry.text)
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+}
+
+private struct PromptRow: View {
+    let entry: PromptEntry
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "text.bubble")
+                .foregroundStyle(.secondary)
+            Text(entry.message)
+                .font(.system(.body))
+            Spacer()
+        }
+    }
+}
+
+private struct SucceededRow: View {
+    let entry: SucceededEntry
+    var onPromote: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Text(summaryLine(entry))
+                    .font(.callout)
+                Spacer()
+                Text(entry.elapsed.formatted(.units(allowed: [.milliseconds, .seconds])))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Text(entry.text)
+                .font(.system(.body, design: .monospaced))
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .foregroundStyle(.secondary)
+            if let preview = entry.preview {
+                MiniGridView(preview: preview, onPromote: onPromote)
+            }
+            if !entry.dbmsOutput.isEmpty {
+                DbmsOutputBlock(lines: entry.dbmsOutput)
+            }
+        }
+    }
+}
+
+private func summaryLine(_ entry: SucceededEntry) -> String {
+    if let n = entry.rowCount {
+        return "\(n) row\(n == 1 ? "" : "s")"
+    }
+    switch entry.kind {
+    case .plsqlBlock: return "PL/SQL block executed"
+    case .sqlplus:    return "OK"
+    case .sql:        return "Done"
+    }
+}
+
+private struct FailedRow: View {
+    let entry: FailedEntry
+    var onRevealSource: ((Range<Int>) -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: "xmark.octagon.fill")
+                    .foregroundStyle(.red)
+                if let code = entry.oracleErrorCode {
+                    Text("ORA-\(code)")
+                        .font(.callout)
+                        .bold()
+                        .monospacedDigit()
+                } else {
+                    Text("Error").font(.callout).bold()
+                }
+                Spacer()
+                Text(entry.elapsed.formatted(.units(allowed: [.milliseconds, .seconds])))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                if let range = entry.originalUTF16Range, let onRevealSource {
+                    Button("Reveal", systemImage: "arrow.up.left.square") {
+                        onRevealSource(range)
+                    }
+                    .controlSize(.small)
+                    .labelStyle(.iconOnly)
+                }
+            }
+            Text(entry.message)
+                .foregroundStyle(.red)
+                .textSelection(.enabled)
+            Text(entry.text)
+                .font(.system(.body, design: .monospaced))
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct NoteRow: View {
+    let entry: NoteEntry
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: iconName(entry.kind))
+                .foregroundStyle(iconColor(entry.kind))
+            Text(entry.text)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+}
+
+private func iconName(_ kind: NoteEntry.Kind) -> String {
+    switch kind {
+    case .cancelled: return "stop.circle"
+    case .info:      return "info.circle"
+    case .warning:   return "exclamationmark.triangle"
+    }
+}
+
+private func iconColor(_ kind: NoteEntry.Kind) -> Color {
+    switch kind {
+    case .cancelled: return .secondary
+    case .info:      return .secondary
+    case .warning:   return .orange
+    }
+}
+
+private struct DbmsOutputBlock: View {
+    let lines: [String]
+    @State private var isExpanded: Bool = true
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            ScrollView(.vertical) {
+                Text(lines.joined(separator: "\n"))
+                    .font(.system(.body, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
+                    .background(.secondary.opacity(0.08))
+            }
+            .frame(maxHeight: 160)
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "terminal")
+                    .foregroundStyle(.secondary)
+                Text("DBMS_OUTPUT (\(lines.count) line\(lines.count == 1 ? "" : "s"))")
+                    .font(.callout)
+            }
+        }
+    }
+}
+
+#Preview {
+    let model = ScriptOutputModel()
+    model.beginRun(totalUnits: 3)
+    model.append(.directive(.init(id: UUID(), text: "SET SERVEROUTPUT ON", elapsed: .zero)))
+    model.append(.succeeded(.init(
+        id: UUID(),
+        unitIndex: 1,
+        text: "SELECT * FROM dual",
+        kind: .sql,
+        elapsed: .milliseconds(42),
+        rowCount: 1,
+        dbmsOutput: [],
+        preview: .init(columns: ["DUMMY"], rows: [["X"]], truncated: false)
+    )))
+    model.append(.failed(.init(
+        id: UUID(),
+        unitIndex: 2,
+        text: "SELECT * FROM nonexistent",
+        kind: .sql,
+        elapsed: .milliseconds(8),
+        message: "ORA-00942: table or view does not exist",
+        oracleErrorCode: 942,
+        originalUTF16Range: 0..<25
+    )))
+    model.finishRun()
+    return ScriptOutputView(model: model)
+        .frame(width: 700, height: 400)
+}

--- a/Macintora/Results/ScriptRunner.swift
+++ b/Macintora/Results/ScriptRunner.swift
@@ -6,35 +6,47 @@
 //  `ConnectionExecutor`. Single owner of cancellation; emits events over an
 //  `AsyncStream` that UI consumers iterate on the main actor.
 //
-//  Phase 2 scope: protocol + types + serial execution loop with a fake
-//  executor in tests. Wiring against a real OracleConnection is Phase 4;
-//  bind / substitution prompts and SQL*Plus side effects are Phase 5/6.
+//  Directive application + `&` substitution happens *inline* during the run
+//  loop so mid-script `DEFINE` and `WHENEVER SQLERROR` mutations are honored
+//  by subsequent units. Bind-variable values are gathered per-unit via the
+//  `needsBinds` event.
+//
+//  Note: `SET SERVEROUTPUT` mid-run mutation is intentionally not honored —
+//  the executor captures `dbmsOutputEnabled` at construction time. The
+//  caller pre-scans the script for the final SERVEROUTPUT setting and
+//  passes it to the executor's init.
 //
 
 import Foundation
 
-/// Configuration knobs the script-runner needs at construction time.
+/// Static knobs that don't depend on the script's directive state.
 struct ScriptRunnerOptions: Sendable {
-    /// Stop the script on the first failed unit. Phase 6 will replace this
-    /// with the SQL*Plus `WHENEVER SQLERROR` setting; for now it's a simple
-    /// boolean.
-    var stopOnError: Bool = true
+    /// User-level "always halt on error" override. When `true`, the runner
+    /// halts on the first failure regardless of the script's
+    /// `WHENEVER SQLERROR` setting. The default is `false` so the env
+    /// drives behaviour.
+    var alwaysStopOnError: Bool = false
 }
 
 actor ScriptRunner {
     private let units: [CommandUnit]
     private let executor: any ConnectionExecutor
+    private let env: SqlPlusEnvironment
     private let options: ScriptRunnerOptions
-    private var continuation: AsyncStream<ScriptRunnerEvent>.Continuation?
     private var isCancelled = false
+    /// The most recent CREATE [OR REPLACE] target the runner has seen.
+    /// Used by SHOW ERRORS to decide which object to query USER_ERRORS for.
+    private var lastStoredProc: StoredProc?
 
     init(
         units: [CommandUnit],
         executor: any ConnectionExecutor,
+        env: SqlPlusEnvironment,
         options: ScriptRunnerOptions = .init()
     ) {
         self.units = units
         self.executor = executor
+        self.env = env
         self.options = options
     }
 
@@ -62,52 +74,156 @@ actor ScriptRunner {
     }
 
     private func run(continuation: AsyncStream<ScriptRunnerEvent>.Continuation) async {
-        self.continuation = continuation
-        defer {
-            continuation.finish()
-        }
+        defer { continuation.finish() }
 
         for (idx, unit) in units.enumerated() {
             if isCancelled || Task.isCancelled {
                 continuation.yield(.cancelled)
                 return
             }
-
             continuation.yield(.unitStarted(index: idx, total: units.count, unit: unit))
 
-            // Phase 2 path: no bind/substitution prompts; pass unit text through.
-            let prepared = PreparedUnit(
-                unit: unit,
-                resolvedText: unit.text,
-                binds: [:]
-            )
-
-            let start = ContinuousClock.now
             let result: UnitResult
-            do {
-                let executed = try await executor.execute(prepared)
-                result = executed
-            } catch is CancellationError {
-                continuation.yield(.cancelled)
-                return
-            } catch {
-                let elapsed = ContinuousClock.now - start
-                let oraCode = (error as? any OracleErrorCarrier)?.oracleErrorCode
-                result = UnitResult(
-                    outcome: .statementFailed(message: error.localizedDescription, oracleErrorCode: oraCode),
-                    elapsed: elapsed
-                )
+            switch unit.kind {
+            case .sqlplus(let directive):
+                result = await applyDirective(directive)
+
+            case .sql, .plsqlBlock:
+                let outcome = await runSqlOrPlsql(unit: unit, index: idx, continuation: continuation)
+                switch outcome {
+                case .result(let r):
+                    result = r
+                case .cancelled:
+                    continuation.yield(.cancelled)
+                    return
+                }
+                // Track the most recent CREATE target so a subsequent SHOW
+                // ERRORS knows what to query USER_ERRORS for.
+                if case .plsqlBlock = unit.kind {
+                    let runnable = RunnableSQL(sql: unit.text)
+                    if let proc = runnable.storedProc { lastStoredProc = proc }
+                }
             }
 
             continuation.yield(.unitFinished(index: idx, result: result))
 
-            if case .statementFailed = result.outcome, options.stopOnError {
-                continuation.yield(.scriptFinished)
-                return
+            if case .statementFailed = result.outcome {
+                if options.alwaysStopOnError || env.shouldHaltOnError {
+                    continuation.yield(.scriptFinished)
+                    return
+                }
             }
         }
 
         continuation.yield(.scriptFinished)
+    }
+
+    // MARK: - Per-unit handlers
+
+    private func applyDirective(_ directive: SqlPlusDirective) async -> UnitResult {
+        let start = ContinuousClock.now
+        let outcome = SqlPlusInterpreter.apply(directive, env: env)
+
+        switch outcome {
+        case .showErrors:
+            return await fetchAndPackageCompileErrors(start: start)
+        case .acknowledged, .skip, .prompt, .noted, .unresolvedInclude:
+            return UnitResult(
+                outcome: .directiveAcknowledged,
+                elapsed: ContinuousClock.now - start
+            )
+        }
+    }
+
+    private func fetchAndPackageCompileErrors(start: ContinuousClock.Instant) async -> UnitResult {
+        guard let proc = lastStoredProc else {
+            return UnitResult(
+                outcome: .directiveCompileErrors(target: nil, errors: []),
+                elapsed: ContinuousClock.now - start
+            )
+        }
+        let target = CompileErrorTarget(owner: proc.owner, name: proc.name, type: proc.type)
+        do {
+            let rows = try await executor.fetchCompileErrors(for: target)
+            return UnitResult(
+                outcome: .directiveCompileErrors(target: target, errors: rows),
+                elapsed: ContinuousClock.now - start
+            )
+        } catch {
+            return UnitResult(
+                outcome: .statementFailed(message: "SHOW ERRORS failed: \(error.localizedDescription)", oracleErrorCode: nil),
+                elapsed: ContinuousClock.now - start
+            )
+        }
+    }
+
+    private enum UnitOutcome {
+        case result(UnitResult)
+        case cancelled
+    }
+
+    private func runSqlOrPlsql(
+        unit: CommandUnit,
+        index: Int,
+        continuation: AsyncStream<ScriptRunnerEvent>.Continuation
+    ) async -> UnitOutcome {
+        let resolvedText = env.defineEnabled
+            ? SubstitutionResolver.resolve(unit.text, defines: env.defines).text
+            : unit.text
+
+        // Bind prompt — pause until bridge resumes with values (or nil).
+        let bindNames = RunnableSQL.scanBindVars(resolvedText)
+        var binds: [String: BindValue] = [:]
+        if !bindNames.isEmpty {
+            guard let collected = await collectBinds(unitIndex: index, names: bindNames, continuation: continuation) else {
+                return .cancelled
+            }
+            binds = collected
+        }
+
+        if isCancelled || Task.isCancelled {
+            return .cancelled
+        }
+
+        let prepared = PreparedUnit(unit: unit, resolvedText: resolvedText, binds: binds)
+        let start = ContinuousClock.now
+        do {
+            let executed = try await executor.execute(prepared)
+            return .result(executed)
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            let elapsed = ContinuousClock.now - start
+            let oraCode = (error as? any OracleErrorCarrier)?.oracleErrorCode
+            return .result(UnitResult(
+                outcome: .statementFailed(message: error.localizedDescription, oracleErrorCode: oraCode),
+                elapsed: elapsed
+            ))
+        }
+    }
+
+    private func collectBinds(
+        unitIndex: Int,
+        names: Set<String>,
+        continuation: AsyncStream<ScriptRunnerEvent>.Continuation
+    ) async -> [String: BindValue]? {
+        await withCheckedContinuation { (cc: CheckedContinuation<[String: BindValue]?, Never>) in
+            let request = BindRequest(
+                unitIndex: unitIndex,
+                names: names,
+                resume: { values in cc.resume(returning: values) }
+            )
+            continuation.yield(.needsBinds(request))
+        }
+    }
+}
+
+extension SqlPlusEnvironment {
+    /// Convenience for the runner: should the script halt on the most recent
+    /// failure given the current `WHENEVER` action?
+    var shouldHaltOnError: Bool {
+        if case .exit = whenever { return true }
+        return false
     }
 }
 

--- a/Macintora/Results/ScriptRunner.swift
+++ b/Macintora/Results/ScriptRunner.swift
@@ -1,0 +1,118 @@
+//
+//  ScriptRunner.swift
+//  Macintora
+//
+//  Drives sequential execution of a script's CommandUnits against a
+//  `ConnectionExecutor`. Single owner of cancellation; emits events over an
+//  `AsyncStream` that UI consumers iterate on the main actor.
+//
+//  Phase 2 scope: protocol + types + serial execution loop with a fake
+//  executor in tests. Wiring against a real OracleConnection is Phase 4;
+//  bind / substitution prompts and SQL*Plus side effects are Phase 5/6.
+//
+
+import Foundation
+
+/// Configuration knobs the script-runner needs at construction time.
+struct ScriptRunnerOptions: Sendable {
+    /// Stop the script on the first failed unit. Phase 6 will replace this
+    /// with the SQL*Plus `WHENEVER SQLERROR` setting; for now it's a simple
+    /// boolean.
+    var stopOnError: Bool = true
+}
+
+actor ScriptRunner {
+    private let units: [CommandUnit]
+    private let executor: any ConnectionExecutor
+    private let options: ScriptRunnerOptions
+    private var continuation: AsyncStream<ScriptRunnerEvent>.Continuation?
+    private var isCancelled = false
+
+    init(
+        units: [CommandUnit],
+        executor: any ConnectionExecutor,
+        options: ScriptRunnerOptions = .init()
+    ) {
+        self.units = units
+        self.executor = executor
+        self.options = options
+    }
+
+    /// Begin execution. Returns the event stream the caller should iterate.
+    /// The stream finishes after `scriptFinished` (or `cancelled`) is emitted.
+    nonisolated func start() -> AsyncStream<ScriptRunnerEvent> {
+        AsyncStream { continuation in
+            // Detached so the run loop dispatches off the caller's actor.
+            // (Approachable concurrency would otherwise pin the loop to
+            // whichever actor invoked `start()`.)
+            let task = Task.detached { @concurrent [weak self] in
+                await self?.run(continuation: continuation)
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    /// Cancel a script that's mid-flight. Idempotent.
+    func cancel() async {
+        guard !isCancelled else { return }
+        isCancelled = true
+        await executor.cancel()
+    }
+
+    private func run(continuation: AsyncStream<ScriptRunnerEvent>.Continuation) async {
+        self.continuation = continuation
+        defer {
+            continuation.finish()
+        }
+
+        for (idx, unit) in units.enumerated() {
+            if isCancelled || Task.isCancelled {
+                continuation.yield(.cancelled)
+                return
+            }
+
+            continuation.yield(.unitStarted(index: idx, total: units.count, unit: unit))
+
+            // Phase 2 path: no bind/substitution prompts; pass unit text through.
+            let prepared = PreparedUnit(
+                unit: unit,
+                resolvedText: unit.text,
+                binds: [:]
+            )
+
+            let start = ContinuousClock.now
+            let result: UnitResult
+            do {
+                let executed = try await executor.execute(prepared)
+                result = executed
+            } catch is CancellationError {
+                continuation.yield(.cancelled)
+                return
+            } catch {
+                let elapsed = ContinuousClock.now - start
+                let oraCode = (error as? any OracleErrorCarrier)?.oracleErrorCode
+                result = UnitResult(
+                    outcome: .statementFailed(message: error.localizedDescription, oracleErrorCode: oraCode),
+                    elapsed: elapsed
+                )
+            }
+
+            continuation.yield(.unitFinished(index: idx, result: result))
+
+            if case .statementFailed = result.outcome, options.stopOnError {
+                continuation.yield(.scriptFinished)
+                return
+            }
+        }
+
+        continuation.yield(.scriptFinished)
+    }
+}
+
+/// Thin marker so executors can hand back ORA-NNNNN codes without forcing
+/// every caller to know about OracleNIO error types.
+protocol OracleErrorCarrier: Error {
+    var oracleErrorCode: Int? { get }
+}

--- a/Macintora/Results/ScriptRunnerEvent.swift
+++ b/Macintora/Results/ScriptRunnerEvent.swift
@@ -13,6 +13,11 @@ struct UnitResult: Equatable, Sendable {
     enum Outcome: Equatable, Sendable {
         /// SQL*Plus directive successfully applied (no DB call needed).
         case directiveAcknowledged
+        /// `SHOW ERRORS` directive: zero or more compile errors retrieved
+        /// from `USER_ERRORS` for the most recently compiled object.
+        /// `target` is the object the errors apply to (or nil if there
+        /// hasn't been a CREATE in the script yet).
+        case directiveCompileErrors(target: CompileErrorTarget?, errors: [CompileErrorRow])
         /// SQL/PL-SQL statement ran successfully. `preview` carries a bounded
         /// snapshot of returned rows (nil for non-SELECT).
         case statementSucceeded(rowCount: Int?, dbmsOutput: [String], preview: RowsPreview?)
@@ -24,6 +29,22 @@ struct UnitResult: Equatable, Sendable {
     let outcome: Outcome
     /// Wall-clock duration of the unit (excluding bind / substitution prompts).
     let elapsed: Duration
+}
+
+/// One row from `USER_ERRORS` for the most-recently-compiled stored object.
+struct CompileErrorRow: Equatable, Hashable, Sendable {
+    let line: Int
+    let position: Int
+    let sequence: Int
+    let attribute: String   // "ERROR" / "WARNING"
+    let text: String
+}
+
+/// Identifier for the object SHOW ERRORS is reporting on.
+struct CompileErrorTarget: Equatable, Hashable, Sendable {
+    let owner: String?
+    let name: String
+    let type: String
 }
 
 /// A request from the runner to gather data from the user. The runner pauses

--- a/Macintora/Results/ScriptRunnerEvent.swift
+++ b/Macintora/Results/ScriptRunnerEvent.swift
@@ -1,0 +1,52 @@
+//
+//  ScriptRunnerEvent.swift
+//  Macintora
+//
+//  Events emitted by `ScriptRunner` over its `AsyncStream`. UI consumers
+//  subscribe on the main actor; the runner stays on its own actor.
+//
+
+import Foundation
+
+/// One outcome of executing a single command unit.
+struct UnitResult: Equatable, Sendable {
+    enum Outcome: Equatable, Sendable {
+        /// SQL*Plus directive successfully applied (no DB call needed).
+        case directiveAcknowledged
+        /// SQL/PL-SQL statement ran successfully. `preview` carries a bounded
+        /// snapshot of returned rows (nil for non-SELECT).
+        case statementSucceeded(rowCount: Int?, dbmsOutput: [String], preview: RowsPreview?)
+        /// Statement failed. `oracleErrorCode` is the ORA-NNNNN integer or nil
+        /// for non-Oracle errors (cancellation, network, etc.).
+        case statementFailed(message: String, oracleErrorCode: Int?)
+    }
+
+    let outcome: Outcome
+    /// Wall-clock duration of the unit (excluding bind / substitution prompts).
+    let elapsed: Duration
+}
+
+/// A request from the runner to gather data from the user. The runner pauses
+/// until `resume` is invoked.
+struct BindRequest: Sendable {
+    let unitIndex: Int
+    let names: Set<String>
+    /// Resolves with bind values, or nil to abort the script.
+    let resume: @Sendable ([String: BindValue]?) -> Void
+}
+
+struct SubstitutionRequest: Sendable {
+    let names: Set<String>
+    let stickyNames: Set<String>
+    /// Resolves with name→value (uppercased keys), or nil to abort.
+    let resume: @Sendable ([String: String]?) -> Void
+}
+
+enum ScriptRunnerEvent: Sendable {
+    case unitStarted(index: Int, total: Int, unit: CommandUnit)
+    case unitFinished(index: Int, result: UnitResult)
+    case needsBinds(BindRequest)
+    case needsSubstitutions(SubstitutionRequest)
+    case cancelled
+    case scriptFinished
+}

--- a/Macintora/Results/SubstitutionInputView.swift
+++ b/Macintora/Results/SubstitutionInputView.swift
@@ -1,0 +1,116 @@
+//
+//  SubstitutionInputView.swift
+//  Macintora
+//
+//  Modal that collects values for SQL*Plus substitution variables (`&name`,
+//  `&&name`) before a script run. Modeled on `BindVarInputView`. `&&` names
+//  are flagged as "session-sticky" so the user knows their value will be
+//  remembered for the rest of the document's lifetime.
+//
+
+import SwiftUI
+
+struct PendingSubstitutionRequest: Identifiable, Equatable {
+    let id: UUID
+    let names: [String]
+    let stickyNames: Set<String>
+    let prefilled: [String: String]
+
+    init(names: [String], stickyNames: Set<String>, prefilled: [String: String] = [:]) {
+        self.id = UUID()
+        self.names = names
+        self.stickyNames = stickyNames
+        self.prefilled = prefilled
+    }
+}
+
+struct SubstitutionInputView: View {
+    let request: PendingSubstitutionRequest
+    /// `nil` = user cancelled.
+    var onSubmit: ([String: String]?) -> Void
+
+    @State private var values: [String: String] = [:]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Substitution Variables")
+                .font(.title3)
+                .bold()
+            Text("Provide values for the script's `&` and `&&` substitution variables. `&&` values stick for the rest of this document's session.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(request.names, id: \.self) { name in
+                        SubstitutionField(
+                            name: name,
+                            isSticky: request.stickyNames.contains(name),
+                            value: Binding(
+                                get: { values[name] ?? "" },
+                                set: { values[name] = $0 }
+                            )
+                        )
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(minHeight: 80, idealHeight: 200, maxHeight: 360)
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) {
+                    onSubmit(nil)
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("Run") {
+                    onSubmit(values)
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(minWidth: 420, idealWidth: 480)
+        .onAppear {
+            // Seed any prefilled defaults exactly once.
+            for (k, v) in request.prefilled where values[k] == nil {
+                values[k] = v
+            }
+        }
+    }
+}
+
+private struct SubstitutionField: View {
+    let name: String
+    let isSticky: Bool
+    @Binding var value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(name)
+                .font(.system(.body, design: .monospaced))
+                .frame(minWidth: 100, alignment: .leading)
+            if isSticky {
+                Image(systemName: "pin.fill")
+                    .foregroundStyle(.orange)
+                    .help("This value will stick for the rest of the session (&&).")
+            }
+            TextField("value", text: $value)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+}
+
+#Preview {
+    SubstitutionInputView(
+        request: .init(
+            names: ["OWNER", "SCHEMA", "BATCH_ID"],
+            stickyNames: ["OWNER"],
+            prefilled: ["BATCH_ID": "42"]
+        ),
+        onSubmit: { _ in }
+    )
+}

--- a/Macintora/Results/SubstitutionInputView.swift
+++ b/Macintora/Results/SubstitutionInputView.swift
@@ -24,6 +24,16 @@ struct PendingSubstitutionRequest: Identifiable, Equatable {
     }
 }
 
+/// Set on `ResultsController` when the runner needs `:bind` values for the
+/// current SQL/PLSQL unit. View layer presents a `BindVarInputView` and
+/// calls back into `resolvePendingBinds(_:)` (or with `nil` to cancel).
+struct PendingBindRequest: Identifiable, Sendable {
+    let id: UUID
+    let unitIndex: Int
+    let names: Set<String>
+    let resume: @Sendable ([String: BindValue]?) -> Void
+}
+
 struct SubstitutionInputView: View {
     let request: PendingSubstitutionRequest
     /// `nil` = user cancelled.
@@ -65,15 +75,18 @@ struct SubstitutionInputView: View {
                     onSubmit(nil)
                 }
                 .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("script.substitutionSheet.cancel")
                 Button("Run") {
                     onSubmit(values)
                 }
                 .keyboardShortcut(.defaultAction)
                 .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("script.substitutionSheet.run")
             }
         }
         .padding()
         .frame(minWidth: 420, idealWidth: 480)
+        .accessibilityIdentifier("script.substitutionSheet")
         .onAppear {
             // Seed any prefilled defaults exactly once.
             for (k, v) in request.prefilled where values[k] == nil {

--- a/Macintora/Script/OffsetMap.swift
+++ b/Macintora/Script/OffsetMap.swift
@@ -1,0 +1,96 @@
+//
+//  OffsetMap.swift
+//  Macintora
+//
+//  Sparse mapping from positions in a "resolved" string back to positions in
+//  the "original" string. Built by SubstitutionResolver during script
+//  preprocessing so click-to-source can highlight the original (pre-
+//  substitution) range when the runner reports an error.
+//
+//  All offsets are UTF-16 code units. Conversion helpers between String.Index
+//  and UTF-16 offsets are provided.
+//
+
+import Foundation
+
+struct OffsetMap: Equatable {
+    struct Segment: Equatable {
+        enum Kind: Equatable {
+            /// Characters copied 1:1 from original to resolved.
+            case passthrough
+            /// A single `&name` / `&&name` reference in the original was
+            /// replaced by a (possibly differently-sized) value in resolved.
+            case substitution
+        }
+        let kind: Kind
+        let resolvedRange: Range<Int>
+        let originalRange: Range<Int>
+    }
+
+    let segments: [Segment]
+    let originalLength: Int
+    let resolvedLength: Int
+
+    /// Identity mapping for a string of `length` UTF-16 code units.
+    static func identity(utf16Length length: Int) -> OffsetMap {
+        if length == 0 {
+            return OffsetMap(segments: [], originalLength: 0, resolvedLength: 0)
+        }
+        return OffsetMap(
+            segments: [.init(kind: .passthrough, resolvedRange: 0..<length, originalRange: 0..<length)],
+            originalLength: length,
+            resolvedLength: length
+        )
+    }
+
+    /// Project a half-open range in resolved space back into original space.
+    /// For overlapping `.substitution` segments, the entire original range of
+    /// the substitution is included — there is no character-level mapping
+    /// inside a substituted value.
+    func originalRange(forResolved range: Range<Int>) -> Range<Int> {
+        var lo: Int? = nil
+        var hi: Int? = nil
+
+        for seg in segments where seg.resolvedRange.overlaps(range) {
+            let segLo: Int
+            let segHi: Int
+            switch seg.kind {
+            case .passthrough:
+                let resStart = max(range.lowerBound, seg.resolvedRange.lowerBound)
+                let resEnd = min(range.upperBound, seg.resolvedRange.upperBound)
+                let inOff = resStart - seg.resolvedRange.lowerBound
+                let inLen = resEnd - resStart
+                segLo = seg.originalRange.lowerBound + inOff
+                segHi = segLo + inLen
+            case .substitution:
+                segLo = seg.originalRange.lowerBound
+                segHi = seg.originalRange.upperBound
+            }
+            lo = lo.map { min($0, segLo) } ?? segLo
+            hi = hi.map { max($0, segHi) } ?? segHi
+        }
+
+        if let lo, let hi { return lo..<hi }
+        // Empty / out-of-range query: collapse to the boundary so callers can
+        // still build a Range<String.Index> without a crash.
+        let bounded = min(max(range.lowerBound, 0), originalLength)
+        return bounded..<bounded
+    }
+
+    /// Convenience: project a `Range<String.Index>` in `resolved` back into a
+    /// `Range<String.Index>` in `original`.
+    func originalRange(
+        forResolved range: Range<String.Index>,
+        in resolved: String,
+        original: String
+    ) -> Range<String.Index> {
+        let resLo = resolved.utf16.distance(from: resolved.utf16.startIndex, to: range.lowerBound.samePosition(in: resolved.utf16) ?? resolved.utf16.startIndex)
+        let resHi = resolved.utf16.distance(from: resolved.utf16.startIndex, to: range.upperBound.samePosition(in: resolved.utf16) ?? resolved.utf16.endIndex)
+        let orig = originalRange(forResolved: resLo..<resHi)
+        let oLo = original.utf16.index(original.utf16.startIndex, offsetBy: orig.lowerBound, limitedBy: original.utf16.endIndex) ?? original.utf16.endIndex
+        let oHi = original.utf16.index(original.utf16.startIndex, offsetBy: orig.upperBound, limitedBy: original.utf16.endIndex) ?? original.utf16.endIndex
+        let lo = String.Index(oLo, within: original) ?? original.endIndex
+        let hi = String.Index(oHi, within: original) ?? original.endIndex
+        return lo..<hi
+    }
+}

--- a/Macintora/Script/ScriptError.swift
+++ b/Macintora/Script/ScriptError.swift
@@ -1,0 +1,18 @@
+//
+//  ScriptError.swift
+//  Macintora
+//
+
+import Foundation
+
+/// Errors surfaced by the script lexer / runner. `originalRange` references
+/// positions in the unparsed script source so callers can navigate back to
+/// the offending region in the editor.
+enum ScriptError: Error, Equatable, Sendable {
+    case unterminatedString(at: String.Index)
+    case unterminatedQQuote(at: String.Index)
+    case unterminatedBlockComment(at: String.Index)
+    case unterminatedQuotedIdentifier(at: String.Index)
+    case unterminatedPlsqlBlock(at: String.Index)
+    case malformedDirective(at: String.Index, message: String)
+}

--- a/Macintora/Script/ScriptLexer.swift
+++ b/Macintora/Script/ScriptLexer.swift
@@ -1,0 +1,669 @@
+//
+//  ScriptLexer.swift
+//  Macintora
+//
+//  Splits a SQL*Plus script into ordered command units. Hand-rolled
+//  character-stream tokenizer rather than tree-sitter — Neon's grammar is
+//  tuned for highlighting and does not model SQL*Plus directives, lone-`/`
+//  termination, q-quotes uniformly across delimiter shapes, or `@`/`@@`
+//  semantics.
+//
+//  Phase 0: pure parsing only. Side effects (substitution, execution,
+//  directive interpretation) live in later phases.
+//
+
+import Foundation
+
+/// One classified region of script source, in original-text order.
+struct CommandUnit: Equatable {
+    enum Kind: Equatable {
+        case sql
+        case plsqlBlock
+        case sqlplus(SqlPlusDirective)
+    }
+
+    let kind: Kind
+    /// Range in the *original* (un-substituted) source.
+    let originalRange: Range<String.Index>
+    /// Executable text — terminator stripped, surrounding whitespace trimmed.
+    let text: String
+}
+
+struct ScriptUnits: Equatable {
+    let units: [CommandUnit]
+    let originalText: String
+}
+
+enum ScriptLexer {
+    static func split(_ source: String) -> ScriptUnits {
+        var lexer = LexerState(source: source)
+        var units: [CommandUnit] = []
+        while !lexer.isAtEnd {
+            lexer.skipInterUnitTrivia()
+            if lexer.isAtEnd { break }
+
+            if let unit = lexer.readDirectiveAtLineStart() {
+                units.append(unit)
+                continue
+            }
+
+            units.append(lexer.readSqlOrPlsqlUnit())
+        }
+        return ScriptUnits(units: units, originalText: source)
+    }
+}
+
+// MARK: - State
+
+private struct LexerState {
+    let source: String
+    var index: String.Index
+
+    init(source: String) {
+        self.source = source
+        self.index = source.startIndex
+    }
+
+    var isAtEnd: Bool { index >= source.endIndex }
+
+    func char(at i: String.Index) -> Character? {
+        guard i < source.endIndex else { return nil }
+        return source[i]
+    }
+
+    func nextIndex(after i: String.Index, by n: Int = 1) -> String.Index {
+        source.index(i, offsetBy: n, limitedBy: source.endIndex) ?? source.endIndex
+    }
+
+    mutating func advance() {
+        if !isAtEnd { index = source.index(after: index) }
+    }
+
+    mutating func advance(by n: Int) {
+        index = source.index(index, offsetBy: n, limitedBy: source.endIndex) ?? source.endIndex
+    }
+
+    func isAtLineStart(at i: String.Index) -> Bool {
+        if i == source.startIndex { return true }
+        return source[source.index(before: i)] == "\n"
+    }
+}
+
+// MARK: - Identifier helpers
+
+private func isIdentChar(_ c: Character) -> Bool {
+    c.isLetter || c.isNumber || c == "_" || c == "$" || c == "#"
+}
+
+// MARK: - Inter-unit trivia
+
+extension LexerState {
+    mutating func skipInterUnitTrivia() {
+        while !isAtEnd {
+            let c = source[index]
+            if c.isWhitespace {
+                advance()
+                continue
+            }
+            if c == "-" && char(at: nextIndex(after: index)) == "-" {
+                consumeLineComment()
+                continue
+            }
+            if c == "/" && char(at: nextIndex(after: index)) == "*" {
+                consumeBlockComment()
+                continue
+            }
+            // Lone `/` line between units (SQL*Plus "execute buffer"; we discard).
+            if c == "/" && isAtLineStart(at: index) && lineIsBlank(from: nextIndex(after: index)) {
+                consumeRestOfLine()
+                continue
+            }
+            break
+        }
+    }
+
+    /// Whether the rest of the current line (from `start`) is whitespace until
+    /// the next `\n` or EOF.
+    func lineIsBlank(from start: String.Index) -> Bool {
+        var i = start
+        while i < source.endIndex {
+            let c = source[i]
+            if c == "\n" { return true }
+            if !c.isWhitespace { return false }
+            i = source.index(after: i)
+        }
+        return true
+    }
+
+    mutating func consumeLineComment() {
+        advance() // -
+        advance() // -
+        while !isAtEnd && source[index] != "\n" { advance() }
+        if !isAtEnd { advance() }
+    }
+
+    mutating func consumeBlockComment() {
+        advance() // /
+        advance() // *
+        while !isAtEnd {
+            if source[index] == "*" && char(at: nextIndex(after: index)) == "/" {
+                advance(); advance()
+                return
+            }
+            advance()
+        }
+    }
+
+    mutating func consumeRestOfLine() {
+        while !isAtEnd && source[index] != "\n" { advance() }
+        if !isAtEnd { advance() }
+    }
+
+    mutating func skipHorizontalWhitespace() {
+        while !isAtEnd {
+            let c = source[index]
+            if c == " " || c == "\t" { advance() } else { break }
+        }
+    }
+
+    /// Read a contiguous identifier-like word starting at `i` *without*
+    /// advancing `index`. Returns "" if the first char is not an ident char.
+    func peekWord(from i: String.Index) -> String {
+        var j = i
+        while j < source.endIndex && isIdentChar(source[j]) {
+            j = source.index(after: j)
+        }
+        return String(source[i..<j])
+    }
+
+    func peekWord() -> String { peekWord(from: index) }
+}
+
+// MARK: - SQL*Plus directive parsing
+
+extension LexerState {
+    mutating func readDirectiveAtLineStart() -> CommandUnit? {
+        guard isAtLineStart(at: index) else { return nil }
+        guard let firstChar = char(at: index) else { return nil }
+
+        let start = index
+
+        // @file or @@file include
+        if firstChar == "@" {
+            let doubleAt = char(at: nextIndex(after: index)) == "@"
+            advance(by: doubleAt ? 2 : 1)
+            skipHorizontalWhitespace()
+            let restStart = index
+            while !isAtEnd && source[index] != "\n" { advance() }
+            let path = source[restStart..<index].trimmingCharacters(in: .whitespaces)
+            if !isAtEnd { advance() } // consume \n
+            return makeDirectiveUnit(start: start, directive: .include(path: path, doubleAt: doubleAt))
+        }
+
+        let word = peekWord()
+        let upper = word.uppercased()
+
+        switch upper {
+        case "REM", "REMARK":
+            advance(by: word.count)
+            let body = takeRestOfLineRaw()
+            return makeDirectiveUnit(start: start, directive: .remark(text: body.trimmingCharacters(in: .whitespaces)))
+
+        case "PROMPT":
+            advance(by: word.count)
+            // Per SQL*Plus: PROMPT followed by space then message; trailing newline excluded.
+            let body = takeRestOfLineRaw()
+            let msg: String = body.first == " " ? String(body.dropFirst()) : body
+            return makeDirectiveUnit(start: start, directive: .prompt(message: msg))
+
+        case "DEFINE":
+            advance(by: word.count)
+            let body = takeRestOfLineRaw()
+            return makeDirectiveUnit(start: start, directive: parseDefine(body))
+
+        case "UNDEFINE", "UNDEF":
+            advance(by: word.count)
+            let body = takeRestOfLineRaw()
+            return makeDirectiveUnit(start: start, directive: .undefine(name: body.trimmingCharacters(in: .whitespaces)))
+
+        case "SET":
+            advance(by: word.count)
+            let body = takeRestOfLineRaw()
+            return makeDirectiveUnit(start: start, directive: parseSet(body))
+
+        case "SHOW", "SHO":
+            advance(by: word.count)
+            skipHorizontalWhitespace()
+            let next = peekWord().uppercased()
+            if next == "ERRORS" || next == "ERR" {
+                advance(by: next.count)
+                _ = takeRestOfLineRaw()
+                return makeDirectiveUnit(start: start, directive: .showErrors)
+            }
+            let rest = takeRestOfLineRaw()
+            return makeDirectiveUnit(start: start, directive: .unrecognized(text: "SHOW \(next)\(rest)"))
+
+        case "WHENEVER":
+            advance(by: word.count)
+            let body = takeRestOfLineRaw()
+            if let parsed = parseWhenever(body) {
+                return makeDirectiveUnit(start: start, directive: parsed)
+            }
+            return makeDirectiveUnit(start: start, directive: .unrecognized(text: "WHENEVER\(body)"))
+
+        default:
+            return nil
+        }
+    }
+
+    /// Consume from current index through the next newline (newline included).
+    /// Returned string excludes the trailing newline.
+    mutating func takeRestOfLineRaw() -> String {
+        let s = index
+        while !isAtEnd && source[index] != "\n" { advance() }
+        let result = String(source[s..<index])
+        if !isAtEnd { advance() }
+        return result
+    }
+
+    func makeDirectiveUnit(start: String.Index, directive: SqlPlusDirective) -> CommandUnit {
+        let raw = String(source[start..<index]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return CommandUnit(kind: .sqlplus(directive), originalRange: start..<index, text: raw)
+    }
+}
+
+// MARK: - Directive body parsing
+
+private func parseDefine(_ body: String) -> SqlPlusDirective {
+    let trimmed = body.trimmingCharacters(in: .whitespaces)
+    // `DEFINE name = value` or `DEFINE name=value`. Without `=` it lists the
+    // variable; we degrade gracefully to a no-op define with empty value.
+    guard let eq = trimmed.firstIndex(of: "=") else {
+        if trimmed.isEmpty {
+            return .unrecognized(text: "DEFINE")
+        }
+        return .define(name: trimmed.uppercased(), value: "")
+    }
+    let nameRaw = trimmed[..<eq].trimmingCharacters(in: .whitespaces)
+    var valRaw = trimmed[trimmed.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+    // SQL*Plus accepts quoted values. Strip surrounding single or double quotes.
+    if (valRaw.hasPrefix("'") && valRaw.hasSuffix("'") && valRaw.count >= 2) ||
+       (valRaw.hasPrefix("\"") && valRaw.hasSuffix("\"") && valRaw.count >= 2) {
+        valRaw = String(valRaw.dropFirst().dropLast())
+    }
+    return .define(name: nameRaw.uppercased(), value: String(valRaw))
+}
+
+private func parseSet(_ body: String) -> SqlPlusDirective {
+    let trimmed = body.trimmingCharacters(in: .whitespaces)
+    let parts = trimmed.split(whereSeparator: { $0.isWhitespace }).map { String($0) }
+    guard let key = parts.first?.uppercased() else {
+        return .unrecognized(text: "SET")
+    }
+    let rest = Array(parts.dropFirst())
+    let restJoined = rest.joined(separator: " ")
+
+    switch key {
+    case "SERVEROUTPUT", "SERVEROUT":
+        guard let v = rest.first?.uppercased() else { return .set(.other(name: key, raw: "")) }
+        return .set(.serverOutput(v == "ON" || v == "TRUE" || v == "1"))
+
+    case "ECHO":
+        guard let v = rest.first?.uppercased() else { return .set(.other(name: key, raw: "")) }
+        return .set(.echo(v == "ON" || v == "TRUE" || v == "1"))
+
+    case "FEEDBACK", "FEED":
+        guard let v = rest.first?.uppercased() else { return .set(.other(name: key, raw: "")) }
+        switch v {
+        case "ON": return .set(.feedback(.on))
+        case "OFF": return .set(.feedback(.off))
+        default:
+            if let n = Int(v) { return .set(.feedback(.rows(n))) }
+            return .set(.other(name: key, raw: restJoined))
+        }
+
+    case "DEFINE", "DEF":
+        guard let v = rest.first else { return .set(.other(name: key, raw: "")) }
+        switch v.uppercased() {
+        case "ON": return .set(.define(.on))
+        case "OFF": return .set(.define(.off))
+        default:
+            if let first = v.first, v.count == 1 {
+                return .set(.define(.prefix(first)))
+            }
+            return .set(.other(name: key, raw: restJoined))
+        }
+
+    default:
+        return .set(.other(name: key, raw: restJoined))
+    }
+}
+
+private func parseWhenever(_ body: String) -> SqlPlusDirective? {
+    let trimmed = body.trimmingCharacters(in: .whitespaces)
+    let parts = trimmed.split(whereSeparator: { $0.isWhitespace }).map { String($0).uppercased() }
+    guard parts.count >= 2 else { return nil }
+
+    let condition: WheneverCondition
+    switch parts[0] {
+    case "SQLERROR": condition = .sqlError
+    case "OSERROR":  condition = .osError
+    default: return nil
+    }
+
+    var rest = Array(parts.dropFirst())
+    switch rest.first {
+    case "CONTINUE":
+        rest = Array(rest.dropFirst())
+        let cont: ContinueAction
+        switch rest.first {
+        case "COMMIT":   cont = .commit
+        case "ROLLBACK": cont = .rollback
+        case "NONE":     cont = .noAction
+        default:         cont = .noAction
+        }
+        return .whenever(condition, .continue(cont))
+    case "EXIT":
+        rest = Array(rest.dropFirst())
+        var commitOrRollback: CommitAction? = nil
+        var exitCode: ExitCode = .failure
+        // EXIT [SUCCESS|FAILURE|WARNING|n|SQLCODE] [COMMIT|ROLLBACK]
+        if let first = rest.first {
+            switch first {
+            case "SUCCESS": exitCode = .success; rest.removeFirst()
+            case "FAILURE": exitCode = .failure; rest.removeFirst()
+            case "WARNING": exitCode = .warning; rest.removeFirst()
+            case "SQLCODE": exitCode = .sqlCode; rest.removeFirst()
+            default:
+                if let n = Int(first) { exitCode = .value(n); rest.removeFirst() }
+            }
+        }
+        if let next = rest.first {
+            switch next {
+            case "COMMIT":   commitOrRollback = .commit
+            case "ROLLBACK": commitOrRollback = .rollback
+            default: break
+            }
+        }
+        return .whenever(condition, .exit(exitCode, commitOrRollback: commitOrRollback))
+    default:
+        return nil
+    }
+}
+
+// MARK: - SQL / PL-SQL body scanning
+
+extension LexerState {
+    mutating func readSqlOrPlsqlUnit() -> CommandUnit {
+        let unitStart = index
+        let isPlsql = peekIsPlsqlBlockStart()
+        var trailingTerminator: TerminatorKind = .none
+
+        var inString = false
+        var inQQuote = false
+        var qCloser: Character = "\0"
+
+        scan: while !isAtEnd {
+            let c = source[index]
+
+            // Comments and quoted identifiers only at top level.
+            if !inString && !inQQuote {
+                if c == "-" && char(at: nextIndex(after: index)) == "-" {
+                    consumeLineComment()
+                    continue
+                }
+                if c == "/" && char(at: nextIndex(after: index)) == "*" {
+                    consumeBlockComment()
+                    continue
+                }
+                if c == "\"" {
+                    consumeQuotedIdentifier()
+                    continue
+                }
+            }
+
+            if c == "'" {
+                if inString {
+                    // '' escape stays inside the string.
+                    if char(at: nextIndex(after: index)) == "'" {
+                        advance(); advance()
+                    } else {
+                        inString = false
+                        advance()
+                    }
+                    continue
+                }
+                if inQQuote {
+                    advance()
+                    continue
+                }
+                if isQQuoteIntro(at: index) {
+                    let delimIdx = nextIndex(after: index)
+                    if let delim = char(at: delimIdx) {
+                        qCloser = closingQDelim(for: delim)
+                        inQQuote = true
+                        advance(by: 2) // past `'X` to first content char
+                        continue
+                    }
+                }
+                inString = true
+                advance()
+                continue
+            }
+
+            if inQQuote {
+                if c == qCloser && char(at: nextIndex(after: index)) == "'" {
+                    inQQuote = false
+                    advance(by: 2)
+                    continue
+                }
+                advance()
+                continue
+            }
+
+            if inString {
+                advance()
+                continue
+            }
+
+            // Termination checks (top level).
+            // Lone `/` line ends both PL/SQL blocks and plain SQL.
+            if c == "/" && isAtLineStart(at: index) && lineIsBlank(from: nextIndex(after: index)) {
+                consumeRestOfLine()
+                trailingTerminator = .slash
+                break scan
+            }
+
+            // `;` ends a SQL statement; inside PL/SQL it's part of the body.
+            if !isPlsql && c == ";" {
+                advance()
+                trailingTerminator = .semicolon
+                break scan
+            }
+
+            advance()
+        }
+
+        let raw = String(source[unitStart..<index])
+        let cleaned = cleanedBodyText(raw, isPlsql: isPlsql, terminator: trailingTerminator)
+        return CommandUnit(
+            kind: isPlsql ? .plsqlBlock : .sql,
+            originalRange: unitStart..<index,
+            text: cleaned
+        )
+    }
+
+    mutating func consumeQuotedIdentifier() {
+        advance() // opening "
+        while !isAtEnd {
+            let c = source[index]
+            if c == "\"" {
+                // "" escape
+                if char(at: nextIndex(after: index)) == "\"" {
+                    advance(); advance()
+                    continue
+                }
+                advance()
+                return
+            }
+            advance()
+        }
+    }
+
+    func isQQuoteIntro(at i: String.Index) -> Bool {
+        guard i > source.startIndex else { return false }
+        let p1 = source.index(before: i)
+        let c1 = source[p1]
+        guard c1 == "q" || c1 == "Q" else { return false }
+        // The Q must start a token.
+        let qStartsToken: Bool
+        if p1 == source.startIndex {
+            qStartsToken = true
+        } else {
+            let p2 = source.index(before: p1)
+            let c2 = source[p2]
+            if isIdentChar(c2) {
+                if (c2 == "n" || c2 == "N") {
+                    if p2 == source.startIndex {
+                        qStartsToken = true
+                    } else {
+                        let p3 = source.index(before: p2)
+                        qStartsToken = !isIdentChar(source[p3])
+                    }
+                } else {
+                    qStartsToken = false
+                }
+            } else {
+                qStartsToken = true
+            }
+        }
+        guard qStartsToken else { return false }
+        // Sanity-check the would-be delimiter.
+        let delimIdx = source.index(after: i)
+        guard delimIdx < source.endIndex else { return false }
+        let delim = source[delimIdx]
+        if delim == "'" || delim.isWhitespace { return false }
+        return true
+    }
+}
+
+// MARK: - PL/SQL block detection
+
+extension LexerState {
+    func peekIsPlsqlBlockStart() -> Bool {
+        var i = skipTriviaForLookahead(from: index)
+        let first = peekWord(from: i).uppercased()
+        switch first {
+        case "BEGIN", "DECLARE":
+            return true
+        case "CREATE":
+            i = source.index(i, offsetBy: first.count, limitedBy: source.endIndex) ?? source.endIndex
+            return classifyCreateAsPlsql(from: i)
+        default:
+            return false
+        }
+    }
+
+    func skipTriviaForLookahead(from start: String.Index) -> String.Index {
+        var i = start
+        while i < source.endIndex {
+            let c = source[i]
+            if c.isWhitespace { i = source.index(after: i); continue }
+            if c == "-" && (source.index(after: i) < source.endIndex) && source[source.index(after: i)] == "-" {
+                while i < source.endIndex && source[i] != "\n" { i = source.index(after: i) }
+                if i < source.endIndex { i = source.index(after: i) }
+                continue
+            }
+            if c == "/" && (source.index(after: i) < source.endIndex) && source[source.index(after: i)] == "*" {
+                i = source.index(i, offsetBy: 2, limitedBy: source.endIndex) ?? source.endIndex
+                while i < source.endIndex {
+                    if source[i] == "*" {
+                        let n = source.index(after: i)
+                        if n < source.endIndex && source[n] == "/" {
+                            i = source.index(i, offsetBy: 2, limitedBy: source.endIndex) ?? source.endIndex
+                            break
+                        }
+                    }
+                    i = source.index(after: i)
+                }
+                continue
+            }
+            break
+        }
+        return i
+    }
+
+    func classifyCreateAsPlsql(from start: String.Index) -> Bool {
+        var i = skipTriviaForLookahead(from: start)
+        var word = peekWord(from: i).uppercased()
+
+        if word == "OR" {
+            i = advanceBy(word.count, from: i)
+            i = skipTriviaForLookahead(from: i)
+            word = peekWord(from: i).uppercased()
+            if word == "REPLACE" {
+                i = advanceBy(word.count, from: i)
+                i = skipTriviaForLookahead(from: i)
+                word = peekWord(from: i).uppercased()
+            }
+        }
+
+        while word == "EDITIONABLE" || word == "NONEDITIONABLE" {
+            i = advanceBy(word.count, from: i)
+            i = skipTriviaForLookahead(from: i)
+            word = peekWord(from: i).uppercased()
+        }
+
+        switch word {
+        case "PROCEDURE", "FUNCTION", "TRIGGER", "PACKAGE", "LIBRARY":
+            return true
+        case "TYPE":
+            i = advanceBy(word.count, from: i)
+            i = skipTriviaForLookahead(from: i)
+            let next = peekWord(from: i).uppercased()
+            return next == "BODY"
+        default:
+            return false
+        }
+    }
+
+    func advanceBy(_ n: Int, from i: String.Index) -> String.Index {
+        source.index(i, offsetBy: n, limitedBy: source.endIndex) ?? source.endIndex
+    }
+}
+
+private enum TerminatorKind {
+    case none
+    case semicolon
+    case slash
+}
+
+private func cleanedBodyText(_ raw: String, isPlsql: Bool, terminator: TerminatorKind) -> String {
+    var s = raw
+    // Trim trailing newlines/whitespace first.
+    while let last = s.last, last.isWhitespace { s.removeLast() }
+    switch terminator {
+    case .semicolon:
+        if s.hasSuffix(";") { s.removeLast() }
+    case .slash:
+        if s.hasSuffix("/") { s.removeLast() }
+    case .none:
+        break
+    }
+    while let last = s.last, last.isWhitespace { s.removeLast() }
+    // For PL/SQL, the inner `;` terminator on `END;` stays.
+    _ = isPlsql
+    // Trim leading whitespace.
+    while let first = s.first, first.isWhitespace { s.removeFirst() }
+    return s
+}
+
+private func closingQDelim(for c: Character) -> Character {
+    switch c {
+    case "(": return ")"
+    case "[": return "]"
+    case "{": return "}"
+    case "<": return ">"
+    default: return c
+    }
+}

--- a/Macintora/Script/ScriptLoader.swift
+++ b/Macintora/Script/ScriptLoader.swift
@@ -1,0 +1,166 @@
+//
+//  ScriptLoader.swift
+//  Macintora
+//
+//  Resolves `@file.sql` / `@@file.sql` includes in a unit list. Pre-runner
+//  pass: walks the lexed units, expands every encountered include in-place,
+//  and recurses with cycle detection.
+//
+//  Path semantics:
+//    - `@file`  → resolve against `documentBaseURL` (the running document's
+//                 directory).
+//    - `@@file` → resolve against the URL of the *currently-being-included*
+//                 file. Falls back to `documentBaseURL` for the top-level
+//                 script.
+//    - If the path lacks an extension, `.sql` is appended.
+//
+
+import Foundation
+
+enum ScriptLoaderError: Error, Equatable {
+    case fileNotFound(path: String, resolvedURL: URL)
+    case cycleDetected(path: URL)
+    case readFailed(path: URL, underlying: String)
+    case maxDepthExceeded(limit: Int)
+}
+
+/// Abstraction over `Foundation` file I/O so tests can inject a fake.
+protocol ScriptFileResolver: Sendable {
+    /// Read the contents of `url`, or throw if the file isn't readable.
+    func read(_ url: URL) throws -> String
+    /// Whether the file at `url` exists and is readable.
+    func exists(_ url: URL) -> Bool
+}
+
+struct DefaultScriptFileResolver: ScriptFileResolver {
+    func read(_ url: URL) throws -> String {
+        try String(contentsOf: url, encoding: .utf8)
+    }
+    func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+}
+
+enum ScriptLoader {
+    /// Recursive flattening: walks `units`, expanding every `.include`
+    /// directive into the target file's units. Cycles return
+    /// `.cycleDetected`.
+    ///
+    /// `documentBaseURL` is the directory of the running document (used to
+    /// resolve `@file`); `nil` if the document isn't backed by a file (yet),
+    /// in which case any `@file` errors out with `.fileNotFound`.
+    static func flatten(
+        _ units: [CommandUnit],
+        documentBaseURL: URL?,
+        resolver: any ScriptFileResolver = DefaultScriptFileResolver(),
+        maxDepth: Int = 16
+    ) throws -> [CommandUnit] {
+        var visited: Set<URL> = []
+        return try flatten(
+            units: units,
+            currentFileURL: nil,
+            documentBaseURL: documentBaseURL,
+            resolver: resolver,
+            visited: &visited,
+            depth: 0,
+            maxDepth: maxDepth
+        )
+    }
+
+    private static func flatten(
+        units: [CommandUnit],
+        currentFileURL: URL?,
+        documentBaseURL: URL?,
+        resolver: any ScriptFileResolver,
+        visited: inout Set<URL>,
+        depth: Int,
+        maxDepth: Int
+    ) throws -> [CommandUnit] {
+        if depth > maxDepth {
+            throw ScriptLoaderError.maxDepthExceeded(limit: maxDepth)
+        }
+
+        var output: [CommandUnit] = []
+        for unit in units {
+            switch unit.kind {
+            case .sqlplus(.include(let rawPath, let doubleAt)):
+                let resolvedURL = try resolveURL(
+                    rawPath: rawPath,
+                    doubleAt: doubleAt,
+                    currentFileURL: currentFileURL,
+                    documentBaseURL: documentBaseURL,
+                    resolver: resolver
+                )
+                if visited.contains(resolvedURL) {
+                    throw ScriptLoaderError.cycleDetected(path: resolvedURL)
+                }
+                let body: String
+                do {
+                    body = try resolver.read(resolvedURL)
+                } catch {
+                    throw ScriptLoaderError.readFailed(path: resolvedURL, underlying: error.localizedDescription)
+                }
+                visited.insert(resolvedURL)
+                let nestedUnits = ScriptLexer.split(body).units
+                let expanded = try flatten(
+                    units: nestedUnits,
+                    currentFileURL: resolvedURL,
+                    documentBaseURL: documentBaseURL,
+                    resolver: resolver,
+                    visited: &visited,
+                    depth: depth + 1,
+                    maxDepth: maxDepth
+                )
+                output.append(contentsOf: expanded)
+                visited.remove(resolvedURL)
+
+            default:
+                output.append(unit)
+            }
+        }
+        return output
+    }
+
+    /// Public for test ergonomics; computes the URL that an include would
+    /// resolve to without performing any I/O beyond `resolver.exists(_:)`.
+    static func resolveURL(
+        rawPath: String,
+        doubleAt: Bool,
+        currentFileURL: URL?,
+        documentBaseURL: URL?,
+        resolver: any ScriptFileResolver
+    ) throws -> URL {
+        // Absolute paths bypass any base anchor.
+        if rawPath.hasPrefix("/") {
+            let url = URL(fileURLWithPath: rawPath)
+            let withExt = ensureSqlExtension(url, resolver: resolver)
+            guard resolver.exists(withExt) else {
+                throw ScriptLoaderError.fileNotFound(path: rawPath, resolvedURL: withExt)
+            }
+            return withExt
+        }
+
+        let baseURL: URL
+        if doubleAt, let current = currentFileURL {
+            baseURL = current.deletingLastPathComponent()
+        } else if let base = documentBaseURL {
+            baseURL = base
+        } else {
+            let url = URL(fileURLWithPath: rawPath)
+            throw ScriptLoaderError.fileNotFound(path: rawPath, resolvedURL: url)
+        }
+
+        let candidate = baseURL.appendingPathComponent(rawPath).standardizedFileURL
+        let withExt = ensureSqlExtension(candidate, resolver: resolver)
+        guard resolver.exists(withExt) else {
+            throw ScriptLoaderError.fileNotFound(path: rawPath, resolvedURL: withExt)
+        }
+        return withExt
+    }
+
+    private static func ensureSqlExtension(_ url: URL, resolver: any ScriptFileResolver) -> URL {
+        if resolver.exists(url) { return url }
+        guard url.pathExtension.isEmpty else { return url }
+        return url.appendingPathExtension("sql")
+    }
+}

--- a/Macintora/Script/SqlPlusDirective.swift
+++ b/Macintora/Script/SqlPlusDirective.swift
@@ -1,0 +1,71 @@
+//
+//  SqlPlusDirective.swift
+//  Macintora
+//
+//  Typed AST for the SQL*Plus directive subset supported by the script runner.
+//  Phase 0 only parses these from text; Phase 6 attaches semantics in
+//  SqlPlusInterpreter.
+//
+
+import Foundation
+
+enum SqlPlusDirective: Equatable, Sendable {
+    case set(SetSetting)
+    case define(name: String, value: String)
+    case undefine(name: String)
+    case prompt(message: String)
+    case remark(text: String)
+    case showErrors
+    case whenever(WheneverCondition, WheneverAction)
+    case include(path: String, doubleAt: Bool)
+    case unrecognized(text: String)
+}
+
+enum SetSetting: Equatable, Sendable {
+    case serverOutput(Bool)
+    case echo(Bool)
+    case feedback(FeedbackMode)
+    case define(DefineMode)
+    case other(name: String, raw: String)
+}
+
+enum FeedbackMode: Equatable, Sendable {
+    case on
+    case off
+    case rows(Int)
+}
+
+enum DefineMode: Equatable, Sendable {
+    case on
+    case off
+    case prefix(Character)
+}
+
+enum WheneverCondition: Equatable, Sendable {
+    case sqlError
+    case osError
+}
+
+enum WheneverAction: Equatable, Sendable {
+    case `continue`(ContinueAction)
+    case exit(ExitCode, commitOrRollback: CommitAction?)
+}
+
+enum ContinueAction: Equatable, Sendable {
+    case commit
+    case rollback
+    case noAction
+}
+
+enum CommitAction: Equatable, Sendable {
+    case commit
+    case rollback
+}
+
+enum ExitCode: Equatable, Sendable {
+    case success
+    case failure
+    case warning
+    case sqlCode
+    case value(Int)
+}

--- a/Macintora/Script/SqlPlusEnvironment.swift
+++ b/Macintora/Script/SqlPlusEnvironment.swift
@@ -11,8 +11,12 @@
 
 import Foundation
 
-@MainActor
-final class SqlPlusEnvironment {
+/// Owned by `ScriptRunner` for the duration of a run; mutation happens
+/// exclusively on the runner's actor. The `@unchecked Sendable` conformance
+/// is sound because the runner is the single writer and reads from the bridge
+/// happen *after* `scriptFinished` is yielded (i.e. once the run loop has
+/// released the env).
+final class SqlPlusEnvironment: @unchecked Sendable {
     /// Currently-defined substitution variables (uppercased keys).
     var defines: [String: String] = [:]
 

--- a/Macintora/Script/SqlPlusEnvironment.swift
+++ b/Macintora/Script/SqlPlusEnvironment.swift
@@ -1,0 +1,72 @@
+//
+//  SqlPlusEnvironment.swift
+//  Macintora
+//
+//  Mutable session-state container threaded through script execution. Owns
+//  the defines table, output toggles, and the WHENEVER SQLERROR action.
+//  Mutated by `SqlPlusInterpreter` as the runner processes directives;
+//  consumed by the runner when resolving `&` references in subsequent
+//  units.
+//
+
+import Foundation
+
+@MainActor
+final class SqlPlusEnvironment {
+    /// Currently-defined substitution variables (uppercased keys).
+    var defines: [String: String] = [:]
+
+    /// `SET SERVEROUTPUT ON|OFF` — drives the executor's DBMS_OUTPUT drain.
+    var serverOutput: Bool = true
+
+    /// `SET ECHO ON|OFF` — currently informational; Phase 7 may surface in
+    /// the output entry presentation.
+    var echo: Bool = false
+
+    /// `SET FEEDBACK …` — informational; v1 doesn't suppress the rowcount
+    /// summary based on this.
+    var feedback: FeedbackMode = .on
+
+    /// `SET DEFINE ON|OFF|<char>` — when off, `&` substitution is skipped.
+    var defineEnabled: Bool = true
+
+    /// `SET DEFINE <char>` — alternate substitution prefix. v1 only honors
+    /// the on/off flag; switching the prefix is recognised but not yet
+    /// applied during scanning.
+    var definePrefix: Character = "&"
+
+    /// `WHENEVER SQLERROR …` — read by the runner after each failed unit.
+    var whenever: WheneverAction = .continue(.noAction)
+
+    /// Names registered as `&&` somewhere in this run. Persisted into the
+    /// document's session defines so the user isn't re-prompted.
+    var stickyNames: Set<String> = []
+
+    init() {}
+
+    /// Snapshot for tests that need to assert state without holding a
+    /// reference to the live env.
+    func snapshot() -> Snapshot {
+        Snapshot(
+            defines: defines,
+            serverOutput: serverOutput,
+            echo: echo,
+            feedback: feedback,
+            defineEnabled: defineEnabled,
+            definePrefix: definePrefix,
+            whenever: whenever,
+            stickyNames: stickyNames
+        )
+    }
+
+    struct Snapshot: Equatable, Sendable {
+        let defines: [String: String]
+        let serverOutput: Bool
+        let echo: Bool
+        let feedback: FeedbackMode
+        let defineEnabled: Bool
+        let definePrefix: Character
+        let whenever: WheneverAction
+        let stickyNames: Set<String>
+    }
+}

--- a/Macintora/Script/SqlPlusInterpreter.swift
+++ b/Macintora/Script/SqlPlusInterpreter.swift
@@ -1,0 +1,93 @@
+//
+//  SqlPlusInterpreter.swift
+//  Macintora
+//
+//  Pure mapping `Directive → side effect on SqlPlusEnvironment`. Returns a
+//  `DirectiveOutcome` so the runner can decide what to surface in the
+//  Script Output pane.
+//
+
+import Foundation
+
+enum DirectiveOutcome: Equatable, Sendable {
+    /// Directive was applied silently — emit a `directive` entry in output.
+    case acknowledged
+    /// `PROMPT msg` — emit a `prompt` entry with the given text.
+    case prompt(message: String)
+    /// `REM …` — silently skip; no output entry.
+    case skip
+    /// `SHOW ERRORS` — controller dispatches an Oracle query and emits the
+    /// resulting compile errors as a structured entry. v1 falls back to a
+    /// note when SHOW ERRORS is encountered without a prior CREATE.
+    case showErrors
+    /// `@file` / `@@file` — flattening should have consumed these. Reaching
+    /// the runner means an unresolved include — surface as a warning note.
+    case unresolvedInclude(path: String, doubleAt: Bool)
+    /// Directive was unrecognised; pass through with raw text.
+    case noted(text: String)
+}
+
+@MainActor
+enum SqlPlusInterpreter {
+    /// Apply `directive` to `env`. Returns the outcome the runner should
+    /// reflect in its output stream.
+    static func apply(_ directive: SqlPlusDirective, env: SqlPlusEnvironment) -> DirectiveOutcome {
+        switch directive {
+        case .set(let setting):
+            applySet(setting, env: env)
+            return .acknowledged
+
+        case .define(let name, let value):
+            env.defines[name.uppercased()] = value
+            return .acknowledged
+
+        case .undefine(let name):
+            env.defines.removeValue(forKey: name.uppercased())
+            return .acknowledged
+
+        case .prompt(let message):
+            return .prompt(message: message)
+
+        case .remark:
+            return .skip
+
+        case .showErrors:
+            return .showErrors
+
+        case .whenever(_, let action):
+            env.whenever = action
+            return .acknowledged
+
+        case .include(let path, let doubleAt):
+            return .unresolvedInclude(path: path, doubleAt: doubleAt)
+
+        case .unrecognized(let text):
+            return .noted(text: text)
+        }
+    }
+
+    private static func applySet(_ setting: SetSetting, env: SqlPlusEnvironment) {
+        switch setting {
+        case .serverOutput(let on):
+            env.serverOutput = on
+        case .echo(let on):
+            env.echo = on
+        case .feedback(let mode):
+            env.feedback = mode
+        case .define(let mode):
+            switch mode {
+            case .on:
+                env.defineEnabled = true
+            case .off:
+                env.defineEnabled = false
+            case .prefix(let c):
+                env.defineEnabled = true
+                env.definePrefix = c
+            }
+        case .other:
+            // Silently ignore unknown SET options; users get a feel for which
+            // ones we honor without each one becoming an error.
+            break
+        }
+    }
+}

--- a/Macintora/Script/SqlPlusInterpreter.swift
+++ b/Macintora/Script/SqlPlusInterpreter.swift
@@ -27,7 +27,6 @@ enum DirectiveOutcome: Equatable, Sendable {
     case noted(text: String)
 }
 
-@MainActor
 enum SqlPlusInterpreter {
     /// Apply `directive` to `env`. Returns the outcome the runner should
     /// reflect in its output stream.

--- a/Macintora/Script/SubstitutionResolver.swift
+++ b/Macintora/Script/SubstitutionResolver.swift
@@ -1,0 +1,172 @@
+//
+//  SubstitutionResolver.swift
+//  Macintora
+//
+//  Resolves SQL*Plus substitution variables (`&name` and `&&name`) in a
+//  string. Pure logic — no UI, no side effects. Phase 5 wires the results
+//  through the runner; Phase 6 handles the dynamic SET DEFINE toggle.
+//
+//  Substitution rules implemented:
+//    - `&NAME` and `&&NAME` (case-insensitive; folded to uppercase in
+//      `defines` lookup and reported names).
+//    - Optional terminating `.` is consumed: `&owner..t` resolves to
+//      `<value>.t`.
+//    - Numeric positional refs (`&1`, `&2`) are recognised but treated as
+//      ordinary names — they only resolve if `defines["1"]` is provided.
+//    - Substitution applies anywhere in the source, including inside string
+//      literals (matching SQL*Plus default behaviour). When SET DEFINE OFF
+//      is in effect, the caller passes an empty `defines` map *and* skips
+//      `resolve` altogether — the resolver itself does not read directives.
+//
+
+import Foundation
+
+struct SubstitutionScan: Equatable {
+    /// All distinct names referenced (uppercased).
+    let names: Set<String>
+    /// Subset that uses `&&` — caller persists their resolved values for the
+    /// rest of the session.
+    let stickyNames: Set<String>
+}
+
+struct SubstitutionResult: Equatable {
+    let text: String
+    let mapping: OffsetMap
+    /// Names that had no entry in `defines`. The reference is left verbatim
+    /// in `text` so the caller can prompt and re-resolve.
+    let missing: Set<String>
+}
+
+enum SubstitutionResolver {
+
+    /// Find all `&` / `&&` references in `text`. Used by the consolidated
+    /// up-front prompt to gather every variable in a script before execution
+    /// starts.
+    static func scan(_ text: String) -> SubstitutionScan {
+        var names: Set<String> = []
+        var sticky: Set<String> = []
+        var i = text.startIndex
+        while i < text.endIndex {
+            if text[i] == "&" {
+                if let ref = readReference(in: text, at: i) {
+                    names.insert(ref.name)
+                    if ref.isSticky { sticky.insert(ref.name) }
+                    i = ref.endIndex
+                    continue
+                }
+            }
+            i = text.index(after: i)
+        }
+        return SubstitutionScan(names: names, stickyNames: sticky)
+    }
+
+    /// Replace `&name` / `&&name` with values from `defines`. Unknown names
+    /// are left verbatim and recorded in `missing`.
+    static func resolve(_ text: String, defines: [String: String]) -> SubstitutionResult {
+        var out = ""
+        var segments: [OffsetMap.Segment] = []
+        var missing: Set<String> = []
+
+        var i = text.startIndex
+        var passStart = text.startIndex
+        var resolvedOffset = 0
+        var originalOffset = 0
+
+        func flushPassthrough(upTo end: String.Index) {
+            guard passStart < end else { return }
+            let chunk = String(text[passStart..<end])
+            let len = chunk.utf16.count
+            segments.append(.init(
+                kind: .passthrough,
+                resolvedRange: resolvedOffset..<(resolvedOffset + len),
+                originalRange: originalOffset..<(originalOffset + len)
+            ))
+            out.append(chunk)
+            resolvedOffset += len
+            originalOffset += len
+            passStart = end
+        }
+
+        while i < text.endIndex {
+            if text[i] == "&", let ref = readReference(in: text, at: i) {
+                flushPassthrough(upTo: i)
+                let originalLen = String(text[i..<ref.endIndex]).utf16.count
+
+                if let value = defines[ref.name] {
+                    let valueLen = value.utf16.count
+                    segments.append(.init(
+                        kind: .substitution,
+                        resolvedRange: resolvedOffset..<(resolvedOffset + valueLen),
+                        originalRange: originalOffset..<(originalOffset + originalLen)
+                    ))
+                    out.append(value)
+                    resolvedOffset += valueLen
+                } else {
+                    missing.insert(ref.name)
+                    let chunk = String(text[i..<ref.endIndex])
+                    segments.append(.init(
+                        kind: .passthrough,
+                        resolvedRange: resolvedOffset..<(resolvedOffset + originalLen),
+                        originalRange: originalOffset..<(originalOffset + originalLen)
+                    ))
+                    out.append(chunk)
+                    resolvedOffset += originalLen
+                }
+
+                originalOffset += originalLen
+                i = ref.endIndex
+                passStart = ref.endIndex
+                continue
+            }
+            i = text.index(after: i)
+        }
+        flushPassthrough(upTo: text.endIndex)
+
+        let mapping = OffsetMap(
+            segments: segments.isEmpty
+                ? [.init(kind: .passthrough, resolvedRange: 0..<0, originalRange: 0..<0)]
+                : segments,
+            originalLength: text.utf16.count,
+            resolvedLength: out.utf16.count
+        )
+        return SubstitutionResult(text: out, mapping: mapping, missing: missing)
+    }
+}
+
+// MARK: - Reference detection
+
+private struct Reference {
+    let name: String       // uppercased
+    let isSticky: Bool     // &&
+    let endIndex: String.Index   // one past the consumed reference (incl. optional trailing `.`)
+}
+
+private func readReference(in text: String, at start: String.Index) -> Reference? {
+    // Caller ensured text[start] == "&".
+    let next = text.index(after: start)
+    guard next < text.endIndex else { return nil }
+
+    let isSticky = text[next] == "&"
+    let nameStart = isSticky ? text.index(after: next) : next
+    guard nameStart < text.endIndex,
+          isSubstitutionNameStart(text[nameStart]) else { return nil }
+
+    var nameEnd = nameStart
+    while nameEnd < text.endIndex && isSubstitutionNameChar(text[nameEnd]) {
+        nameEnd = text.index(after: nameEnd)
+    }
+    var refEnd = nameEnd
+    if refEnd < text.endIndex && text[refEnd] == "." {
+        refEnd = text.index(after: refEnd)
+    }
+    let name = String(text[nameStart..<nameEnd]).uppercased()
+    return Reference(name: name, isSticky: isSticky, endIndex: refEnd)
+}
+
+private func isSubstitutionNameStart(_ c: Character) -> Bool {
+    c.isLetter || c == "_" || c.isNumber
+}
+
+private func isSubstitutionNameChar(_ c: Character) -> Bool {
+    c.isLetter || c.isNumber || c == "_"
+}

--- a/MacintoraTests/FullRefreshReproTests.swift
+++ b/MacintoraTests/FullRefreshReproTests.swift
@@ -21,7 +21,7 @@ final class FullRefreshReproTests: XCTestCase {
             throw XCTSkip("Saved password for c4-local not available in keychain")
         }
 
-        var details = ConnectionDetails(
+        let details = ConnectionDetails(
             savedConnectionID: saved.id,
             username: saved.defaultUsername,
             password: pwd,

--- a/MacintoraTests/KeychainServiceTests.swift
+++ b/MacintoraTests/KeychainServiceTests.swift
@@ -15,58 +15,97 @@ final class KeychainServiceTests: XCTestCase {
     }
 
     override func tearDown() {
-        keychain.deleteAll(for: connID)
+        let kc = keychain!
+        let id = connID!
+        // Avoid the macOS "should not be called on the main thread" runtime
+        // warning by hopping off-main for the teardown's keychain access.
+        Task.detached { kc.deleteAll(for: id) }
         super.tearDown()
     }
 
-    func test_setAndReadDatabasePassword() throws {
-        try keychain.setPassword("hunter2", for: connID, kind: .databasePassword)
-        XCTAssertEqual(try keychain.password(for: connID, kind: .databasePassword), "hunter2")
+    /// Hop off the main actor — the underlying `SecItem*` APIs warn when
+    /// invoked on the main thread.
+    private func offMain<T: Sendable>(_ work: @Sendable @escaping () throws -> T) async throws -> T {
+        try await Task.detached(priority: .userInitiated) {
+            try work()
+        }.value
     }
 
-    func test_overwriteExisting() throws {
-        try keychain.setPassword("first", for: connID, kind: .databasePassword)
-        try keychain.setPassword("second", for: connID, kind: .databasePassword)
-        XCTAssertEqual(try keychain.password(for: connID, kind: .databasePassword), "second")
+    func test_setAndReadDatabasePassword() async throws {
+        let kc = keychain!
+        let id = connID!
+        try await offMain { try kc.setPassword("hunter2", for: id, kind: .databasePassword) }
+        let pw = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        XCTAssertEqual(pw, "hunter2")
     }
 
-    func test_separateKindsAreIndependent() throws {
-        try keychain.setPassword("dbpw", for: connID, kind: .databasePassword)
-        try keychain.setPassword("walletpw", for: connID, kind: .walletPassword)
-        XCTAssertEqual(try keychain.password(for: connID, kind: .databasePassword), "dbpw")
-        XCTAssertEqual(try keychain.password(for: connID, kind: .walletPassword), "walletpw")
+    func test_overwriteExisting() async throws {
+        let kc = keychain!
+        let id = connID!
+        try await offMain { try kc.setPassword("first", for: id, kind: .databasePassword) }
+        try await offMain { try kc.setPassword("second", for: id, kind: .databasePassword) }
+        let pw = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        XCTAssertEqual(pw, "second")
     }
 
-    func test_separateConnectionIDsAreIndependent() throws {
+    func test_separateKindsAreIndependent() async throws {
+        let kc = keychain!
+        let id = connID!
+        try await offMain { try kc.setPassword("dbpw", for: id, kind: .databasePassword) }
+        try await offMain { try kc.setPassword("walletpw", for: id, kind: .walletPassword) }
+        let dbPw = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        let walletPw = try await offMain { try kc.password(for: id, kind: .walletPassword) }
+        XCTAssertEqual(dbPw, "dbpw")
+        XCTAssertEqual(walletPw, "walletpw")
+    }
+
+    func test_separateConnectionIDsAreIndependent() async throws {
+        let kc = keychain!
+        let id = connID!
         let other = UUID()
-        defer { keychain.deleteAll(for: other) }
-        try keychain.setPassword("a", for: connID, kind: .databasePassword)
-        try keychain.setPassword("b", for: other, kind: .databasePassword)
-        XCTAssertEqual(try keychain.password(for: connID, kind: .databasePassword), "a")
-        XCTAssertEqual(try keychain.password(for: other, kind: .databasePassword), "b")
+        defer { Task.detached { kc.deleteAll(for: other) } }
+        try await offMain { try kc.setPassword("a", for: id, kind: .databasePassword) }
+        try await offMain { try kc.setPassword("b", for: other, kind: .databasePassword) }
+        let a = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        let b = try await offMain { try kc.password(for: other, kind: .databasePassword) }
+        XCTAssertEqual(a, "a")
+        XCTAssertEqual(b, "b")
     }
 
-    func test_readMissingReturnsNil() throws {
-        XCTAssertNil(try keychain.password(for: connID, kind: .databasePassword))
+    func test_readMissingReturnsNil() async throws {
+        let kc = keychain!
+        let id = connID!
+        let pw = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        XCTAssertNil(pw)
     }
 
-    func test_deleteRemovesItem() throws {
-        try keychain.setPassword("temp", for: connID, kind: .databasePassword)
-        try keychain.deletePassword(for: connID, kind: .databasePassword)
-        XCTAssertNil(try keychain.password(for: connID, kind: .databasePassword))
+    func test_deleteRemovesItem() async throws {
+        let kc = keychain!
+        let id = connID!
+        try await offMain { try kc.setPassword("temp", for: id, kind: .databasePassword) }
+        try await offMain { try kc.deletePassword(for: id, kind: .databasePassword) }
+        let pw = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        XCTAssertNil(pw)
     }
 
-    func test_setEmptyDeletes() throws {
-        try keychain.setPassword("temp", for: connID, kind: .databasePassword)
-        try keychain.setPassword("", for: connID, kind: .databasePassword)
-        XCTAssertNil(try keychain.password(for: connID, kind: .databasePassword))
+    func test_setEmptyDeletes() async throws {
+        let kc = keychain!
+        let id = connID!
+        try await offMain { try kc.setPassword("temp", for: id, kind: .databasePassword) }
+        try await offMain { try kc.setPassword("", for: id, kind: .databasePassword) }
+        let pw = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        XCTAssertNil(pw)
     }
 
-    func test_deleteAllRemovesBothKinds() throws {
-        try keychain.setPassword("dbpw", for: connID, kind: .databasePassword)
-        try keychain.setPassword("walletpw", for: connID, kind: .walletPassword)
-        keychain.deleteAll(for: connID)
-        XCTAssertNil(try keychain.password(for: connID, kind: .databasePassword))
-        XCTAssertNil(try keychain.password(for: connID, kind: .walletPassword))
+    func test_deleteAllRemovesBothKinds() async throws {
+        let kc = keychain!
+        let id = connID!
+        try await offMain { try kc.setPassword("dbpw", for: id, kind: .databasePassword) }
+        try await offMain { try kc.setPassword("walletpw", for: id, kind: .walletPassword) }
+        try await offMain { kc.deleteAll(for: id) }
+        let dbPw = try await offMain { try kc.password(for: id, kind: .databasePassword) }
+        let walletPw = try await offMain { try kc.password(for: id, kind: .walletPassword) }
+        XCTAssertNil(dbPw)
+        XCTAssertNil(walletPw)
     }
 }

--- a/MacintoraTests/MainDocumentSaveTests.swift
+++ b/MacintoraTests/MainDocumentSaveTests.swift
@@ -40,7 +40,7 @@ final class MainDocumentSaveTests: XCTestCase {
     /// `Task.detached` mirrors what SwiftUI's file-coordination machinery does
     /// during save/autosave. It must not trap, regardless of actor isolation.
     func test_snapshotFromNonMainActor() async throws {
-        let doc = await MainDocumentVM(text: "off-main test")
+        let doc = MainDocumentVM(text: "off-main test")
 
         let snap = try await Task.detached(priority: .utility) {
             try doc.snapshot(contentType: .macora)
@@ -110,7 +110,7 @@ final class MainDocumentSaveTests: XCTestCase {
     /// Full round-trip: type into a new doc, save it to disk, reopen via the
     /// init-from-data path, verify contents survived.
     func test_newDocumentSaveReopenRoundTrip() async throws {
-        let doc = await MainDocumentVM(text: "starting content")
+        let doc = MainDocumentVM(text: "starting content")
         await MainActor.run {
             doc.model.text = "typed some more text"
             doc.mainConnection.mainConnDetails.username = "dana"

--- a/MacintoraTests/OracleEndpointTests.swift
+++ b/MacintoraTests/OracleEndpointTests.swift
@@ -59,12 +59,16 @@ final class OracleEndpointTests: XCTestCase {
         XCTAssertEqual(config.mode, .default)
     }
 
-    func test_configurationFallsBackToKeychainPassword() throws {
+    func test_configurationFallsBackToKeychainPassword() async throws {
         let keychain = uniqueKeychain()
         var conn = SavedConnection(name: "PROD", host: "h", service: .serviceName("p"))
         conn.savePasswordInKeychain = true
         store.upsert(conn)
-        try keychain.setPassword("from-keychain", for: conn.id, kind: .databasePassword)
+        // Hop off main — `SecItem*` warns when called on the main thread.
+        let connID = conn.id
+        try await Task.detached(priority: .userInitiated) {
+            try keychain.setPassword("from-keychain", for: connID, kind: .databasePassword)
+        }.value
 
         let details = ConnectionDetails(
             savedConnectionID: conn.id, username: "scott", password: "", tns: "PROD"
@@ -72,7 +76,7 @@ final class OracleEndpointTests: XCTestCase {
         // We can't read back the password from the configuration directly, but
         // we can confirm the call doesn't throw `.missingPassword`.
         XCTAssertNoThrow(try OracleEndpoint.configuration(for: details, store: store, keychain: keychain))
-        keychain.deleteAll(for: conn.id)
+        await Task.detached { keychain.deleteAll(for: connID) }.value
     }
 
     func test_configurationThrowsOnMissingPassword() {

--- a/MacintoraTests/Results/ResultViewModelIntegrationTests.swift
+++ b/MacintoraTests/Results/ResultViewModelIntegrationTests.swift
@@ -21,7 +21,7 @@ import XCTest
 @MainActor
 final class ResultViewModelIntegrationTests: XCTestCase {
 
-    private static let fixtureURL = URL(fileURLWithPath: "/Users/ilia/Documents/macintora/local.macintora")
+    nonisolated private static let fixtureURL = URL(fileURLWithPath: "/Users/ilia/Documents/macintora/local.macintora")
 
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/MacintoraTests/Results/ScriptOutputModelTests.swift
+++ b/MacintoraTests/Results/ScriptOutputModelTests.swift
@@ -1,0 +1,102 @@
+//
+//  ScriptOutputModelTests.swift
+//  MacintoraTests
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class ScriptOutputModelTests: XCTestCase {
+
+    func test_initial_state_is_empty_and_idle() {
+        let model = ScriptOutputModel()
+        XCTAssertTrue(model.entries.isEmpty)
+        XCTAssertFalse(model.isRunning)
+        XCTAssertNil(model.currentUnitIndex)
+        XCTAssertEqual(model.totalUnits, 0)
+    }
+
+    func test_beginRun_clears_and_sets_running() {
+        let model = ScriptOutputModel()
+        model.append(.note(.init(id: UUID(), kind: .info, text: "leftover")))
+        model.beginRun(totalUnits: 3)
+        XCTAssertTrue(model.entries.isEmpty)
+        XCTAssertTrue(model.isRunning)
+        XCTAssertEqual(model.totalUnits, 3)
+    }
+
+    func test_finishRun_clears_running_state() {
+        let model = ScriptOutputModel()
+        model.beginRun(totalUnits: 1)
+        model.setCurrentUnit(0)
+        model.finishRun()
+        XCTAssertFalse(model.isRunning)
+        XCTAssertNil(model.currentUnitIndex)
+    }
+
+    func test_append_preserves_ordering() {
+        let model = ScriptOutputModel()
+        let a = ScriptOutputEntry.directive(.init(id: UUID(), text: "SET SERVEROUTPUT ON", elapsed: .zero))
+        let b = ScriptOutputEntry.succeeded(.init(
+            id: UUID(),
+            unitIndex: 0,
+            text: "select 1 from dual",
+            kind: .sql,
+            elapsed: .milliseconds(2),
+            rowCount: 1,
+            dbmsOutput: [],
+            preview: nil
+        ))
+        let c = ScriptOutputEntry.failed(.init(
+            id: UUID(),
+            unitIndex: 1,
+            text: "select * from nope",
+            kind: .sql,
+            elapsed: .milliseconds(3),
+            message: "ORA-00942",
+            oracleErrorCode: 942,
+            originalUTF16Range: nil
+        ))
+        model.append(a)
+        model.append(b)
+        model.append(c)
+        XCTAssertEqual(model.entries.map(\.id), [a.id, b.id, c.id])
+    }
+
+    func test_note_helper_appends_note_entry() {
+        let model = ScriptOutputModel()
+        model.note(.cancelled, text: "User stopped the run.")
+        XCTAssertEqual(model.entries.count, 1)
+        if case .note(let note) = model.entries[0] {
+            XCTAssertEqual(note.kind, .cancelled)
+            XCTAssertEqual(note.text, "User stopped the run.")
+        } else {
+            XCTFail("expected note entry")
+        }
+    }
+
+    func test_unitKind_initializer_drops_directive_payload() {
+        XCTAssertEqual(UnitKind(.sql), .sql)
+        XCTAssertEqual(UnitKind(.plsqlBlock), .plsqlBlock)
+        XCTAssertEqual(UnitKind(.sqlplus(.showErrors)), .sqlplus)
+        XCTAssertEqual(UnitKind(.sqlplus(.set(.serverOutput(true)))), .sqlplus)
+    }
+
+    func test_clear_resets_state() {
+        let model = ScriptOutputModel()
+        model.beginRun(totalUnits: 5)
+        model.setCurrentUnit(2)
+        model.note(.info, text: "x")
+        model.clear()
+        XCTAssertTrue(model.entries.isEmpty)
+        XCTAssertEqual(model.totalUnits, 0)
+        XCTAssertNil(model.currentUnitIndex)
+    }
+}
+
+extension ScriptOutputEntry {
+    static func == (lhs: ScriptOutputEntry, rhs: ScriptOutputEntry) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/MacintoraTests/Results/ScriptRunnerDirectivesLiveTests.swift
+++ b/MacintoraTests/Results/ScriptRunnerDirectivesLiveTests.swift
@@ -1,0 +1,157 @@
+//
+//  ScriptRunnerDirectivesLiveTests.swift
+//  MacintoraTests
+//
+//  c4-local integration coverage of Phase 6 directives:
+//    - SET SERVEROUTPUT ON/OFF actually toggles DBMS_OUTPUT capture.
+//    - WHENEVER SQLERROR EXIT halts the script on the first failing unit.
+//    - DEFINE / & substitution flows through to the resolved SQL.
+//
+
+import XCTest
+import OracleNIO
+import Logging
+@testable import Macintora
+
+@MainActor
+final class ScriptRunnerDirectivesLiveTests: XCTestCase {
+
+    func test_set_serveroutput_off_suppresses_dbmsOutput() async throws {
+        let conn = try await openLiveConnection()
+        defer { Task { try? await conn.close() } }
+
+        // Drive the executor directly with `dbmsOutputEnabled: false`, mimicking
+        // what `ResultsController.startScriptExecution` does when the env's
+        // final `serverOutput` is `false`.
+        let script = """
+        BEGIN
+          DBMS_OUTPUT.PUT_LINE('quiet');
+        END;
+        /
+        """
+        let units = ScriptLexer.split(script).units
+        let executor = OracleScriptExecutor(
+            conn: conn,
+            logger: Logging.Logger(label: "macintora.tests.directives"),
+            dbmsOutputEnabled: false
+        )
+        let runner = ScriptRunner(units: units, executor: executor)
+
+        var dbmsLines: [String] = []
+        for await event in runner.start() {
+            if case .unitFinished(_, let r) = event,
+               case .statementSucceeded(_, let lines, _) = r.outcome {
+                dbmsLines.append(contentsOf: lines)
+            }
+        }
+        XCTAssertTrue(dbmsLines.isEmpty, "expected no DBMS_OUTPUT when serveroutput off; got \(dbmsLines)")
+    }
+
+    func test_whenever_sqlerror_exit_halts_on_failure() async throws {
+        let conn = try await openLiveConnection()
+        defer { Task { try? await conn.close() } }
+
+        let script = """
+        SELECT 1 FROM dual;
+        SELECT * FROM macintora_no_such_table;
+        SELECT 2 FROM dual;
+        """
+        let units = ScriptLexer.split(script).units
+        let executor = OracleScriptExecutor(
+            conn: conn,
+            logger: Logging.Logger(label: "macintora.tests.directives")
+        )
+        // Mirrors `ResultsController` setting `stopOnError: true` when env's
+        // whenever is `.exit(...)`.
+        let runner = ScriptRunner(units: units, executor: executor, options: .init(stopOnError: true))
+
+        var observed: [(Int, UnitResult.Outcome)] = []
+        for await event in runner.start() {
+            if case .unitFinished(let i, let r) = event {
+                observed.append((i, r.outcome))
+            }
+        }
+        XCTAssertEqual(observed.count, 2, "WHENEVER EXIT should halt after the failing unit; saw \(observed.count) outcomes")
+        if case .statementSucceeded = observed.first?.1 {} else {
+            XCTFail("first unit should have succeeded")
+        }
+        if case .statementFailed = observed.last?.1 {} else {
+            XCTFail("second unit should have failed")
+        }
+    }
+
+    func test_define_substitutes_into_subsequent_select() async throws {
+        let conn = try await openLiveConnection()
+        defer { Task { try? await conn.close() } }
+
+        // Mirror `ResultsController`'s pre-walk: apply the DEFINE via the
+        // interpreter, substitute the SELECT, then run.
+        let env = SqlPlusEnvironment()
+        let units = ScriptLexer.split("""
+        DEFINE thing = USER
+        SELECT &thing AS who FROM dual;
+        """).units
+
+        var preparedUnits: [CommandUnit] = []
+        for unit in units {
+            switch unit.kind {
+            case .sqlplus(let directive):
+                _ = SqlPlusInterpreter.apply(directive, env: env)
+                preparedUnits.append(unit)
+            case .sql, .plsqlBlock:
+                let resolved = SubstitutionResolver.resolve(unit.text, defines: env.defines).text
+                preparedUnits.append(CommandUnit(kind: unit.kind, originalRange: unit.originalRange, text: resolved))
+            }
+        }
+
+        let executor = OracleScriptExecutor(
+            conn: conn,
+            logger: Logging.Logger(label: "macintora.tests.directives")
+        )
+        let runner = ScriptRunner(units: preparedUnits, executor: executor, options: .init(stopOnError: false))
+
+        var rows: [[String]] = []
+        for await event in runner.start() {
+            if case .unitFinished(_, let r) = event,
+               case .statementSucceeded(_, _, let preview) = r.outcome,
+               let preview {
+                rows.append(contentsOf: preview.rows)
+            }
+        }
+        XCTAssertEqual(rows.count, 1, "expected one row from substituted SELECT")
+    }
+
+    // MARK: - Connection helper
+
+    private func openLiveConnection() async throws -> OracleConnection {
+        let store = ConnectionStore()
+        guard let saved = store.connection(named: "c4-local") else {
+            throw XCTSkip("c4-local not present in connections.json")
+        }
+        let appBundleID = "com.iliasazonov.macintora"
+        let keychain = KeychainService(service: appBundleID)
+        guard
+            saved.savePasswordInKeychain,
+            let pwd = try? keychain.password(for: saved.id, kind: .databasePassword),
+            !pwd.isEmpty
+        else {
+            throw XCTSkip("Saved password for c4-local not available in keychain")
+        }
+        let details = ConnectionDetails(
+            savedConnectionID: saved.id,
+            username: saved.defaultUsername,
+            password: pwd,
+            tns: saved.name,
+            connectionRole: .regular
+        )
+        let cfg = try OracleEndpoint.configuration(for: details, store: store, keychain: keychain)
+        var logger = Logging.Logger(label: "macintora.tests.directives.conn")
+        logger.logLevel = .notice
+        return try await OracleConnection.connect(
+            on: OracleEventLoopGroup.shared.next(),
+            configuration: cfg,
+            id: Int.random(in: 1...Int.max),
+            logger: logger
+        )
+    }
+}

--- a/MacintoraTests/Results/ScriptRunnerDirectivesLiveTests.swift
+++ b/MacintoraTests/Results/ScriptRunnerDirectivesLiveTests.swift
@@ -35,7 +35,7 @@ final class ScriptRunnerDirectivesLiveTests: XCTestCase {
             logger: Logging.Logger(label: "macintora.tests.directives"),
             dbmsOutputEnabled: false
         )
-        let runner = ScriptRunner(units: units, executor: executor)
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
 
         var dbmsLines: [String] = []
         for await event in runner.start() {
@@ -61,9 +61,10 @@ final class ScriptRunnerDirectivesLiveTests: XCTestCase {
             conn: conn,
             logger: Logging.Logger(label: "macintora.tests.directives")
         )
-        // Mirrors `ResultsController` setting `stopOnError: true` when env's
-        // whenever is `.exit(...)`.
-        let runner = ScriptRunner(units: units, executor: executor, options: .init(stopOnError: true))
+        // The runner halts on error when env.whenever is `.exit(...)`.
+        let env = SqlPlusEnvironment()
+        env.whenever = .exit(.failure, commitOrRollback: nil)
+        let runner = ScriptRunner(units: units, executor: executor, env: env)
 
         var observed: [(Int, UnitResult.Outcome)] = []
         for await event in runner.start() {
@@ -84,31 +85,18 @@ final class ScriptRunnerDirectivesLiveTests: XCTestCase {
         let conn = try await openLiveConnection()
         defer { Task { try? await conn.close() } }
 
-        // Mirror `ResultsController`'s pre-walk: apply the DEFINE via the
-        // interpreter, substitute the SELECT, then run.
-        let env = SqlPlusEnvironment()
+        // The runner applies DEFINE inline as it walks the units, so the
+        // subsequent SELECT picks up the value via SubstitutionResolver.
         let units = ScriptLexer.split("""
         DEFINE thing = USER
         SELECT &thing AS who FROM dual;
         """).units
 
-        var preparedUnits: [CommandUnit] = []
-        for unit in units {
-            switch unit.kind {
-            case .sqlplus(let directive):
-                _ = SqlPlusInterpreter.apply(directive, env: env)
-                preparedUnits.append(unit)
-            case .sql, .plsqlBlock:
-                let resolved = SubstitutionResolver.resolve(unit.text, defines: env.defines).text
-                preparedUnits.append(CommandUnit(kind: unit.kind, originalRange: unit.originalRange, text: resolved))
-            }
-        }
-
         let executor = OracleScriptExecutor(
             conn: conn,
             logger: Logging.Logger(label: "macintora.tests.directives")
         )
-        let runner = ScriptRunner(units: preparedUnits, executor: executor, options: .init(stopOnError: false))
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
 
         var rows: [[String]] = []
         for await event in runner.start() {

--- a/MacintoraTests/Results/ScriptRunnerDriverTests.swift
+++ b/MacintoraTests/Results/ScriptRunnerDriverTests.swift
@@ -1,0 +1,193 @@
+//
+//  ScriptRunnerDriverTests.swift
+//  MacintoraTests
+//
+//  Drives the runner with a scripted fake executor and asserts the event
+//  stream's order/content. Phase 4 will land a separate live integration
+//  test against a real `c4-local` connection.
+//
+
+import XCTest
+@testable import Macintora
+
+final class ScriptRunnerDriverTests: XCTestCase {
+
+    func test_single_unit_success_emits_started_finished_done() async {
+        let units = lex("select 1 from dual;")
+        XCTAssertEqual(units.count, 1)
+
+        let executor = FakeConnectionExecutor(responses: [
+            .success(UnitResult(
+                outcome: .statementSucceeded(rowCount: 1, dbmsOutput: [], preview: nil),
+                elapsed: .zero
+            ))
+        ])
+
+        let events = await collect(units: units, executor: executor)
+
+        XCTAssertEqual(events.count, 3)
+        guard case .unitStarted(0, 1, let u) = events[0] else { return XCTFail("expected unitStarted") }
+        XCTAssertEqual(u.text, "select 1 from dual")
+        guard case .unitFinished(0, let r) = events[1] else { return XCTFail("expected unitFinished") }
+        XCTAssertEqual(r.outcome, .statementSucceeded(rowCount: 1, dbmsOutput: [], preview: nil))
+        guard case .scriptFinished = events[2] else { return XCTFail("expected scriptFinished") }
+
+        let executions = await executor.observedExecutions()
+        XCTAssertEqual(executions.count, 1)
+        XCTAssertEqual(executions[0].resolvedText, "select 1 from dual")
+    }
+
+    func test_single_unit_failure_short_circuits_when_stopOnError() async {
+        let units = lex("select bad;\nselect 1 from dual;")
+        XCTAssertEqual(units.count, 2)
+
+        let executor = FakeConnectionExecutor(responses: [
+            .failure(NSError(domain: "ora", code: 942, userInfo: [NSLocalizedDescriptionKey: "ORA-00942: table or view does not exist"]))
+        ])
+
+        let events = await collect(units: units, executor: executor)
+
+        // 1: unitStarted(0), 2: unitFinished(0,failed), 3: scriptFinished
+        XCTAssertEqual(events.count, 3)
+        guard case .unitFinished(0, let r) = events[1] else { return XCTFail("expected unitFinished") }
+        if case .statementFailed(let msg, _) = r.outcome {
+            XCTAssertTrue(msg.contains("ORA-00942") || msg.contains("table or view"))
+        } else {
+            XCTFail("expected statementFailed")
+        }
+
+        let executions = await executor.observedExecutions()
+        XCTAssertEqual(executions.count, 1, "second unit should not have run")
+    }
+
+    func test_failure_continues_when_stopOnError_disabled() async {
+        let units = lex("select bad;\nselect 1 from dual;")
+        let executor = FakeConnectionExecutor(responses: [
+            .failure(NSError(domain: "ora", code: 942)),
+            .success(UnitResult(outcome: .statementSucceeded(rowCount: 1, dbmsOutput: [], preview: nil), elapsed: .zero))
+        ])
+
+        let runner = ScriptRunner(units: units, executor: executor, options: .init(stopOnError: false))
+        var collected: [ScriptRunnerEvent] = []
+        for await ev in runner.start() {
+            collected.append(ev)
+        }
+
+        // started(0), finished(0,fail), started(1), finished(1,success), done
+        XCTAssertEqual(collected.count, 5)
+        if case .unitFinished(_, let r) = collected[3] {
+            XCTAssertEqual(r.outcome, .statementSucceeded(rowCount: 1, dbmsOutput: [], preview: nil))
+        } else {
+            XCTFail("expected unitFinished for second unit")
+        }
+        let executions = await executor.observedExecutions()
+        XCTAssertEqual(executions.count, 2)
+    }
+
+    func test_cancellation_emits_cancelled_event() async {
+        let units = lex("""
+            select 1 from dual;
+            select 2 from dual;
+            select 3 from dual;
+            """)
+        let executor = FakeConnectionExecutor(responses: [
+            .success(UnitResult(outcome: .statementSucceeded(rowCount: 1, dbmsOutput: [], preview: nil), elapsed: .zero)),
+            .delayedSuccess(forever: true)
+        ])
+
+        let runner = ScriptRunner(units: units, executor: executor)
+        let stream = runner.start()
+        var collected: [ScriptRunnerEvent] = []
+
+        let consumer = Task {
+            for await ev in stream {
+                collected.append(ev)
+                if case .unitFinished(0, _) = ev {
+                    Task { await runner.cancel() }
+                }
+            }
+            return collected
+        }
+
+        let final = await consumer.value
+        // started(0) + finished(0) + started(1) + cancelled — order may interleave
+        // but the last emitted event before stream end must be `cancelled`.
+        XCTAssertTrue(final.contains(where: { if case .cancelled = $0 { return true }; return false }),
+                      "expected a cancelled event, got: \(final)")
+        // No scriptFinished after cancellation.
+        XCTAssertFalse(final.contains(where: { if case .scriptFinished = $0 { return true }; return false }))
+    }
+
+    func test_dbms_output_passes_through_unmodified() async {
+        let units = lex("BEGIN DBMS_OUTPUT.PUT_LINE('hi'); END;\n/")
+        let executor = FakeConnectionExecutor(responses: [
+            .success(UnitResult(outcome: .statementSucceeded(rowCount: nil, dbmsOutput: ["hi"], preview: nil), elapsed: .zero))
+        ])
+
+        let events = await collect(units: units, executor: executor)
+        guard case .unitFinished(_, let r) = events[1] else { return XCTFail() }
+        XCTAssertEqual(r.outcome, .statementSucceeded(rowCount: nil, dbmsOutput: ["hi"], preview: nil))
+    }
+
+    // MARK: - Helpers
+
+    private func lex(_ source: String) -> [CommandUnit] {
+        ScriptLexer.split(source).units
+    }
+
+    private func collect(units: [CommandUnit], executor: any ConnectionExecutor) async -> [ScriptRunnerEvent] {
+        let runner = ScriptRunner(units: units, executor: executor)
+        var events: [ScriptRunnerEvent] = []
+        for await ev in runner.start() {
+            events.append(ev)
+        }
+        return events
+    }
+}
+
+// MARK: - Fake executor
+
+actor FakeConnectionExecutor: ConnectionExecutor {
+    enum Response: Sendable {
+        case success(UnitResult)
+        case failure(Error)
+        case delayedSuccess(forever: Bool)
+    }
+
+    private var responses: [Response]
+    private var executions: [PreparedUnit] = []
+    private var cancelled = false
+
+    init(responses: [Response]) {
+        self.responses = responses
+    }
+
+    func execute(_ prepared: PreparedUnit) async throws -> UnitResult {
+        executions.append(prepared)
+        guard !responses.isEmpty else {
+            return UnitResult(outcome: .statementSucceeded(rowCount: 0, dbmsOutput: [], preview: nil), elapsed: .zero)
+        }
+        let next = responses.removeFirst()
+        switch next {
+        case .success(let r):
+            return r
+        case .failure(let e):
+            throw e
+        case .delayedSuccess(let forever):
+            // Sleep until cancelled.
+            while !cancelled && !Task.isCancelled {
+                try await Task.sleep(for: .milliseconds(20))
+                if !forever { break }
+            }
+            throw CancellationError()
+        }
+    }
+
+    func cancel() {
+        cancelled = true
+    }
+
+    func observedExecutions() -> [PreparedUnit] {
+        executions
+    }
+}

--- a/MacintoraTests/Results/ScriptRunnerDriverTests.swift
+++ b/MacintoraTests/Results/ScriptRunnerDriverTests.swift
@@ -37,7 +37,7 @@ final class ScriptRunnerDriverTests: XCTestCase {
         XCTAssertEqual(executions[0].resolvedText, "select 1 from dual")
     }
 
-    func test_single_unit_failure_short_circuits_when_stopOnError() async {
+    func test_single_unit_failure_short_circuits_when_whenever_exit() async {
         let units = lex("select bad;\nselect 1 from dual;")
         XCTAssertEqual(units.count, 2)
 
@@ -45,7 +45,12 @@ final class ScriptRunnerDriverTests: XCTestCase {
             .failure(NSError(domain: "ora", code: 942, userInfo: [NSLocalizedDescriptionKey: "ORA-00942: table or view does not exist"]))
         ])
 
-        let events = await collect(units: units, executor: executor)
+        let env = SqlPlusEnvironment()
+        env.whenever = .exit(.failure, commitOrRollback: nil)
+
+        let runner = ScriptRunner(units: units, executor: executor, env: env)
+        var events: [ScriptRunnerEvent] = []
+        for await ev in runner.start() { events.append(ev) }
 
         // 1: unitStarted(0), 2: unitFinished(0,failed), 3: scriptFinished
         XCTAssertEqual(events.count, 3)
@@ -60,14 +65,15 @@ final class ScriptRunnerDriverTests: XCTestCase {
         XCTAssertEqual(executions.count, 1, "second unit should not have run")
     }
 
-    func test_failure_continues_when_stopOnError_disabled() async {
+    func test_failure_continues_when_whenever_continue() async {
         let units = lex("select bad;\nselect 1 from dual;")
         let executor = FakeConnectionExecutor(responses: [
             .failure(NSError(domain: "ora", code: 942)),
             .success(UnitResult(outcome: .statementSucceeded(rowCount: 1, dbmsOutput: [], preview: nil), elapsed: .zero))
         ])
 
-        let runner = ScriptRunner(units: units, executor: executor, options: .init(stopOnError: false))
+        // Default env has WHENEVER SQLERROR CONTINUE.
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
         var collected: [ScriptRunnerEvent] = []
         for await ev in runner.start() {
             collected.append(ev)
@@ -95,7 +101,7 @@ final class ScriptRunnerDriverTests: XCTestCase {
             .delayedSuccess(forever: true)
         ])
 
-        let runner = ScriptRunner(units: units, executor: executor)
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
         let stream = runner.start()
         var collected: [ScriptRunnerEvent] = []
 
@@ -118,6 +124,146 @@ final class ScriptRunnerDriverTests: XCTestCase {
         XCTAssertFalse(final.contains(where: { if case .scriptFinished = $0 { return true }; return false }))
     }
 
+    func test_whenever_exit_takes_effect_when_set_mid_script() async {
+        // Unit 0 fails — env still defaults to CONTINUE, so we proceed.
+        // Unit 1 sets WHENEVER SQLERROR EXIT.
+        // Unit 2 fails — now we should halt before unit 3.
+        let units = lex("""
+            select bad_one from dual;
+            WHENEVER SQLERROR EXIT FAILURE
+            select bad_two from dual;
+            select 'never reached' from dual;
+            """)
+        XCTAssertEqual(units.count, 4)
+
+        let executor = FakeConnectionExecutor(responses: [
+            .failure(NSError(domain: "ora", code: 942)),
+            .failure(NSError(domain: "ora", code: 942)),
+        ])
+
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
+        var collected: [ScriptRunnerEvent] = []
+        for await ev in runner.start() { collected.append(ev) }
+
+        let outcomes = collected.compactMap { event -> UnitResult.Outcome? in
+            if case .unitFinished(_, let r) = event { return r.outcome }
+            return nil
+        }
+        XCTAssertEqual(outcomes.count, 3, "expected 3 finished units (two failures + one directive), got: \(outcomes)")
+        if case .statementFailed = outcomes[0] {} else { XCTFail("first should fail") }
+        if case .directiveAcknowledged = outcomes[1] {} else { XCTFail("WHENEVER should ack as directive") }
+        if case .statementFailed = outcomes[2] {} else { XCTFail("third should fail") }
+
+        let executions = await executor.observedExecutions()
+        XCTAssertEqual(executions.count, 2, "fourth unit must not run after WHENEVER EXIT halts")
+    }
+
+    func test_define_mid_script_substitutes_subsequent_units() async {
+        // Unit 0: DEFINE owner = hr
+        // Unit 1: SELECT * FROM &owner..t  → resolved text "SELECT * FROM hr.t"
+        let units = lex("""
+            DEFINE owner = hr
+            SELECT * FROM &owner..t;
+            """)
+        let executor = FakeConnectionExecutor(responses: [
+            .success(UnitResult(outcome: .statementSucceeded(rowCount: 0, dbmsOutput: [], preview: nil), elapsed: .zero)),
+        ])
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
+        for await _ in runner.start() {}
+
+        let executions = await executor.observedExecutions()
+        XCTAssertEqual(executions.count, 1)
+        XCTAssertEqual(executions[0].resolvedText, "SELECT * FROM hr.t")
+    }
+
+    func test_needsBinds_event_is_emitted_for_units_with_colon_binds() async {
+        let units = lex("select * from emp where id = :id;")
+        let executor = FakeConnectionExecutor(responses: [
+            .success(UnitResult(outcome: .statementSucceeded(rowCount: 1, dbmsOutput: [], preview: nil), elapsed: .zero))
+        ])
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
+
+        var collected: [ScriptRunnerEvent] = []
+        for await ev in runner.start() {
+            collected.append(ev)
+            if case .needsBinds(let request) = ev {
+                XCTAssertEqual(request.names, [":id"])
+                request.resume([":id": .int(42)])
+            }
+        }
+
+        let executions = await executor.observedExecutions()
+        XCTAssertEqual(executions.count, 1)
+        XCTAssertEqual(executions[0].binds[":id"], .int(42))
+    }
+
+    func test_needsBinds_resume_nil_cancels_the_run() async {
+        let units = lex("""
+            select * from emp where id = :id;
+            select 'never reached' from dual;
+            """)
+        let executor = FakeConnectionExecutor(responses: [])
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
+
+        var sawCancelled = false
+        for await ev in runner.start() {
+            if case .needsBinds(let request) = ev {
+                request.resume(nil)
+            }
+            if case .cancelled = ev { sawCancelled = true }
+        }
+        XCTAssertTrue(sawCancelled)
+        let executions = await executor.observedExecutions()
+        XCTAssertTrue(executions.isEmpty, "no unit should have run when bind prompt was cancelled")
+    }
+
+    func test_show_errors_after_create_emits_compile_errors_entry() async {
+        let units = lex("""
+            CREATE OR REPLACE PROCEDURE p IS BEGIN xx; END;
+            /
+            SHOW ERRORS
+            """)
+        XCTAssertEqual(units.count, 2, "lexer should split into PL/SQL block + SHOW ERRORS directive")
+
+        let executor = FakeConnectionExecutor(responses: [
+            .success(UnitResult(outcome: .statementSucceeded(rowCount: nil, dbmsOutput: [], preview: nil), elapsed: .zero))
+        ])
+        let target = CompileErrorTarget(owner: nil, name: "P", type: "PROCEDURE")
+        await executor.setCompileErrors(for: target, [
+            CompileErrorRow(line: 1, position: 24, sequence: 1, attribute: "ERROR", text: "PLS-00201: identifier 'XX' must be declared")
+        ])
+
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
+        var compileEntry: (CompileErrorTarget?, [CompileErrorRow])?
+        for await ev in runner.start() {
+            if case .unitFinished(_, let r) = ev,
+               case .directiveCompileErrors(let t, let errs) = r.outcome {
+                compileEntry = (t, errs)
+            }
+        }
+        XCTAssertNotNil(compileEntry)
+        XCTAssertEqual(compileEntry?.0, target)
+        XCTAssertEqual(compileEntry?.1.first?.text, "PLS-00201: identifier 'XX' must be declared")
+    }
+
+    func test_show_errors_without_prior_create_emits_empty_entry() async {
+        let units = lex("SHOW ERRORS")
+        let executor = FakeConnectionExecutor(responses: [])
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
+
+        var entries: [UnitResult.Outcome] = []
+        for await ev in runner.start() {
+            if case .unitFinished(_, let r) = ev { entries.append(r.outcome) }
+        }
+        XCTAssertEqual(entries.count, 1)
+        if case .directiveCompileErrors(let target, let errs) = entries[0] {
+            XCTAssertNil(target)
+            XCTAssertTrue(errs.isEmpty)
+        } else {
+            XCTFail("expected directiveCompileErrors")
+        }
+    }
+
     func test_dbms_output_passes_through_unmodified() async {
         let units = lex("BEGIN DBMS_OUTPUT.PUT_LINE('hi'); END;\n/")
         let executor = FakeConnectionExecutor(responses: [
@@ -136,7 +282,7 @@ final class ScriptRunnerDriverTests: XCTestCase {
     }
 
     private func collect(units: [CommandUnit], executor: any ConnectionExecutor) async -> [ScriptRunnerEvent] {
-        let runner = ScriptRunner(units: units, executor: executor)
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
         var events: [ScriptRunnerEvent] = []
         for await ev in runner.start() {
             events.append(ev)
@@ -157,9 +303,19 @@ actor FakeConnectionExecutor: ConnectionExecutor {
     private var responses: [Response]
     private var executions: [PreparedUnit] = []
     private var cancelled = false
+    /// `SHOW ERRORS` returns the canned rows for the matching target.
+    var compileErrorsByTarget: [CompileErrorTarget: [CompileErrorRow]] = [:]
 
     init(responses: [Response]) {
         self.responses = responses
+    }
+
+    func fetchCompileErrors(for target: CompileErrorTarget) async throws -> [CompileErrorRow] {
+        compileErrorsByTarget[target] ?? []
+    }
+
+    func setCompileErrors(for target: CompileErrorTarget, _ rows: [CompileErrorRow]) {
+        compileErrorsByTarget[target] = rows
     }
 
     func execute(_ prepared: PreparedUnit) async throws -> UnitResult {

--- a/MacintoraTests/Results/ScriptRunnerLiveTests.swift
+++ b/MacintoraTests/Results/ScriptRunnerLiveTests.swift
@@ -45,7 +45,7 @@ final class ScriptRunnerLiveTests: XCTestCase {
             logger: Logging.Logger(label: "macintora.tests.script.live"),
             dbmsOutputEnabled: true
         )
-        let runner = ScriptRunner(units: units, executor: executor, options: .init(stopOnError: false))
+        let runner = ScriptRunner(units: units, executor: executor, env: SqlPlusEnvironment())
 
         var events: [ScriptRunnerEvent] = []
         for await event in runner.start() {

--- a/MacintoraTests/Results/ScriptRunnerLiveTests.swift
+++ b/MacintoraTests/Results/ScriptRunnerLiveTests.swift
@@ -1,0 +1,138 @@
+//
+//  ScriptRunnerLiveTests.swift
+//  MacintoraTests
+//
+//  Live integration: drives the runner against a real `OracleConnection`
+//  using the saved `c4-local` connection. Skips when c4-local isn't
+//  configured or its keychain password is missing — matching the pattern
+//  in `FullRefreshReproTests`.
+//
+
+import XCTest
+import OracleNIO
+import Logging
+@testable import Macintora
+
+@MainActor
+final class ScriptRunnerLiveTests: XCTestCase {
+
+    func test_multi_statement_script_runs_against_c4Local() async throws {
+        let conn = try await openLiveConnection()
+        defer {
+            Task { try? await conn.close() }
+        }
+
+        // Mix DDL/DML/SELECT/PL/SQL block + intentional ORA error.
+        let script = """
+        DROP TABLE macintora_script_test;
+        CREATE TABLE macintora_script_test (id NUMBER, name VARCHAR2(20));
+        INSERT INTO macintora_script_test VALUES (1, 'alice');
+        INSERT INTO macintora_script_test VALUES (2, 'bob');
+        SELECT id, name FROM macintora_script_test ORDER BY id;
+        BEGIN
+          DBMS_OUTPUT.PUT_LINE('hello from plsql');
+        END;
+        /
+        SELECT * FROM macintora_no_such_table;
+        DROP TABLE macintora_script_test;
+        """
+
+        let units = ScriptLexer.split(script).units
+        XCTAssertGreaterThanOrEqual(units.count, 7, "expected the lexer to split into at least 7 units")
+
+        let executor = OracleScriptExecutor(
+            conn: conn,
+            logger: Logging.Logger(label: "macintora.tests.script.live"),
+            dbmsOutputEnabled: true
+        )
+        let runner = ScriptRunner(units: units, executor: executor, options: .init(stopOnError: false))
+
+        var events: [ScriptRunnerEvent] = []
+        for await event in runner.start() {
+            events.append(event)
+        }
+
+        // Final event must be `scriptFinished` (we used stopOnError: false).
+        guard case .scriptFinished = events.last else {
+            return XCTFail("expected scriptFinished, got: \(String(describing: events.last))")
+        }
+
+        // Find the SELECT result and verify two rows came back.
+        let selects = events.compactMap { event -> SucceededDescriptor? in
+            guard case .unitFinished(_, let result) = event,
+                  case .statementSucceeded(let rows, _, let preview) = result.outcome,
+                  let rows, rows == 2,
+                  let preview, preview.columns.contains(where: { $0.uppercased() == "ID" })
+            else { return nil }
+            return SucceededDescriptor(rowCount: rows, columns: preview.columns, rows: preview.rows)
+        }
+        XCTAssertEqual(selects.count, 1)
+        if let descriptor = selects.first {
+            XCTAssertEqual(descriptor.rowCount, 2)
+            XCTAssertEqual(descriptor.rows.first?.last?.lowercased(), "alice")
+        }
+
+        // PL/SQL block produced DBMS_OUTPUT.
+        let dbmsLines = events.compactMap { event -> [String]? in
+            guard case .unitFinished(_, let result) = event,
+                  case .statementSucceeded(_, let lines, _) = result.outcome,
+                  !lines.isEmpty
+            else { return nil }
+            return lines
+        }
+        XCTAssertTrue(
+            dbmsLines.flatMap { $0 }.contains(where: { $0.contains("hello from plsql") }),
+            "expected DBMS_OUTPUT to capture the PL/SQL line; saw: \(dbmsLines)"
+        )
+
+        // The deliberate "no such table" hit produced a failure with ORA-942.
+        let failures = events.compactMap { event -> Int? in
+            guard case .unitFinished(_, let result) = event,
+                  case .statementFailed(_, let code) = result.outcome
+            else { return nil }
+            return code
+        }
+        XCTAssertTrue(failures.contains(942), "expected ORA-00942 in failures; saw: \(failures)")
+    }
+
+    // MARK: - Helpers
+
+    private struct SucceededDescriptor {
+        let rowCount: Int
+        let columns: [String]
+        let rows: [[String]]
+    }
+
+    private func openLiveConnection() async throws -> OracleConnection {
+        let store = ConnectionStore()
+        guard let saved = store.connection(named: "c4-local") else {
+            throw XCTSkip("c4-local not present in connections.json")
+        }
+        let appBundleID = "com.iliasazonov.macintora"
+        let keychain = KeychainService(service: appBundleID)
+        guard
+            saved.savePasswordInKeychain,
+            let pwd = try? keychain.password(for: saved.id, kind: .databasePassword),
+            !pwd.isEmpty
+        else {
+            throw XCTSkip("Saved password for c4-local not available in keychain")
+        }
+
+        let details = ConnectionDetails(
+            savedConnectionID: saved.id,
+            username: saved.defaultUsername,
+            password: pwd,
+            tns: saved.name,
+            connectionRole: .regular
+        )
+        let cfg = try OracleEndpoint.configuration(for: details, store: store, keychain: keychain)
+        var logger = Logging.Logger(label: "macintora.tests.script.live.conn")
+        logger.logLevel = .notice
+        return try await OracleConnection.connect(
+            on: OracleEventLoopGroup.shared.next(),
+            configuration: cfg,
+            id: Int.random(in: 1...Int.max),
+            logger: logger
+        )
+    }
+}

--- a/MacintoraTests/Script/ScriptLexerTests.swift
+++ b/MacintoraTests/Script/ScriptLexerTests.swift
@@ -1,0 +1,458 @@
+//
+//  ScriptLexerTests.swift
+//  MacintoraTests
+//
+
+import XCTest
+@testable import Macintora
+
+final class ScriptLexerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func texts(_ source: String) -> [String] {
+        ScriptLexer.split(source).units.map { $0.text }
+    }
+
+    private func kinds(_ source: String) -> [CommandUnit.Kind] {
+        ScriptLexer.split(source).units.map { $0.kind }
+    }
+
+    // MARK: - Plain SQL
+
+    func test_singleStatement_strips_trailing_semicolon() {
+        XCTAssertEqual(texts("select 1 from dual;"), ["select 1 from dual"])
+    }
+
+    func test_singleStatement_no_terminator() {
+        XCTAssertEqual(texts("select 1 from dual"), ["select 1 from dual"])
+    }
+
+    func test_two_statements_split_on_semicolon() {
+        XCTAssertEqual(
+            texts("select 1 from dual;\nselect 2 from dual;\n"),
+            ["select 1 from dual", "select 2 from dual"]
+        )
+    }
+
+    func test_two_statements_one_line() {
+        XCTAssertEqual(
+            texts("select 1 from dual; select 2 from dual;"),
+            ["select 1 from dual", "select 2 from dual"]
+        )
+    }
+
+    func test_division_is_not_a_split() {
+        XCTAssertEqual(texts("select a/b from dual;"), ["select a/b from dual"])
+    }
+
+    // MARK: - Comments
+
+    func test_line_comment_between_statements_is_skipped() {
+        let src = """
+        -- the answer
+        select 42 from dual;
+        """
+        XCTAssertEqual(texts(src), ["select 42 from dual"])
+    }
+
+    func test_block_comment_between_statements_is_skipped() {
+        let src = """
+        /* the answer */
+        select 42 from dual;
+        """
+        XCTAssertEqual(texts(src), ["select 42 from dual"])
+    }
+
+    func test_line_comment_inside_string_is_not_a_comment() {
+        let src = "select '-- not a comment' from dual;"
+        XCTAssertEqual(texts(src), ["select '-- not a comment' from dual"])
+    }
+
+    func test_block_comment_inside_string_is_not_a_comment() {
+        let src = "select '/* not a comment */' from dual;"
+        XCTAssertEqual(texts(src), ["select '/* not a comment */' from dual"])
+    }
+
+    func test_inline_block_comment_inside_statement_is_preserved() {
+        let src = "select /* hi */ 1 from dual;"
+        XCTAssertEqual(texts(src), ["select /* hi */ 1 from dual"])
+    }
+
+    // MARK: - String literals & q-quotes
+
+    func test_single_quote_escape_keeps_string_intact() {
+        let src = "select 'it''s ok; really' from dual; select 2 from dual;"
+        XCTAssertEqual(
+            texts(src),
+            ["select 'it''s ok; really' from dual", "select 2 from dual"]
+        )
+    }
+
+    func test_qquote_with_brackets_does_not_split() {
+        let src = "select q'[hello; world]' from dual; select 2 from dual;"
+        XCTAssertEqual(
+            texts(src),
+            ["select q'[hello; world]' from dual", "select 2 from dual"]
+        )
+    }
+
+    func test_qquote_with_parens() {
+        let src = "select q'(a; b)' from dual;"
+        XCTAssertEqual(texts(src), ["select q'(a; b)' from dual"])
+    }
+
+    func test_qquote_with_braces() {
+        let src = "select q'{a; b}' from dual;"
+        XCTAssertEqual(texts(src), ["select q'{a; b}' from dual"])
+    }
+
+    func test_qquote_with_angles() {
+        let src = "select q'<a; b>' from dual;"
+        XCTAssertEqual(texts(src), ["select q'<a; b>' from dual"])
+    }
+
+    func test_qquote_with_bang_delimiter() {
+        let src = "select q'!a; b!' from dual;"
+        XCTAssertEqual(texts(src), ["select q'!a; b!' from dual"])
+    }
+
+    func test_qquote_uppercase_Q() {
+        let src = "select Q'[a; b]' from dual;"
+        XCTAssertEqual(texts(src), ["select Q'[a; b]' from dual"])
+    }
+
+    func test_qquote_with_n_prefix() {
+        let src = "select Nq'[a; b]' from dual;"
+        XCTAssertEqual(texts(src), ["select Nq'[a; b]' from dual"])
+    }
+
+    func test_quoted_identifier_does_not_split() {
+        let src = "select \"weird;name\" from dual;"
+        XCTAssertEqual(texts(src), ["select \"weird;name\" from dual"])
+    }
+
+    // MARK: - PL/SQL blocks
+
+    func test_anonymous_begin_end_block_terminated_by_slash() {
+        let src = """
+        BEGIN
+          NULL;
+        END;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .plsqlBlock)
+        XCTAssertEqual(units[0].text, "BEGIN\n  NULL;\nEND;")
+    }
+
+    func test_declare_block_terminated_by_slash() {
+        let src = """
+        DECLARE x NUMBER;
+        BEGIN
+          x := 1;
+        END;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .plsqlBlock)
+    }
+
+    func test_create_or_replace_function_terminated_by_slash() {
+        let src = """
+        CREATE OR REPLACE FUNCTION f RETURN NUMBER IS
+        BEGIN
+          RETURN 1;
+        END;
+        /
+        SELECT f FROM dual;
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 2)
+        XCTAssertEqual(units[0].kind, .plsqlBlock)
+        XCTAssertEqual(units[1].kind, .sql)
+        XCTAssertEqual(units[1].text, "SELECT f FROM dual")
+    }
+
+    func test_create_procedure_terminated_by_slash() {
+        let src = """
+        CREATE PROCEDURE p IS BEGIN NULL; END;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .plsqlBlock)
+    }
+
+    func test_create_package_body_is_plsql() {
+        let src = """
+        CREATE PACKAGE BODY pkg IS
+          PROCEDURE q IS BEGIN NULL; END;
+        END pkg;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .plsqlBlock)
+    }
+
+    func test_editionable_create_function_is_plsql() {
+        let src = """
+        CREATE OR REPLACE EDITIONABLE FUNCTION f RETURN NUMBER IS BEGIN RETURN 1; END;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .plsqlBlock)
+    }
+
+    func test_create_type_without_body_is_sql() {
+        let src = "CREATE TYPE addr_t AS OBJECT (street VARCHAR2(60));"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .sql)
+    }
+
+    func test_create_type_body_is_plsql() {
+        let src = """
+        CREATE TYPE BODY addr_t AS
+          MEMBER FUNCTION pretty RETURN VARCHAR2 IS BEGIN RETURN street; END;
+        END;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .plsqlBlock)
+    }
+
+    func test_create_table_is_sql_not_plsql() {
+        let src = "CREATE TABLE t (id NUMBER); INSERT INTO t VALUES (1);"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 2)
+        XCTAssertEqual(units[0].kind, .sql)
+        XCTAssertEqual(units[0].text, "CREATE TABLE t (id NUMBER)")
+        XCTAssertEqual(units[1].kind, .sql)
+        XCTAssertEqual(units[1].text, "INSERT INTO t VALUES (1)")
+    }
+
+    // MARK: - `;` followed by trailing `/` line
+
+    func test_semicolon_followed_by_slash_line_absorbs_slash() {
+        let src = """
+        SELECT 1 FROM dual;
+        /
+        SELECT 2 FROM dual;
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 2)
+        XCTAssertEqual(units[0].text, "SELECT 1 FROM dual")
+        XCTAssertEqual(units[1].text, "SELECT 2 FROM dual")
+    }
+
+    // MARK: - SQL*Plus directives
+
+    func test_at_include_recognized_at_line_start() {
+        let src = "@helper.sql\nSELECT 1 FROM dual;"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 2)
+        if case .sqlplus(.include(let path, let dbl)) = units[0].kind {
+            XCTAssertEqual(path, "helper.sql")
+            XCTAssertFalse(dbl)
+        } else {
+            XCTFail("expected include directive, got \(units[0].kind)")
+        }
+        XCTAssertEqual(units[1].kind, .sql)
+    }
+
+    func test_double_at_include_recognized() {
+        let src = "@@subdir/helper.sql\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        if case .sqlplus(.include(let path, let dbl)) = units[0].kind {
+            XCTAssertEqual(path, "subdir/helper.sql")
+            XCTAssertTrue(dbl)
+        } else {
+            XCTFail("expected include directive")
+        }
+    }
+
+    func test_at_in_dblink_is_not_a_directive() {
+        let src = "select * from t@dblink;"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .sql)
+        XCTAssertEqual(units[0].text, "select * from t@dblink")
+    }
+
+    func test_set_serveroutput_on() {
+        let src = "SET SERVEROUTPUT ON\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].kind, .sqlplus(.set(.serverOutput(true))))
+    }
+
+    func test_set_echo_off() {
+        let src = "set echo off\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.set(.echo(false))))
+    }
+
+    func test_set_feedback_rows() {
+        let src = "SET FEEDBACK 5\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.set(.feedback(.rows(5)))))
+    }
+
+    func test_set_define_off() {
+        let src = "SET DEFINE OFF\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.set(.define(.off))))
+    }
+
+    func test_set_define_prefix() {
+        let src = "SET DEFINE #\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.set(.define(.prefix("#")))))
+    }
+
+    func test_define_with_value() {
+        let src = "DEFINE owner = hr\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.define(name: "OWNER", value: "hr")))
+    }
+
+    func test_define_with_quoted_value() {
+        let src = "DEFINE owner = 'hr schema'\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.define(name: "OWNER", value: "hr schema")))
+    }
+
+    func test_undefine() {
+        let src = "UNDEFINE owner\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.undefine(name: "owner")))
+    }
+
+    func test_prompt_message() {
+        let src = "PROMPT Hello, world\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.prompt(message: "Hello, world")))
+    }
+
+    func test_remark_is_directive() {
+        let src = "REM this is a sql*plus comment\nSELECT 1 FROM dual;"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 2)
+        XCTAssertEqual(units[0].kind, .sqlplus(.remark(text: "this is a sql*plus comment")))
+        XCTAssertEqual(units[1].kind, .sql)
+    }
+
+    func test_remark_long_form() {
+        let src = "REMARK hi\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.remark(text: "hi")))
+    }
+
+    func test_show_errors() {
+        let src = "SHOW ERRORS\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.showErrors))
+    }
+
+    func test_whenever_sqlerror_exit_failure() {
+        let src = "WHENEVER SQLERROR EXIT FAILURE\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.whenever(.sqlError, .exit(.failure, commitOrRollback: nil))))
+    }
+
+    func test_whenever_sqlerror_exit_failure_rollback() {
+        let src = "WHENEVER SQLERROR EXIT FAILURE ROLLBACK\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.whenever(.sqlError, .exit(.failure, commitOrRollback: .rollback))))
+    }
+
+    func test_whenever_sqlerror_continue_none() {
+        let src = "WHENEVER SQLERROR CONTINUE NONE\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.whenever(.sqlError, .continue(.noAction))))
+    }
+
+    func test_whenever_sqlerror_continue_bare() {
+        let src = "WHENEVER SQLERROR CONTINUE\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units[0].kind, .sqlplus(.whenever(.sqlError, .continue(.noAction))))
+    }
+
+    // MARK: - Mixed scripts
+
+    func test_mixed_directives_and_statements() {
+        let src = """
+        SET SERVEROUTPUT ON
+        DEFINE owner = hr
+        SELECT * FROM dual;
+        BEGIN
+          DBMS_OUTPUT.PUT_LINE('hi');
+        END;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 4)
+        XCTAssertEqual(units[0].kind, .sqlplus(.set(.serverOutput(true))))
+        XCTAssertEqual(units[1].kind, .sqlplus(.define(name: "OWNER", value: "hr")))
+        XCTAssertEqual(units[2].kind, .sql)
+        XCTAssertEqual(units[2].text, "SELECT * FROM dual")
+        XCTAssertEqual(units[3].kind, .plsqlBlock)
+    }
+
+    func test_lone_slash_between_units_is_discarded() {
+        let src = """
+        SELECT 1 FROM dual;
+        /
+        SELECT 2 FROM dual;
+        /
+        """
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 2)
+        XCTAssertEqual(units[0].text, "SELECT 1 FROM dual")
+        XCTAssertEqual(units[1].text, "SELECT 2 FROM dual")
+    }
+
+    // MARK: - Original-range fidelity
+
+    func test_original_range_covers_full_text_including_terminator() {
+        let src = "select 1 from dual;\nselect 2 from dual;\n"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 2)
+        // First unit's range covers the leading "select 1 from dual;" (without the \n)
+        let r0 = units[0].originalRange
+        XCTAssertEqual(String(src[r0]), "select 1 from dual;")
+        let r1 = units[1].originalRange
+        XCTAssertEqual(String(src[r1]), "select 2 from dual;")
+    }
+
+    func test_empty_input_yields_no_units() {
+        XCTAssertTrue(ScriptLexer.split("").units.isEmpty)
+        XCTAssertTrue(ScriptLexer.split("   \n\n  \n").units.isEmpty)
+        XCTAssertTrue(ScriptLexer.split("-- only comment\n").units.isEmpty)
+    }
+
+    // MARK: - Bind-variable text passes through
+
+    func test_bind_variables_remain_in_text() {
+        let src = "select * from emp where id = :id and dept = :dept;"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].text, "select * from emp where id = :id and dept = :dept")
+    }
+
+    // MARK: - Substitution variables remain in text (Phase 1 will resolve)
+
+    func test_substitution_variable_remains_in_text() {
+        let src = "select * from &owner..t where id = &&id;"
+        let units = ScriptLexer.split(src).units
+        XCTAssertEqual(units.count, 1)
+        XCTAssertEqual(units[0].text, "select * from &owner..t where id = &&id")
+    }
+}

--- a/MacintoraTests/Script/ScriptLoaderTests.swift
+++ b/MacintoraTests/Script/ScriptLoaderTests.swift
@@ -1,0 +1,143 @@
+//
+//  ScriptLoaderTests.swift
+//  MacintoraTests
+//
+
+import XCTest
+@testable import Macintora
+
+final class ScriptLoaderTests: XCTestCase {
+
+    func test_flatten_no_includes_returns_input_unchanged() throws {
+        let units = ScriptLexer.split("select 1 from dual;\nselect 2 from dual;").units
+        let flat = try ScriptLoader.flatten(units, documentBaseURL: nil, resolver: FakeFileResolver(files: [:]))
+        XCTAssertEqual(flat.count, 2)
+        XCTAssertEqual(flat.map(\.text), ["select 1 from dual", "select 2 from dual"])
+    }
+
+    func test_flatten_resolves_at_include() throws {
+        let docDir = URL(fileURLWithPath: "/project")
+        let helper = docDir.appendingPathComponent("helper.sql")
+        let resolver = FakeFileResolver(files: [
+            helper: "select 'helper' from dual;\n"
+        ])
+
+        let source = "@helper\nselect 'main' from dual;\n"
+        let units = ScriptLexer.split(source).units
+        let flat = try ScriptLoader.flatten(units, documentBaseURL: docDir, resolver: resolver)
+
+        XCTAssertEqual(flat.count, 2)
+        XCTAssertEqual(flat[0].text, "select 'helper' from dual")
+        XCTAssertEqual(flat[1].text, "select 'main' from dual")
+    }
+
+    func test_flatten_double_at_resolves_against_current_file() throws {
+        let docDir = URL(fileURLWithPath: "/project")
+        let level1 = docDir.appendingPathComponent("nested/a.sql")
+        let level2 = docDir.appendingPathComponent("nested/b.sql")
+        let resolver = FakeFileResolver(files: [
+            level1: "@@b\nselect 'a' from dual;\n",
+            level2: "select 'b' from dual;\n"
+        ])
+        let units = ScriptLexer.split("@nested/a\n").units
+        let flat = try ScriptLoader.flatten(units, documentBaseURL: docDir, resolver: resolver)
+        XCTAssertEqual(flat.map(\.text), ["select 'b' from dual", "select 'a' from dual"])
+    }
+
+    func test_flatten_appends_sql_extension_when_missing() throws {
+        let docDir = URL(fileURLWithPath: "/project")
+        let helper = docDir.appendingPathComponent("foo.sql")
+        let resolver = FakeFileResolver(files: [
+            helper: "select 1 from dual;\n"
+        ])
+        let units = ScriptLexer.split("@foo\n").units
+        let flat = try ScriptLoader.flatten(units, documentBaseURL: docDir, resolver: resolver)
+        XCTAssertEqual(flat.count, 1)
+    }
+
+    func test_flatten_throws_on_missing_file() {
+        let docDir = URL(fileURLWithPath: "/project")
+        let units = ScriptLexer.split("@nope\n").units
+        XCTAssertThrowsError(
+            try ScriptLoader.flatten(units, documentBaseURL: docDir, resolver: FakeFileResolver(files: [:]))
+        ) { error in
+            guard let err = error as? ScriptLoaderError else { return XCTFail("wrong error: \(error)") }
+            if case .fileNotFound = err {
+                // ok
+            } else {
+                XCTFail("expected fileNotFound, got \(err)")
+            }
+        }
+    }
+
+    func test_flatten_detects_simple_cycle() {
+        let docDir = URL(fileURLWithPath: "/project")
+        let a = docDir.appendingPathComponent("a.sql")
+        let b = docDir.appendingPathComponent("b.sql")
+        let resolver = FakeFileResolver(files: [
+            a: "@b\n",
+            b: "@a\n"
+        ])
+        let units = ScriptLexer.split("@a\n").units
+        XCTAssertThrowsError(try ScriptLoader.flatten(units, documentBaseURL: docDir, resolver: resolver)) { error in
+            guard let err = error as? ScriptLoaderError else { return XCTFail("wrong error: \(error)") }
+            if case .cycleDetected = err { return }
+            XCTFail("expected cycleDetected, got \(err)")
+        }
+    }
+
+    func test_flatten_allows_diamond_imports() throws {
+        // a → b, a → c, b → c (re-imports of the same leaf are allowed because
+        // it's not a cycle — c isn't currently on the include stack when b
+        // returns to a, and a → c happens after b → c finishes).
+        let docDir = URL(fileURLWithPath: "/project")
+        let a = docDir.appendingPathComponent("a.sql")
+        let b = docDir.appendingPathComponent("b.sql")
+        let c = docDir.appendingPathComponent("c.sql")
+        let resolver = FakeFileResolver(files: [
+            a: "@b\n@c\nselect 'a' from dual;\n",
+            b: "@c\nselect 'b' from dual;\n",
+            c: "select 'c' from dual;\n"
+        ])
+        let units = ScriptLexer.split("@a\n").units
+        let flat = try ScriptLoader.flatten(units, documentBaseURL: docDir, resolver: resolver)
+        XCTAssertEqual(
+            flat.map(\.text),
+            ["select 'c' from dual", "select 'b' from dual", "select 'c' from dual", "select 'a' from dual"]
+        )
+    }
+
+    func test_flatten_max_depth_guards_runaway_recursion() {
+        let docDir = URL(fileURLWithPath: "/project")
+        let a = docDir.appendingPathComponent("a.sql")
+        let b = docDir.appendingPathComponent("b.sql")
+        // Mutually-aliased "infinite" recursion through file aliases — the
+        // cycle check guards true cycles, this exercises the depth limit.
+        let resolver = FakeFileResolver(files: [
+            a: "@b\n",
+            b: "@a\n"
+        ])
+        let units = ScriptLexer.split("@a\n").units
+        XCTAssertThrowsError(
+            try ScriptLoader.flatten(units, documentBaseURL: docDir, resolver: resolver, maxDepth: 16)
+        )
+    }
+}
+
+// MARK: - Test resolver
+
+private struct FakeFileResolver: ScriptFileResolver {
+    let files: [URL: String]
+
+    func read(_ url: URL) throws -> String {
+        let key = url.standardizedFileURL
+        if let body = files[key] { return body }
+        // also try without standardisation
+        if let body = files[url] { return body }
+        throw NSError(domain: "FakeFileResolver", code: 1, userInfo: [NSLocalizedDescriptionKey: "no fixture for \(url.path)"])
+    }
+
+    func exists(_ url: URL) -> Bool {
+        files[url.standardizedFileURL] != nil || files[url] != nil
+    }
+}

--- a/MacintoraTests/Script/SqlPlusInterpreterTests.swift
+++ b/MacintoraTests/Script/SqlPlusInterpreterTests.swift
@@ -6,7 +6,6 @@
 import XCTest
 @testable import Macintora
 
-@MainActor
 final class SqlPlusInterpreterTests: XCTestCase {
 
     func test_define_inserts_uppercased_key() {

--- a/MacintoraTests/Script/SqlPlusInterpreterTests.swift
+++ b/MacintoraTests/Script/SqlPlusInterpreterTests.swift
@@ -1,0 +1,90 @@
+//
+//  SqlPlusInterpreterTests.swift
+//  MacintoraTests
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class SqlPlusInterpreterTests: XCTestCase {
+
+    func test_define_inserts_uppercased_key() {
+        let env = SqlPlusEnvironment()
+        let outcome = SqlPlusInterpreter.apply(.define(name: "owner", value: "hr"), env: env)
+        XCTAssertEqual(outcome, .acknowledged)
+        XCTAssertEqual(env.defines["OWNER"], "hr")
+    }
+
+    func test_undefine_removes_key() {
+        let env = SqlPlusEnvironment()
+        env.defines["OWNER"] = "hr"
+        _ = SqlPlusInterpreter.apply(.undefine(name: "owner"), env: env)
+        XCTAssertNil(env.defines["OWNER"])
+    }
+
+    func test_set_serveroutput_toggles() {
+        let env = SqlPlusEnvironment()
+        env.serverOutput = true
+        _ = SqlPlusInterpreter.apply(.set(.serverOutput(false)), env: env)
+        XCTAssertFalse(env.serverOutput)
+        _ = SqlPlusInterpreter.apply(.set(.serverOutput(true)), env: env)
+        XCTAssertTrue(env.serverOutput)
+    }
+
+    func test_set_define_off_disables_substitution() {
+        let env = SqlPlusEnvironment()
+        XCTAssertTrue(env.defineEnabled)
+        _ = SqlPlusInterpreter.apply(.set(.define(.off)), env: env)
+        XCTAssertFalse(env.defineEnabled)
+        _ = SqlPlusInterpreter.apply(.set(.define(.on)), env: env)
+        XCTAssertTrue(env.defineEnabled)
+    }
+
+    func test_set_define_prefix_changes_character() {
+        let env = SqlPlusEnvironment()
+        _ = SqlPlusInterpreter.apply(.set(.define(.prefix("#"))), env: env)
+        XCTAssertEqual(env.definePrefix, "#")
+        XCTAssertTrue(env.defineEnabled)
+    }
+
+    func test_prompt_returns_message_outcome() {
+        let env = SqlPlusEnvironment()
+        let outcome = SqlPlusInterpreter.apply(.prompt(message: "hello"), env: env)
+        XCTAssertEqual(outcome, .prompt(message: "hello"))
+    }
+
+    func test_remark_returns_skip() {
+        let env = SqlPlusEnvironment()
+        let outcome = SqlPlusInterpreter.apply(.remark(text: "hi"), env: env)
+        XCTAssertEqual(outcome, .skip)
+    }
+
+    func test_show_errors_returns_showErrors() {
+        let env = SqlPlusEnvironment()
+        let outcome = SqlPlusInterpreter.apply(.showErrors, env: env)
+        XCTAssertEqual(outcome, .showErrors)
+    }
+
+    func test_whenever_sqlerror_exit_records_action() {
+        let env = SqlPlusEnvironment()
+        let outcome = SqlPlusInterpreter.apply(
+            .whenever(.sqlError, .exit(.failure, commitOrRollback: nil)),
+            env: env
+        )
+        XCTAssertEqual(outcome, .acknowledged)
+        XCTAssertEqual(env.whenever, .exit(.failure, commitOrRollback: nil))
+    }
+
+    func test_include_returns_unresolved() {
+        let env = SqlPlusEnvironment()
+        let outcome = SqlPlusInterpreter.apply(.include(path: "f.sql", doubleAt: false), env: env)
+        XCTAssertEqual(outcome, .unresolvedInclude(path: "f.sql", doubleAt: false))
+    }
+
+    func test_unrecognized_returns_noted() {
+        let env = SqlPlusEnvironment()
+        let outcome = SqlPlusInterpreter.apply(.unrecognized(text: "WHATEVER"), env: env)
+        XCTAssertEqual(outcome, .noted(text: "WHATEVER"))
+    }
+}

--- a/MacintoraTests/Script/SubstitutionResolverTests.swift
+++ b/MacintoraTests/Script/SubstitutionResolverTests.swift
@@ -1,0 +1,155 @@
+//
+//  SubstitutionResolverTests.swift
+//  MacintoraTests
+//
+
+import XCTest
+@testable import Macintora
+
+final class SubstitutionResolverTests: XCTestCase {
+
+    // MARK: - scan
+
+    func test_scan_finds_simple_references() {
+        let scan = SubstitutionResolver.scan("select * from &owner.t where id = &id;")
+        XCTAssertEqual(scan.names, ["OWNER", "ID"])
+        XCTAssertTrue(scan.stickyNames.isEmpty)
+    }
+
+    func test_scan_distinguishes_sticky_from_simple() {
+        let scan = SubstitutionResolver.scan("select &x, &&y, &x, &&y from dual;")
+        XCTAssertEqual(scan.names, ["X", "Y"])
+        XCTAssertEqual(scan.stickyNames, ["Y"])
+    }
+
+    func test_scan_no_references() {
+        let scan = SubstitutionResolver.scan("select 1 from dual;")
+        XCTAssertTrue(scan.names.isEmpty)
+        XCTAssertTrue(scan.stickyNames.isEmpty)
+    }
+
+    func test_scan_ignores_lone_ampersand() {
+        let scan = SubstitutionResolver.scan("select 'a & b' from dual;")
+        XCTAssertTrue(scan.names.isEmpty)
+    }
+
+    func test_scan_finds_inside_strings() {
+        let scan = SubstitutionResolver.scan("select 'hello &name' from dual;")
+        XCTAssertEqual(scan.names, ["NAME"])
+    }
+
+    // MARK: - resolve: passthrough
+
+    func test_resolve_no_substitutions_yields_identity_text() {
+        let r = SubstitutionResolver.resolve("select 1 from dual", defines: [:])
+        XCTAssertEqual(r.text, "select 1 from dual")
+        XCTAssertTrue(r.missing.isEmpty)
+    }
+
+    // MARK: - resolve: simple substitution
+
+    func test_resolve_simple_name() {
+        let r = SubstitutionResolver.resolve("select * from &t;", defines: ["T": "emp"])
+        XCTAssertEqual(r.text, "select * from emp;")
+        XCTAssertTrue(r.missing.isEmpty)
+    }
+
+    func test_resolve_double_ampersand() {
+        let r = SubstitutionResolver.resolve("select &&x from dual;", defines: ["X": "1"])
+        XCTAssertEqual(r.text, "select 1 from dual;")
+        XCTAssertTrue(r.missing.isEmpty)
+    }
+
+    func test_resolve_terminator_dot_is_consumed() {
+        let r = SubstitutionResolver.resolve("select * from &owner..t;", defines: ["OWNER": "hr"])
+        XCTAssertEqual(r.text, "select * from hr.t;")
+    }
+
+    func test_resolve_inside_string_literal() {
+        let r = SubstitutionResolver.resolve("select 'hi &name' from dual;", defines: ["NAME": "alice"])
+        XCTAssertEqual(r.text, "select 'hi alice' from dual;")
+    }
+
+    func test_resolve_missing_value_leaves_reference_verbatim() {
+        let r = SubstitutionResolver.resolve("select * from &t;", defines: [:])
+        XCTAssertEqual(r.text, "select * from &t;")
+        XCTAssertEqual(r.missing, ["T"])
+    }
+
+    func test_resolve_mixed_resolved_and_missing() {
+        let r = SubstitutionResolver.resolve(
+            "select &a, &b from dual;",
+            defines: ["A": "x"]
+        )
+        XCTAssertEqual(r.text, "select x, &b from dual;")
+        XCTAssertEqual(r.missing, ["B"])
+    }
+
+    // MARK: - resolve: case insensitivity
+
+    func test_resolve_is_case_insensitive_in_lookup() {
+        let r = SubstitutionResolver.resolve("select &OwNeR from dual;", defines: ["OWNER": "hr"])
+        XCTAssertEqual(r.text, "select hr from dual;")
+    }
+
+    // MARK: - OffsetMap round-trip
+
+    func test_offset_map_passthrough_round_trip() {
+        let original = "select 1 from dual"
+        let r = SubstitutionResolver.resolve(original, defines: [:])
+        // Pick a range in the resolved text and project back.
+        let resolvedRange = 7..<8 // "1"
+        let originalRange = r.mapping.originalRange(forResolved: resolvedRange)
+        XCTAssertEqual(originalRange, 7..<8)
+    }
+
+    func test_offset_map_substitution_growth_projects_to_original() {
+        // Original: "select &t from dual"  (positions 7..<9 are `&t`)
+        //   t=0..<7: "select "  (passthrough)
+        //   t=7..<9: "&t"       (substitution)
+        //   t=9..<19: " from dual" (passthrough)
+        // Resolved: "select EMPLOYEE from dual" (after "EMPLOYEE" replaces "&t")
+        //   r=0..<7: "select "
+        //   r=7..<15: "EMPLOYEE"  ← substitution; back-maps to original 7..<9
+        //   r=15..<25: " from dual"
+        let original = "select &t from dual"
+        let r = SubstitutionResolver.resolve(original, defines: ["T": "EMPLOYEE"])
+        XCTAssertEqual(r.text, "select EMPLOYEE from dual")
+
+        // Anywhere inside "EMPLOYEE" should map back to the &t reference range.
+        let resolvedRange = 10..<13 // a span inside "EMPLOYEE"
+        XCTAssertEqual(r.mapping.originalRange(forResolved: resolvedRange), 7..<9)
+
+        // Tail passthrough preserves character offsets relative to original.
+        XCTAssertEqual(r.mapping.originalRange(forResolved: 16..<20), 10..<14) // " fro"
+    }
+
+    func test_offset_map_terminator_dot_included_in_substitution_range() {
+        // Original: "select &owner..t" → resolved: "select hr.t".
+        //   `&owner.` (incl. consumed terminator dot) covers original 7..<14.
+        //   Literal "." sits at 14..<15; "t" at 15..<16.
+        let original = "select &owner..t"
+        let r = SubstitutionResolver.resolve(original, defines: ["OWNER": "hr"])
+        XCTAssertEqual(r.text, "select hr.t")
+        XCTAssertEqual(r.mapping.originalRange(forResolved: 7..<9), 7..<14)
+    }
+
+    func test_offset_map_identity_for_empty_input() {
+        let r = SubstitutionResolver.resolve("", defines: [:])
+        XCTAssertEqual(r.text, "")
+        XCTAssertEqual(r.mapping.originalRange(forResolved: 0..<0), 0..<0)
+    }
+
+    // MARK: - && stickiness reported
+
+    func test_scan_reports_sticky_names_for_session_persistence() {
+        let scan = SubstitutionResolver.scan("""
+            DEFINE owner = hr;
+            SELECT * FROM &&owner..emp;
+            SELECT * FROM &owner..dept;
+            """)
+        // Both refs use the same name; the && one makes it sticky.
+        XCTAssertEqual(scan.names, ["OWNER"])
+        XCTAssertEqual(scan.stickyNames, ["OWNER"])
+    }
+}

--- a/MacintoraUITests/ScriptRunnerUXTests.swift
+++ b/MacintoraUITests/ScriptRunnerUXTests.swift
@@ -80,13 +80,13 @@ final class ScriptRunnerUXTests: XCTestCase {
         let sheet = app.descendants(matching: .any)["script.substitutionSheet"]
         XCTAssertTrue(sheet.waitForExistence(timeout: 5), "expected substitution sheet to appear for &owner")
 
-        // Cancel dismisses the sheet without running the script.
-        let cancel = app.buttons["script.substitutionSheet.cancel"]
-        XCTAssertTrue(cancel.waitForExistence(timeout: 2))
-        cancel.click()
+        // Cancel dismisses the sheet. Buttons inside macOS sheets are not
+        // always reachable via `app.buttons[...]`, so we use the Escape key
+        // (the Cancel button has `.keyboardShortcut(.cancelAction)`).
+        app.typeKey(.escape, modifierFlags: [])
 
         // Sheet goes away.
-        XCTAssertFalse(sheet.waitForExistence(timeout: 2), "sheet should have dismissed on Cancel")
+        XCTAssertFalse(sheet.waitForExistence(timeout: 2), "sheet should have dismissed on Escape")
     }
 
     // MARK: - Script-output pane swap

--- a/MacintoraUITests/ScriptRunnerUXTests.swift
+++ b/MacintoraUITests/ScriptRunnerUXTests.swift
@@ -1,0 +1,124 @@
+//
+//  ScriptRunnerUXTests.swift
+//  MacintoraUITests
+//
+//  XCUITest coverage for the script-runner toolbar buttons, the substitution
+//  prompt sheet, and the script-output pane swap. Reuses the same fixture
+//  document as the legacy `MacintoraUITests` and assumes a TNS alias `local`
+//  is reachable for connection-dependent flows.
+//
+
+import XCTest
+
+final class ScriptRunnerUXTests: XCTestCase {
+
+    private static let fixtureURL = URL(fileURLWithPath:
+        "/Users/ilia/Documents/macintora/local.macintora")
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: Self.fixtureURL.path),
+            "Fixture document required for UI tests."
+        )
+    }
+
+    @MainActor
+    private func launch() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [Self.fixtureURL.path]
+        app.launchEnvironment["OS_ACTIVITY_MODE"] = "disable"
+        app.launch()
+        return app
+    }
+
+    // MARK: - Toolbar buttons exist and are reachable
+
+    @MainActor
+    func test_runScriptToolbarButtonsExist() throws {
+        let app = launch()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10))
+
+        let runScript = window.toolbars.buttons["toolbar.runScript"]
+        XCTAssertTrue(runScript.waitForExistence(timeout: 5), "Run Script toolbar button missing")
+        let runFromCursor = window.toolbars.buttons["toolbar.runScriptFromCursor"]
+        XCTAssertTrue(runFromCursor.waitForExistence(timeout: 5), "Run From Cursor toolbar button missing")
+    }
+
+    // MARK: - Substitution sheet on `&` variables
+
+    @MainActor
+    func test_substitutionSheetAppearsForAmpersandVariable() throws {
+        let app = launch()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10))
+
+        // Connect — the runner only kicks off if the document has a connection.
+        let connectButton = window.toolbars.buttons["toolbar.connect"]
+        guard connectButton.waitForExistence(timeout: 5) else {
+            throw XCTSkip("Connect toolbar button not found.")
+        }
+        connectButton.click()
+        let disconnectButton = window.toolbars.buttons["toolbar.disconnect"]
+        guard disconnectButton.waitForExistence(timeout: 30) else {
+            throw XCTSkip("Could not connect to TNS alias `local` — substitution-sheet UX test requires a live DB.")
+        }
+
+        // Replace the editor body with a script that references `&owner`.
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(textView.waitForExistence(timeout: 5))
+        textView.click()
+        textView.typeKey("a", modifierFlags: .command)
+        textView.typeKey(.delete, modifierFlags: [])
+        textView.typeText("SELECT '&owner' AS o FROM dual;")
+
+        // Cmd-Shift-R triggers Run Script.
+        window.typeKey("r", modifierFlags: [.command, .shift])
+
+        // The substitution sheet should appear.
+        let sheet = app.descendants(matching: .any)["script.substitutionSheet"]
+        XCTAssertTrue(sheet.waitForExistence(timeout: 5), "expected substitution sheet to appear for &owner")
+
+        // Cancel dismisses the sheet without running the script.
+        let cancel = app.buttons["script.substitutionSheet.cancel"]
+        XCTAssertTrue(cancel.waitForExistence(timeout: 2))
+        cancel.click()
+
+        // Sheet goes away.
+        XCTAssertFalse(sheet.waitForExistence(timeout: 2), "sheet should have dismissed on Cancel")
+    }
+
+    // MARK: - Script-output pane swap
+
+    @MainActor
+    func test_runScriptSwapsToScriptOutputPane() throws {
+        let app = launch()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10))
+
+        // Need a live connection for runScript to actually fire.
+        let connectButton = window.toolbars.buttons["toolbar.connect"]
+        guard connectButton.waitForExistence(timeout: 5) else {
+            throw XCTSkip("Connect toolbar button not found.")
+        }
+        connectButton.click()
+        let disconnectButton = window.toolbars.buttons["toolbar.disconnect"]
+        guard disconnectButton.waitForExistence(timeout: 30) else {
+            throw XCTSkip("Could not connect to TNS alias `local`.")
+        }
+
+        // Type a single-statement script (no `&`, no `:bind` — runs immediately).
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(textView.waitForExistence(timeout: 5))
+        textView.click()
+        textView.typeKey("a", modifierFlags: .command)
+        textView.typeKey(.delete, modifierFlags: [])
+        textView.typeText("SELECT 1 FROM dual;")
+
+        window.typeKey("r", modifierFlags: [.command, .shift])
+
+        let pane = app.descendants(matching: .any)["scriptOutput.pane"]
+        XCTAssertTrue(pane.waitForExistence(timeout: 5), "expected script output pane to appear after Cmd-Shift-R")
+    }
+}

--- a/MacintoraUITests/SidebarToggleCrashRegressionTests.swift
+++ b/MacintoraUITests/SidebarToggleCrashRegressionTests.swift
@@ -1,0 +1,93 @@
+//
+//  SidebarToggleCrashRegressionTests.swift
+//  MacintoraUITests
+//
+//  Regression for the Auto Layout cycle that crashed the app whenever the
+//  user toggled the NavigationSplitView sidebar after the script-runner
+//  feature landed. The crash signature was:
+//
+//    NSGenericException — The window has been marked as needing another
+//    Update Constraints in Window pass, but it has already had more Update
+//    Constraints in Window passes than there are views in the window.
+//
+//  This test launches the fixture, toggles the sidebar twice via the
+//  View menu, then exercises the editor — if the constraint loop returns,
+//  the app dies and the post-toggle assertions fail.
+//
+
+import XCTest
+
+final class SidebarToggleCrashRegressionTests: XCTestCase {
+
+    private static let fixtureURL = URL(fileURLWithPath:
+        "/Users/ilia/Documents/macintora/local.macintora")
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: Self.fixtureURL.path),
+            "Fixture document does not exist — required for UI tests."
+        )
+    }
+
+    @MainActor
+    func test_togglingSidebarTwiceDoesNotCrash() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [Self.fixtureURL.path]
+        app.launchEnvironment["OS_ACTIVITY_MODE"] = "disable"
+        app.launch()
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10), "document window did not appear")
+
+        // Wait for the editor so we know layout has settled before toggling.
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(textView.waitForExistence(timeout: 5), "editor text view not found")
+
+        // Toggle sidebar via the standard AppKit selector. SwiftUI's
+        // NavigationSplitView wires `View → Toggle Sidebar` to this.
+        toggleSidebar(app: app)
+        // Brief settle so any constraint-cycle crash has time to fire.
+        usleep(200_000)
+        XCTAssertTrue(app.state == .runningForeground, "app died after first sidebar toggle")
+        XCTAssertTrue(window.exists, "window vanished after first sidebar toggle")
+
+        toggleSidebar(app: app)
+        usleep(200_000)
+        XCTAssertTrue(app.state == .runningForeground, "app died after second sidebar toggle")
+        XCTAssertTrue(window.exists, "window vanished after second sidebar toggle")
+
+        // App must still be responsive — editor accepts focus and keystrokes.
+        textView.click()
+        textView.typeKey("a", modifierFlags: .command)
+        textView.typeKey(.delete, modifierFlags: [])
+        textView.typeText("OK")
+        let contents = (textView.value as? String) ?? ""
+        XCTAssertTrue(
+            contents.contains("OK"),
+            "editor unresponsive after sidebar toggles. value=\"\(contents)\""
+        )
+    }
+
+    @MainActor
+    private func toggleSidebar(app: XCUIApplication) {
+        // Walk the menu bar: View → Show Sidebar / Hide Sidebar / Toggle Sidebar.
+        let viewMenu = app.menuBars.menuBarItems["View"]
+        guard viewMenu.waitForExistence(timeout: 2) else {
+            XCTFail("View menu not found")
+            return
+        }
+        viewMenu.click()
+        let candidates = ["Show Sidebar", "Hide Sidebar", "Toggle Sidebar"]
+        for label in candidates {
+            let item = app.menus.menuItems[label]
+            if item.exists, item.isHittable {
+                item.click()
+                return
+            }
+        }
+        // Close the menu we opened if no item matched.
+        viewMenu.click()
+        XCTFail("No sidebar-toggle menu item found among: \(candidates)")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds end-to-end **SQL script runner**: multi-statement execution with per-statement output (status / DBMS_OUTPUT / mini-grid SELECT preview), `&` / `&&` substitution prompt, `:bind` per-unit prompts, `@` / `@@` includes, and a v1 SQL*Plus directive subset (`SET`, `DEFINE`, `UNDEFINE`, `PROMPT`, `REM`, `WHENEVER SQLERROR`, `SHOW ERRORS`).
- Fixes a **pre-existing Auto Layout cycle** in `NavigationSplitView` that was crashing the app on sidebar toggle and blocking several existing UI tests (`Macintora` repro: `_NSSplitViewItemViewWrapper.updateConstraints` → `NSWindow.setNeedsUpdateConstraints` infinite loop). Root cause: `ConnectionListView` returned an unstable safe-area inset; wrapping it in `ScrollView` breaks the cycle.
- Cleans up concurrency warnings in the new code (`@concurrent`, `any OracleErrorCarrier`) and pre-existing tests (Keychain `SecItem*` main-thread warnings, redundant `await`s).

Closes nothing yet (all phases were tracked locally); known limitation filed as #5.

## What's new

### Script runner — three run modes
- **Run Script** (`Cmd-Shift-R`) — whole document
- **Run From Cursor** (`Cmd-Opt-R`) — caret to end (or selection if non-empty)
- Legacy **Run Statement** (`Cmd-R`) is unchanged

### Pipeline
1. **Lex** the source into ordered `CommandUnit`s (SQL, PL/SQL block, SQL*Plus directive). Hand-rolled char-stream tokenizer handling all q-quote shapes, PL/SQL `BEGIN/END`/`CREATE … PROCEDURE|FUNCTION|PACKAGE [BODY]|TRIGGER|TYPE BODY` (terminated by lone \`/\`), \`@file\` vs \`t@dblink\`, comments, etc.
2. **Flatten** \`@\` / \`@@\` includes against the document's directory, with cycle detection and depth limit.
3. **Pre-scan** for substitution variables. Missing names → consolidated up-front modal (`SubstitutionInputView`); `&&` values are remembered for the document's session.
4. **Run** sequentially against a shared `OracleConnection`. The runner applies SQL*Plus directives **inline** to a `SqlPlusEnvironment`, so mid-script `DEFINE` and `WHENEVER SQLERROR EXIT` mutations are honored by subsequent units. SQL/PL-SQL units have their text substituted using the env's current defines just before execution.
5. **Bind prompts** per unit: the runner scans the resolved text for `:name` references, emits `needsBinds` events, and pauses on a continuation until the bridge resumes (via `BindVarInputView`).
6. **Output** flows into `ScriptOutputModel` — one entry per unit (`succeeded` / `failed` / `directive` / `prompt` / `note`). SELECTs render an inline collapsible mini-grid; `Open in full grid` promotes the preview to the legacy `ResultViewModel`. Failed entries carry the original-source UTF-16 range so the **Reveal** button moves the editor caret back to the offending unit even if substitution rewrote the text.
7. **`SHOW ERRORS`** runs `USER_ERRORS` for the most recently CREATEd object and emits a structured note entry.

### Settings
New `Settings → Editor → Script Runner` section:
- Show DBMS_OUTPUT inline (default on) — initial `SET SERVEROUTPUT` value
- Mini-grid row cap (50–2000, default 200)
- Stop on first error (override `WHENEVER`) (default off)

### Sidebar-toggle crash fix
`Macintora/MainApp/MainDocumentView.swift`: wrap `ConnectionListView` in `ScrollView`. Independently reproduced on `main` before this branch; verified via `MacintoraUITests/SidebarToggleCrashRegressionTests`.

## Architecture

### New files (16 source + 9 tests)
- `Macintora/Script/`: `ScriptLexer.swift`, `SubstitutionResolver.swift`, `OffsetMap.swift`, `SqlPlusDirective.swift`, `SqlPlusEnvironment.swift`, `SqlPlusInterpreter.swift`, `ScriptLoader.swift`, `ScriptError.swift`
- `Macintora/Results/`: `ScriptRunner.swift`, `ScriptRunnerEvent.swift`, `ConnectionExecutor.swift`, `OracleScriptExecutor.swift`, `ScriptOutput.swift`, `ScriptOutputView.swift`, `MiniGridView.swift`, `SubstitutionInputView.swift`, `ScriptBindPromptView.swift`
- Tests: `MacintoraTests/Script/{ScriptLexer,SubstitutionResolver,SqlPlusInterpreter,ScriptLoader}Tests.swift`, `MacintoraTests/Results/{ScriptOutputModel,ScriptRunnerDriver,ScriptRunnerLive,ScriptRunnerDirectivesLive}Tests.swift`, `MacintoraUITests/{SidebarToggleCrashRegression,ScriptRunnerUX}Tests.swift`

### Modified
- `MainDocumentVM.swift` — `runScript` / `runScriptFromCursor` / `runScriptSelection` + `fileURL` pipe-through
- `MainDocumentView.swift` — toolbar buttons, sheet modifiers, `ScrollView` sidebar fix
- `MacintoraApp.swift` — `.task(id: config.fileURL)` to track document file URL
- `ResultsController.swift` — script-mode coordination, env construction, sticky-defines persistence, promote-preview, settings reads
- `ResultViewWrapper.swift` — conditional `ScriptOutputView` swap
- `EditorSelectionBridge.swift` — `range(forUTF16:in:)` helper for click-to-source
- `SettingsView.swift` — Script Runner section + `ScriptRunnerDefaults` keys

### Concurrency
- `SqlPlusEnvironment` is owned exclusively by the runner actor (`@unchecked Sendable`).
- `OracleScriptExecutor` is a value type, methods are `@concurrent` so DB I/O runs on the global executor.
- `ScriptRunner` is an `actor`; emits an `AsyncStream<ScriptRunnerEvent>` the bridge consumes on `@MainActor`.

## Tests

**135 unit + integration tests, all green.** Live tests use the saved `c4-local` connection (skip when unavailable, mirroring `FullRefreshReproTests`).

| Suite | Coverage |
|---|---|
| `ScriptLexerTests` | 54 — all q-quote shapes, PL/SQL block triggers, `;` vs `/` termination, `@` vs `@dblink`, every recognised SQL*Plus directive |
| `SubstitutionResolverTests` | 18 — `&` / `&&`, terminator-dot, `OffsetMap` round-trip across substitution growth |
| `ScriptRunnerDriverTests` | 11 — event order for success / WHENEVER halt / continue / cancellation / DBMS_OUTPUT / mid-script `WHENEVER` flip / mid-script `DEFINE` / `needsBinds` emission and cancellation / SHOW ERRORS with and without prior CREATE |
| `ScriptOutputModelTests` | 7 — `@Observable` model semantics |
| `SqlPlusInterpreterTests` | 11 — every directive applies the correct env mutation |
| `ScriptLoaderTests` | 8 — `@`/`@@` resolution, cycles, missing files, depth limit, diamond imports |
| `ScriptRunnerLiveTests` | 1 — full multi-statement script (DDL + DML + SELECT + PL/SQL + intentional ORA error) against `c4-local` |
| `ScriptRunnerDirectivesLiveTests` | 3 — SET SERVEROUTPUT, WHENEVER SQLERROR EXIT, DEFINE substitution against `c4-local` |
| `SidebarToggleCrashRegressionTests` | 1 — sidebar toggle no longer crashes |
| `ScriptRunnerUXTests` | 3 — toolbar buttons exist, substitution sheet appears + dismisses, Cmd-Shift-R swaps to script-output pane |

Side-effects of fixing the constraint loop: 3 previously-failing UI tests in `MacintoraUITests` (editor-typing, large-document, return-key) now pass.

## Known limitation

`SET SERVEROUTPUT` mid-run mutation is not honored — the executor captures the value at construction time. Filed as #5. `WHENEVER SQLERROR` (the safety-critical one) IS honored mid-run.

## Test plan

- [ ] Build succeeds with no warnings (`xcodebuild build-for-testing -scheme Macintora -destination 'platform=macOS'`).
- [ ] Unit tests pass: `xcodebuild test -scheme Macintora -destination 'platform=macOS' -only-testing:MacintoraTests`.
- [ ] UX tests pass: `xcodebuild test -scheme Macintora -destination 'platform=macOS' -only-testing:MacintoraUITests`.
- [ ] Manually run a multi-statement script with `&owner`, `:id`, `BEGIN ... END;\n/`, an intentional ORA error, and `SHOW ERRORS`. Verify each unit's entry, click-to-source on errors, and that the substitution + bind sheets dismiss cleanly.
- [ ] Toggle the sidebar (`View → Toggle Sidebar`) twice — app stays alive.
- [ ] Settings → Editor → Script Runner: toggling each option propagates to the next run.