### PR TITLE
Editor: SQL autocompletion sourced from local DB cache

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -95,6 +95,17 @@
 		49D0ECED2F9C1D9D0047540A /* EditorLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */; };
 		49D0ECEF2F9C1DB20047540A /* MacintoraEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */; };
 		49D0ECF12F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */; };
+		49C0100100000001 /* SQLTreeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000100000001 /* SQLTreeStore.swift */; };
+		49C0100200000002 /* SQLContextAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000200000002 /* SQLContextAnalyzer.swift */; };
+		49C0100300000003 /* AliasResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000300000003 /* AliasResolver.swift */; };
+		49C0100400000004 /* CompletionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000400000004 /* CompletionItem.swift */; };
+		49C0100500000005 /* CompletionDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000500000005 /* CompletionDataSource.swift */; };
+		49C0100600000006 /* CompletionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000600000006 /* CompletionCoordinator.swift */; };
+		49C0100700000007 /* MacintoraEditor+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000700000007 /* MacintoraEditor+Completion.swift */; };
+		49C0100800000008 /* SQLParserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000800000008 /* SQLParserHelper.swift */; };
+		49C0301300000013 /* SQLContextAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301200000013 /* SQLContextAnalyzerTests.swift */; };
+		49C0301500000015 /* AliasResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301400000015 /* AliasResolverTests.swift */; };
+		49C0301700000017 /* CompletionDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301600000017 /* CompletionDataSourceTests.swift */; };
 		49D0ECF42F9C1E1E0047540A /* EditorSelectionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECF32F9C1E1E0047540A /* EditorSelectionBridgeTests.swift */; };
 		49D0ECF62F9C1EB90047540A /* GetCurrentSqlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */; };
 		49D0ED062F9C346B0047540A /* ResultViewModelIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ED052F9C346B0047540A /* ResultViewModelIntegrationTests.swift */; };
@@ -257,6 +268,17 @@
 		49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLanguage.swift; sourceTree = "<group>"; };
 		49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacintoraEditor.swift; sourceTree = "<group>"; };
 		49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MacintoraEditor+Coordinator.swift"; sourceTree = "<group>"; };
+		49C0000100000001 /* SQLTreeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLTreeStore.swift; sourceTree = "<group>"; };
+		49C0000200000002 /* SQLContextAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLContextAnalyzer.swift; sourceTree = "<group>"; };
+		49C0000300000003 /* AliasResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasResolver.swift; sourceTree = "<group>"; };
+		49C0000400000004 /* CompletionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionItem.swift; sourceTree = "<group>"; };
+		49C0000500000005 /* CompletionDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDataSource.swift; sourceTree = "<group>"; };
+		49C0000600000006 /* CompletionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCoordinator.swift; sourceTree = "<group>"; };
+		49C0000700000007 /* MacintoraEditor+Completion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MacintoraEditor+Completion.swift"; sourceTree = "<group>"; };
+		49C0000800000008 /* SQLParserHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLParserHelper.swift; sourceTree = "<group>"; };
+		49C0301200000013 /* SQLContextAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLContextAnalyzerTests.swift; sourceTree = "<group>"; };
+		49C0301400000015 /* AliasResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasResolverTests.swift; sourceTree = "<group>"; };
+		49C0301600000017 /* CompletionDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDataSourceTests.swift; sourceTree = "<group>"; };
 		49D0ECF32F9C1E1E0047540A /* EditorSelectionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSelectionBridgeTests.swift; sourceTree = "<group>"; };
 		49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentSqlTests.swift; sourceTree = "<group>"; };
 		49D0ED052F9C346B0047540A /* ResultViewModelIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewModelIntegrationTests.swift; sourceTree = "<group>"; };
@@ -559,8 +581,24 @@
 				49D0ED212F9C40000047540A /* EditorTheme.swift */,
 				49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */,
 				49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */,
+				49C0000700000007 /* MacintoraEditor+Completion.swift */,
+				49C0200000000000 /* Completion */,
 			);
 			path = Editor;
+			sourceTree = "<group>";
+		};
+		49C0200000000000 /* Completion */ = {
+			isa = PBXGroup;
+			children = (
+				49C0000100000001 /* SQLTreeStore.swift */,
+				49C0000200000002 /* SQLContextAnalyzer.swift */,
+				49C0000300000003 /* AliasResolver.swift */,
+				49C0000400000004 /* CompletionItem.swift */,
+				49C0000500000005 /* CompletionDataSource.swift */,
+				49C0000600000006 /* CompletionCoordinator.swift */,
+				49C0000800000008 /* SQLParserHelper.swift */,
+			);
+			path = Completion;
 			sourceTree = "<group>";
 		};
 		49D0ECF22F9C1E070047540A /* Editor */ = {
@@ -568,8 +606,19 @@
 			children = (
 				49D0ECF32F9C1E1E0047540A /* EditorSelectionBridgeTests.swift */,
 				49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */,
+				49C0300000000010 /* Completion */,
 			);
 			path = Editor;
+			sourceTree = "<group>";
+		};
+		49C0300000000010 /* Completion */ = {
+			isa = PBXGroup;
+			children = (
+				49C0301200000013 /* SQLContextAnalyzerTests.swift */,
+				49C0301400000015 /* AliasResolverTests.swift */,
+				49C0301600000017 /* CompletionDataSourceTests.swift */,
+			);
+			path = Completion;
 			sourceTree = "<group>";
 		};
 		49D0ED042F9C34410047540A /* Results */ = {
@@ -769,6 +818,9 @@
 				490E96D62FA426F500DDF37F /* ScriptRunnerLiveTests.swift in Sources */,
 				490E96C22FA423CE00DDF37F /* SubstitutionResolverTests.swift in Sources */,
 				49D0ECF42F9C1E1E0047540A /* EditorSelectionBridgeTests.swift in Sources */,
+				49C0301300000013 /* SQLContextAnalyzerTests.swift in Sources */,
+				49C0301500000015 /* AliasResolverTests.swift in Sources */,
+				49C0301700000017 /* CompletionDataSourceTests.swift in Sources */,
 				4982889F28B41F3A00A28B04 /* MacintoraTests.swift in Sources */,
 				AA0000130000000000000000 /* TnsParserTests.swift in Sources */,
 				490E96BC2FA422AF00DDF37F /* ScriptLexerTests.swift in Sources */,
@@ -902,6 +954,14 @@
 				49D0ECEB2F9C1D970047540A /* EditorSelectionBridge.swift in Sources */,
 				49D0ED202F9C40000047540A /* EditorTheme.swift in Sources */,
 				49D0ECEF2F9C1DB20047540A /* MacintoraEditor.swift in Sources */,
+				49C0100100000001 /* SQLTreeStore.swift in Sources */,
+				49C0100200000002 /* SQLContextAnalyzer.swift in Sources */,
+				49C0100300000003 /* AliasResolver.swift in Sources */,
+				49C0100400000004 /* CompletionItem.swift in Sources */,
+				49C0100500000005 /* CompletionDataSource.swift in Sources */,
+				49C0100600000006 /* CompletionCoordinator.swift in Sources */,
+				49C0100700000007 /* MacintoraEditor+Completion.swift in Sources */,
+				49C0100800000008 /* SQLParserHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		49C0100600000006 /* CompletionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000600000006 /* CompletionCoordinator.swift */; };
 		49C0100700000007 /* MacintoraEditor+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000700000007 /* MacintoraEditor+Completion.swift */; };
 		49C0100800000008 /* SQLParserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000800000008 /* SQLParserHelper.swift */; };
+		49C0100900000009 /* MacintoraCompletionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000900000009 /* MacintoraCompletionViewController.swift */; };
 		49C0301300000013 /* SQLContextAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301200000013 /* SQLContextAnalyzerTests.swift */; };
 		49C0301500000015 /* AliasResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301400000015 /* AliasResolverTests.swift */; };
 		49C0301700000017 /* CompletionDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301600000017 /* CompletionDataSourceTests.swift */; };
@@ -276,6 +277,7 @@
 		49C0000600000006 /* CompletionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCoordinator.swift; sourceTree = "<group>"; };
 		49C0000700000007 /* MacintoraEditor+Completion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MacintoraEditor+Completion.swift"; sourceTree = "<group>"; };
 		49C0000800000008 /* SQLParserHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLParserHelper.swift; sourceTree = "<group>"; };
+		49C0000900000009 /* MacintoraCompletionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacintoraCompletionViewController.swift; sourceTree = "<group>"; };
 		49C0301200000013 /* SQLContextAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLContextAnalyzerTests.swift; sourceTree = "<group>"; };
 		49C0301400000015 /* AliasResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasResolverTests.swift; sourceTree = "<group>"; };
 		49C0301600000017 /* CompletionDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDataSourceTests.swift; sourceTree = "<group>"; };
@@ -597,6 +599,7 @@
 				49C0000500000005 /* CompletionDataSource.swift */,
 				49C0000600000006 /* CompletionCoordinator.swift */,
 				49C0000800000008 /* SQLParserHelper.swift */,
+				49C0000900000009 /* MacintoraCompletionViewController.swift */,
 			);
 			path = Completion;
 			sourceTree = "<group>";
@@ -962,6 +965,7 @@
 				49C0100600000006 /* CompletionCoordinator.swift in Sources */,
 				49C0100700000007 /* MacintoraEditor+Completion.swift in Sources */,
 				49C0100800000008 /* SQLParserHelper.swift in Sources */,
+				49C0100900000009 /* MacintoraCompletionViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora/Editor/Completion/AliasResolver.swift
+++ b/Macintora/Editor/Completion/AliasResolver.swift
@@ -1,0 +1,187 @@
+//
+//  AliasResolver.swift
+//  Macintora
+//
+//  Walks the smallest enclosing query's `from` clause to collect the
+//  `[alias: ResolvedTable?]` map needed for column completion when the user
+//  types `t.col` against an aliased table reference. Subqueries and other
+//  non-table relations resolve to `nil` (no inferred columns in v1).
+//
+
+import Foundation
+import STPluginNeon  // re-exports SwiftTreeSitter
+
+struct ResolvedTable: Equatable, Sendable {
+    let owner: String?
+    let name: String
+}
+
+struct AliasResolver {
+
+    /// Test-friendly facade: parses `source` and returns the alias map of the
+    /// first `from` clause encountered. Avoids exposing tree-sitter types to
+    /// the test target.
+    static func parseAndResolve(_ source: String) -> [String: ResolvedTable?] {
+        let tree = SQLParserHelper.parse(source)
+        guard let root = tree.rootNode,
+              let fromNode = Self.findFromClause(in: root) else {
+            return [:]
+        }
+        return AliasResolver().aliases(in: fromNode, source: source)
+    }
+
+    private static func findFromClause(in node: SwiftTreeSitter.Node) -> SwiftTreeSitter.Node? {
+        if node.nodeType == "from" { return node }
+        for i in 0..<node.namedChildCount {
+            if let child = node.namedChild(at: i),
+               let found = findFromClause(in: child) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    /// Walks up from `node` to the nearest `from` clause and returns the
+    /// alias-to-table map. Bare table references are present under their own
+    /// upper-cased name (Oracle's default identifier folding) so callers can
+    /// look them up uniformly.
+    func aliases(near node: SwiftTreeSitter.Node, source: String) -> [String: ResolvedTable?] {
+        guard let fromNode = enclosingFrom(of: node) else { return [:] }
+        return aliases(in: fromNode, source: source)
+    }
+
+    /// Same as `aliases(near:source:)` but takes the FROM node directly. Useful
+    /// for tests.
+    func aliases(in fromNode: SwiftTreeSitter.Node, source: String) -> [String: ResolvedTable?] {
+        var map: [String: ResolvedTable?] = [:]
+        let relations = namedChildren(of: fromNode, ofType: "relation")
+        for relation in relations {
+            collect(from: relation, source: source, into: &map)
+        }
+        // FROM may also enclose nested join clauses whose own `relation`
+        // children carry additional aliases; recurse.
+        for joinKind in ["join", "cross_join", "lateral_join", "lateral_cross_join"] {
+            for join in namedChildren(of: fromNode, ofType: joinKind) {
+                for relation in namedChildren(of: join, ofType: "relation") {
+                    collect(from: relation, source: source, into: &map)
+                }
+            }
+        }
+        return map
+    }
+
+    // MARK: - Internals
+
+    private func enclosingFrom(of node: SwiftTreeSitter.Node) -> SwiftTreeSitter.Node? {
+        var current: SwiftTreeSitter.Node? = node
+        while let n = current {
+            if n.nodeType == "from" { return n }
+            current = n.parent
+        }
+        return nil
+    }
+
+    private func collect(from relation: SwiftTreeSitter.Node,
+                         source: String,
+                         into map: inout [String: ResolvedTable?]) {
+        // First named child of `relation` is one of:
+        //   subquery | invocation | object_reference | values
+        // The optional second is `_alias` (private rule, may not appear in
+        // public iteration). We pull the alias by walking the children.
+        let table = resolveTable(in: relation, source: source)
+
+        // Locate the alias identifier, if any. The grammar's `_alias` is a
+        // hidden rule, so its child identifier appears as a direct child of
+        // the relation. Heuristic: the LAST `identifier` child of `relation`
+        // that is NOT the table's `name` field is the alias.
+        let alias = aliasIdentifier(in: relation, source: source, excluding: table?.name)
+
+        switch (alias, table) {
+        case (let aliasName?, let resolved):
+            map[aliasName.uppercased()] = resolved
+        case (nil, let resolved?):
+            // Bare table reference — alias defaults to the table name.
+            map[resolved.name.uppercased()] = resolved
+        case (nil, nil):
+            break
+        }
+    }
+
+    private func resolveTable(in relation: SwiftTreeSitter.Node, source: String) -> ResolvedTable? {
+        guard let firstChild = firstNamedChild(of: relation) else { return nil }
+        switch firstChild.nodeType {
+        case "object_reference":
+            return parseObjectReference(firstChild, source: source)
+        case "subquery", "invocation", "values":
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    private func parseObjectReference(_ node: SwiftTreeSitter.Node, source: String) -> ResolvedTable? {
+        // Three valid shapes per grammar/expressions.js:
+        //   db.schema.name | schema.name | name
+        // The `name` field is always present; `schema` only on the dotted forms.
+        let nameNode = node.child(byFieldName: "name")
+        let schemaNode = node.child(byFieldName: "schema")
+        guard let nameText = nameNode.flatMap({ text(of: $0, in: source) }) else { return nil }
+        let owner = schemaNode.flatMap { text(of: $0, in: source)?.uppercased() }
+        return ResolvedTable(owner: owner, name: nameText.uppercased())
+    }
+
+    private func aliasIdentifier(in relation: SwiftTreeSitter.Node,
+                                 source: String,
+                                 excluding tableName: String?) -> String? {
+        // Walk named children in reverse and pick the first `identifier`
+        // whose text differs from the table name. Handles the implicit
+        // `_alias` hidden rule case where the alias appears as a sibling of
+        // `object_reference`.
+        let count = relation.namedChildCount
+        for i in stride(from: count - 1, through: 0, by: -1) {
+            guard let child = relation.namedChild(at: i) else { continue }
+            if child.nodeType == "identifier" {
+                if let txt = text(of: child, in: source) {
+                    if let tableName, txt.uppercased() == tableName { continue }
+                    return txt
+                }
+            }
+        }
+        return nil
+    }
+
+    private func firstNamedChild(of node: SwiftTreeSitter.Node) -> SwiftTreeSitter.Node? {
+        guard node.namedChildCount > 0 else { return nil }
+        return node.namedChild(at: 0)
+    }
+
+    private func namedChildren(of node: SwiftTreeSitter.Node, ofType type: String) -> [SwiftTreeSitter.Node] {
+        var result: [SwiftTreeSitter.Node] = []
+        for i in 0..<node.namedChildCount {
+            if let child = node.namedChild(at: i), child.nodeType == type {
+                result.append(child)
+            }
+        }
+        return result
+    }
+
+    /// Returns the substring of `source` covered by the node's byte range.
+    /// `Parser.parse(_:)` parses input as UTF-16 LE, so tree byte ranges are
+    /// `utf16CodeUnitOffset * 2`. We use `String.UTF16View` to convert back
+    /// to a Swift `String.Index` and slice natively.
+    private func text(of node: SwiftTreeSitter.Node, in source: String) -> String? {
+        let lowerByte = Int(node.byteRange.lowerBound)
+        let upperByte = Int(node.byteRange.upperBound)
+        guard lowerByte >= 0, lowerByte <= upperByte,
+              lowerByte.isMultiple(of: 2), upperByte.isMultiple(of: 2) else { return nil }
+        let utf16 = source.utf16
+        let lowerUnits = lowerByte / 2
+        let upperUnits = upperByte / 2
+        guard lowerUnits >= 0, upperUnits <= utf16.count else { return nil }
+        guard let startUTF16 = utf16.index(utf16.startIndex, offsetBy: lowerUnits, limitedBy: utf16.endIndex),
+              let endUTF16 = utf16.index(utf16.startIndex, offsetBy: upperUnits, limitedBy: utf16.endIndex),
+              let start = startUTF16.samePosition(in: source),
+              let end = endUTF16.samePosition(in: source) else { return nil }
+        return String(source[start..<end])
+    }
+}

--- a/Macintora/Editor/Completion/AliasResolver.swift
+++ b/Macintora/Editor/Completion/AliasResolver.swift
@@ -30,6 +30,22 @@ struct AliasResolver {
         return AliasResolver().aliases(in: fromNode, source: source)
     }
 
+    /// Test-friendly facade exercising the production path: parses `source`,
+    /// descends to the node under the cursor at `utf16Offset`, and walks
+    /// outward via `aliases(near:source:)`. Use this when the test cares
+    /// about the cursor location (e.g. cursor inside the SELECT-list with
+    /// FROM as a sibling clause).
+    static func parseAndResolve(_ source: String, utf16Offset: Int) -> [String: ResolvedTable?] {
+        let tree = SQLParserHelper.parse(source)
+        let cap = source.utf16.count
+        let units = max(0, min(utf16Offset, cap))
+        let target = UInt32(units * 2)
+        guard let node = tree.rootNode?.descendant(in: target..<target) else {
+            return [:]
+        }
+        return AliasResolver().aliases(near: node, source: source)
+    }
+
     private static func findFromClause(in node: SwiftTreeSitter.Node) -> SwiftTreeSitter.Node? {
         if node.nodeType == "from" { return node }
         for i in 0..<node.namedChildCount {
@@ -45,9 +61,21 @@ struct AliasResolver {
     /// alias-to-table map. Bare table references are present under their own
     /// upper-cased name (Oracle's default identifier folding) so callers can
     /// look them up uniformly.
+    ///
+    /// When the tree path can't locate a `from` (e.g. partial typing like
+    /// `select b.|` makes the parser fail to recognise the trailing FROM
+    /// clause), falls back to a source-text scan scoped to the statement
+    /// containing the cursor so column-completion still works mid-typing
+    /// without picking up a FROM from a sibling statement in the same
+    /// buffer.
     func aliases(near node: SwiftTreeSitter.Node, source: String) -> [String: ResolvedTable?] {
-        guard let fromNode = enclosingFrom(of: node) else { return [:] }
-        return aliases(in: fromNode, source: source)
+        if let fromNode = enclosingFrom(of: node) {
+            let map = aliases(in: fromNode, source: source)
+            if !map.isEmpty { return map }
+        }
+        // node.byteRange is in UTF-16 LE bytes (2 per code unit).
+        let cursorUTF16 = Int(node.byteRange.lowerBound) / 2
+        return Self.aliasesFromSourceText(source, around: cursorUTF16)
     }
 
     /// Same as `aliases(near:source:)` but takes the FROM node directly. Useful
@@ -72,11 +100,49 @@ struct AliasResolver {
 
     // MARK: - Internals
 
+    /// In `tree-sitter-sql-orcl`, `select` and `from` are *siblings* under
+    /// the enclosing `statement` — not parent/child. And cursors at
+    /// end-of-source after partial typing land on `ERROR` nodes that aren't
+    /// inside `statement` at all. We walk up and also recursively search
+    /// each ancestor's subtree so we pick up a `from` on the way out
+    /// regardless of where the cursor settled.
+    ///
+    /// We stop at statement-like boundaries so the search doesn't escape to
+    /// a sibling statement's FROM in the same buffer (`select 42 from dual;
+    /// select * from bills a;` must not resolve `a` against `from dual`).
     private func enclosingFrom(of node: SwiftTreeSitter.Node) -> SwiftTreeSitter.Node? {
         var current: SwiftTreeSitter.Node? = node
         while let n = current {
-            if n.nodeType == "from" { return n }
+            if let from = findDescendant(in: n, ofType: "from") {
+                return from
+            }
+            if Self.isQueryBoundary(n.nodeType) {
+                return nil
+            }
             current = n.parent
+        }
+        return nil
+    }
+
+    /// Node types that mark the boundary of a query block — we don't escape
+    /// past these when hunting for a sibling `from` clause.
+    private static func isQueryBoundary(_ type: String?) -> Bool {
+        switch type {
+        case "statement", "subquery", "block", "plsql_block",
+             "with", "with_query", "common_table_expression":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func findDescendant(in node: SwiftTreeSitter.Node, ofType type: String) -> SwiftTreeSitter.Node? {
+        if node.nodeType == type { return node }
+        for i in 0..<node.namedChildCount {
+            if let child = node.namedChild(at: i),
+               let found = findDescendant(in: child, ofType: type) {
+                return found
+            }
         }
         return nil
     }
@@ -163,6 +229,106 @@ struct AliasResolver {
             }
         }
         return result
+    }
+
+    /// Source-text fallback used when tree-sitter can't produce a usable
+    /// `from` node — typically when partial typing in the SELECT-list
+    /// (`SELECT b.|`) confuses the grammar and the trailing FROM never
+    /// parses. Looks for the literal `FROM` keyword inside the statement
+    /// containing `cursorUTF16` (delimited by `;`) and pulls comma-
+    /// separated `[schema.]table [[AS] alias]` specs out until it hits a
+    /// terminator (WHERE / GROUP BY / ORDER BY / HAVING / `;`).
+    ///
+    /// `cursorUTF16` defaults to `.max` for backward compatibility (treat
+    /// the entire source as one statement). Doesn't attempt to handle JOIN
+    /// syntax — we'd want a real tokeniser for that — but the common case
+    /// the editor sees mid-typing is the comma-separated form.
+    static func aliasesFromSourceText(_ source: String,
+                                      around cursorUTF16: Int = .max) -> [String: ResolvedTable?] {
+        let nsSource = source as NSString
+        let safeCursor = max(0, min(cursorUTF16, nsSource.length))
+
+        // Statement bounds = last `;` strictly before cursor → next `;` at
+        // or after cursor (or end of source).
+        let beforeCursor = nsSource.substring(to: safeCursor) as NSString
+        let lastSemicolon = beforeCursor.range(of: ";", options: .backwards).location
+        let stmtStart = (lastSemicolon == NSNotFound) ? 0 : lastSemicolon + 1
+
+        let afterCursor = nsSource.substring(from: safeCursor) as NSString
+        let nextSemicolon = afterCursor.range(of: ";").location
+        let stmtEnd = (nextSemicolon == NSNotFound)
+            ? nsSource.length
+            : safeCursor + nextSemicolon
+
+        guard stmtEnd > stmtStart else { return [:] }
+        let stmtRange = NSRange(location: stmtStart, length: stmtEnd - stmtStart)
+        let stmt = nsSource.substring(with: stmtRange)
+
+        guard let fromRange = stmt.range(of: "\\bfrom\\b",
+                                         options: [.regularExpression, .caseInsensitive]) else {
+            return [:]
+        }
+        let afterFrom = stmt[fromRange.upperBound...]
+        let terminator = afterFrom.range(
+            of: "\\b(where|group\\s+by|order\\s+by|having|connect\\s+by|start\\s+with)\\b|;",
+            options: [.regularExpression, .caseInsensitive])
+        let body = terminator.map { afterFrom[..<$0.lowerBound] } ?? afterFrom[...]
+
+        var map: [String: ResolvedTable?] = [:]
+        for relation in body.split(separator: ",") {
+            let trimmed = relation.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            // Tokenise on whitespace; ignore parens / hint blocks for v1.
+            let tokens = trimmed.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+            guard let first = tokens.first else { continue }
+            let dotted = first.split(separator: ".")
+            let owner: String?
+            let name: String
+            switch dotted.count {
+            case 1:
+                owner = nil
+                name = String(dotted[0]).uppercased()
+            case 2:
+                owner = String(dotted[0]).uppercased()
+                name = String(dotted[1]).uppercased()
+            default:
+                // Three-part `db.schema.table` — treat schema as owner.
+                owner = String(dotted[1]).uppercased()
+                name = String(dotted[2]).uppercased()
+            }
+            // Find an alias token after the table reference. Skip an
+            // optional `AS`. The alias must look like an identifier.
+            var aliasName: String? = nil
+            for tokenIndex in 1..<tokens.count {
+                let token = tokens[tokenIndex]
+                if token.lowercased() == "as" { continue }
+                let trimmedToken = token.trimmingCharacters(in: CharacterSet(charactersIn: ".,;()"))
+                if trimmedToken.isEmpty { continue }
+                if Self.looksLikeIdentifier(trimmedToken) {
+                    aliasName = trimmedToken.uppercased()
+                }
+                break
+            }
+            let resolved = ResolvedTable(owner: owner, name: name)
+            if let aliasName, aliasName != name {
+                map[aliasName] = resolved
+            } else {
+                map[name] = resolved
+            }
+        }
+        return map
+    }
+
+    private static func looksLikeIdentifier(_ s: String) -> Bool {
+        guard let first = s.unicodeScalars.first else { return false }
+        guard first.properties.isAlphabetic || first == "_" else { return false }
+        for scalar in s.unicodeScalars {
+            let ok = scalar.properties.isAlphabetic
+                || (scalar.value >= 0x30 && scalar.value <= 0x39)
+                || scalar == "_" || scalar == "$" || scalar == "#"
+            if !ok { return false }
+        }
+        return true
     }
 
     /// Returns the substring of `source` covered by the node's byte range.

--- a/Macintora/Editor/Completion/CompletionCoordinator.swift
+++ b/Macintora/Editor/Completion/CompletionCoordinator.swift
@@ -1,0 +1,252 @@
+//
+//  CompletionCoordinator.swift
+//  Macintora
+//
+//  Glue between the analyzer, the alias resolver, the cache data source, and
+//  STTextView's completion delegate. Holds per-editor state (debounce task,
+//  cached default owner). Created and owned by `MacintoraEditorRepresentable`.
+//
+
+import AppKit
+import STTextView
+import STPluginNeon  // re-exports SwiftTreeSitter
+import os
+
+/// `@unchecked Sendable` because all stored state is either main-actor-bound
+/// (debounceTask is only mutated from MainActor.assumeIsolated paths) or
+/// immutable (`treeStore`, `dataSource`, `defaultOwnerProvider`, value-type
+/// helpers). Marking the class `@MainActor` was rejected by the Swift 6.2
+/// strict-concurrency checker when the editor's nonisolated `STTextViewDelegate`
+/// witness needed to capture it across a `MainActor.assumeIsolated` boundary.
+@MainActor
+final class CompletionCoordinator: @unchecked Sendable {
+
+    let treeStore: SQLTreeStore
+    let dataSource: CompletionDataSource
+    let defaultOwnerProvider: @MainActor () -> String
+    private let analyzer = SQLContextAnalyzer()
+    private let aliasResolver = AliasResolver()
+    private let logger = Logger(subsystem: "com.iliasazonov.macintora",
+                                category: "completion.coordinator")
+
+    /// In-flight auto-trigger task; cancelled on each keystroke so we only
+    /// fire `complete(_:)` after the user pauses.
+    private var debounceTask: Task<Void, Never>?
+
+    /// Maximum suggestions per fetch; keeps the popup table snappy.
+    private let fetchLimit = 50
+
+    /// Debounce window for auto-trigger; tuned for sub-perceptible latency
+    /// without hammering the cache for every keystroke.
+    private let debounceInterval: Duration = .milliseconds(120)
+
+    init(treeStore: SQLTreeStore,
+         dataSource: CompletionDataSource,
+         defaultOwnerProvider: @escaping @MainActor () -> String) {
+        self.treeStore = treeStore
+        self.dataSource = dataSource
+        self.defaultOwnerProvider = defaultOwnerProvider
+    }
+
+    // MARK: - STTextView delegate entry points
+
+    /// Returns suggestion items for the popup. Called from the textView's
+    /// async completion delegate; safe to await here. Returns the concrete
+    /// Sendable item type so the caller can cross actor boundaries safely.
+    func items(for textView: STTextView, atUTF16Offset offset: Int) async -> [MacintoraCompletionItem] {
+        let source = textView.text ?? ""
+        let tree = treeStore.tree
+        let context = analyzer.analyze(source: source, tree: tree, utf16Offset: offset)
+
+        let owner = defaultOwnerProvider()
+
+        switch context {
+        case .none:
+            return []
+
+        case .afterFromKeyword(let prefix):
+            let tables = await dataSource.tables(prefix: prefix,
+                                                 defaultOwner: owner,
+                                                 limit: fetchLimit)
+            return tables.map { MacintoraCompletionItem.make(from: $0) }
+
+        case .columnReference(let qualifier, let prefix):
+            return await columnSuggestions(qualifier: qualifier,
+                                           prefix: prefix,
+                                           source: source,
+                                           tree: tree,
+                                           offset: offset)
+
+        case .dottedMember(let qualifier, let prefix):
+            return await dottedMemberSuggestions(qualifier: qualifier,
+                                                 prefix: prefix,
+                                                 owner: owner,
+                                                 source: source,
+                                                 tree: tree,
+                                                 offset: offset)
+
+        case .identifierPrefix(let prefix):
+            // Soft fallback: if the prefix is non-trivial, surface objects
+            // from the user's schema. Avoids spamming on a single keystroke.
+            guard prefix.count >= 2 else { return [] }
+            let objects = await dataSource.objects(prefix: prefix,
+                                                   owner: owner,
+                                                   types: ["TABLE", "VIEW", "PACKAGE"],
+                                                   limit: fetchLimit)
+            return objects.map { MacintoraCompletionItem.make(from: $0) }
+        }
+    }
+
+    /// Replaces the partial identifier under the cursor with the picked item's
+    /// `insertText`. Falls back to plain insertion if no partial range exists.
+    func insert(_ item: any STCompletionItem, into textView: STTextView) {
+        guard let item = item as? MacintoraCompletionItem else { return }
+        let source = textView.text ?? ""
+        let nsSource = source as NSString
+        let cursor = textView.selectedRange().location
+
+        // Compute the range of the in-progress identifier preceding the
+        // cursor — same backward scan the analyzer uses.
+        var start = max(0, min(cursor, nsSource.length))
+        while start > 0 {
+            let c = nsSource.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            start -= 1
+        }
+        let replaceRange = NSRange(location: start, length: cursor - start)
+        textView.replaceCharacters(in: replaceRange, with: item.insertText)
+    }
+
+    // MARK: - Auto-trigger
+
+    /// Called from the editor's text-change delegate. Decides whether the
+    /// keystroke is one that should pop the completion menu, and if so
+    /// schedules a debounced `complete(_:)` call.
+    func handleTextChange(_ textView: STTextView, replacement: String) {
+        debounceTask?.cancel()
+
+        // Suppress while marked text (IME composition) is active.
+        if textView.hasMarkedText() { return }
+
+        // Decide whether the keystroke is a completion trigger:
+        //   * `.` after an identifier → dotted member
+        //   * an identifier character with prefix length ≥ 1 → prefix typing
+        guard shouldAutoTrigger(textView: textView, replacement: replacement) else { return }
+
+        debounceTask = Task { [weak self, weak textView] in
+            guard let self else { return }
+            try? await Task.sleep(for: debounceInterval)
+            if Task.isCancelled { return }
+            guard let textView else { return }
+            textView.complete(self)
+        }
+    }
+
+    /// Cancel any scheduled auto-trigger. Caller should invoke this when the
+    /// cursor moves away from the identifier or the popup should dismiss.
+    func cancelPending() {
+        debounceTask?.cancel()
+        debounceTask = nil
+    }
+
+    private func shouldAutoTrigger(textView: STTextView, replacement: String) -> Bool {
+        guard let last = replacement.unicodeScalars.last else { return false }
+        if last == "." { return true }
+        if SourceScanner.isIdentifierChar(last) {
+            // Require at least one identifier character before the cursor to
+            // avoid popping for a stray keystroke.
+            let source = textView.text ?? ""
+            let cursor = textView.selectedRange().location
+            return SourceScanner.scan(source: source, utf16Offset: cursor).prefix.count >= 1
+        }
+        return false
+    }
+
+    // MARK: - Column / dotted-member resolution
+
+    private func columnSuggestions(qualifier: String?,
+                                   prefix: String,
+                                   source: String,
+                                   tree: SwiftTreeSitter.Tree?,
+                                   offset: Int) async -> [MacintoraCompletionItem] {
+        let aliases = currentAliases(source: source, tree: tree, offset: offset)
+
+        // Resolve qualifier through alias map first; fall back to treating it
+        // as a literal table name.
+        if let qualifier {
+            let upper = qualifier.uppercased()
+            if let resolved = aliases[upper] ?? nil {
+                return await fetchColumns(table: resolved, prefix: prefix)
+            }
+            // Unknown alias — try direct lookup against the user's schema.
+            return await fetchColumns(table: ResolvedTable(owner: nil, name: upper),
+                                      prefix: prefix)
+        }
+
+        // No qualifier: union columns of every aliased table in scope.
+        var seen = Set<String>()
+        var items: [MacintoraCompletionItem] = []
+        for resolved in aliases.values.compactMap({ $0 }) {
+            let cols = await dataSource.columns(tableName: resolved.name,
+                                                owner: resolved.owner,
+                                                prefix: prefix,
+                                                limit: fetchLimit)
+            for c in cols where !seen.contains(c.columnName) {
+                seen.insert(c.columnName)
+                items.append(MacintoraCompletionItem.make(from: c))
+            }
+        }
+        return items
+    }
+
+    private func dottedMemberSuggestions(qualifier: String,
+                                         prefix: String,
+                                         owner: String,
+                                         source: String,
+                                         tree: SwiftTreeSitter.Tree?,
+                                         offset: Int) async -> [MacintoraCompletionItem] {
+        let aliases = currentAliases(source: source, tree: tree, offset: offset)
+        let upper = qualifier.uppercased()
+
+        // 1) Alias → table columns.
+        if let resolved = aliases[upper] ?? nil {
+            return await fetchColumns(table: resolved, prefix: prefix)
+        }
+
+        // 2) Treat as schema → list its objects (tables/views/packages).
+        let objects = await dataSource.objects(
+            prefix: prefix,
+            owner: upper,
+            types: ["TABLE", "VIEW", "PACKAGE"],
+            limit: fetchLimit)
+        if !objects.isEmpty {
+            return objects.map { MacintoraCompletionItem.make(from: $0) }
+        }
+
+        // 3) Treat as table → its columns under the user's schema.
+        return await dataSource
+            .columns(tableName: upper, owner: owner, prefix: prefix, limit: fetchLimit)
+            .map { MacintoraCompletionItem.make(from: $0) }
+    }
+
+    private func fetchColumns(table: ResolvedTable, prefix: String) async -> [MacintoraCompletionItem] {
+        let cols = await dataSource.columns(tableName: table.name,
+                                            owner: table.owner,
+                                            prefix: prefix,
+                                            limit: fetchLimit)
+        return cols.map { MacintoraCompletionItem.make(from: $0) }
+    }
+
+    private func currentAliases(source: String,
+                                tree: SwiftTreeSitter.Tree?,
+                                offset: Int) -> [String: ResolvedTable?] {
+        guard let tree else { return [:] }
+        // Parser uses UTF-16 LE; byte offset is `utf16Offset * 2`.
+        let cap = source.utf16.count
+        let units = max(0, min(offset, cap))
+        let byteOffset = UInt32(units * 2)
+        guard let node = tree.rootNode?.descendant(in: byteOffset..<byteOffset)
+        else { return [:] }
+        return aliasResolver.aliases(near: node, source: source)
+    }
+}

--- a/Macintora/Editor/Completion/CompletionCoordinator.swift
+++ b/Macintora/Editor/Completion/CompletionCoordinator.swift
@@ -33,6 +33,13 @@ final class CompletionCoordinator: @unchecked Sendable {
     /// fire `complete(_:)` after the user pauses.
     private var debounceTask: Task<Void, Never>?
 
+    /// Set true while we're applying a chosen completion. STTextView fires
+    /// `didChangeTextIn` synchronously inside `replaceCharacters`, which
+    /// would otherwise be interpreted as the user typing the inserted text
+    /// and immediately re-pop the completion menu. We swallow the next
+    /// notification by checking this flag in `handleTextChange`.
+    private var isInsertingCompletion = false
+
     /// Maximum suggestions per fetch; keeps the popup table snappy.
     private let fetchLimit = 50
 
@@ -59,15 +66,17 @@ final class CompletionCoordinator: @unchecked Sendable {
         let context = analyzer.analyze(source: source, tree: tree, utf16Offset: offset)
 
         let owner = defaultOwnerProvider()
+        editorCompletionLog.info("items(): context=\(String(describing: context), privacy: .public) preferredOwner=\(owner, privacy: .public) (sort hint, not a filter) treeAvailable=\(tree != nil)")
 
         switch context {
         case .none:
             return []
 
         case .afterFromKeyword(let prefix):
-            let tables = await dataSource.tables(prefix: prefix,
-                                                 defaultOwner: owner,
+            let tables = await dataSource.tables(search: prefix,
+                                                 preferredOwner: owner,
                                                  limit: fetchLimit)
+            editorCompletionLog.info("afterFromKeyword: search=\(prefix, privacy: .public) preferredOwner=\(owner, privacy: .public) → \(tables.count) tables")
             return tables.map { MacintoraCompletionItem.make(from: $0) }
 
         case .columnReference(let qualifier, let prefix):
@@ -87,12 +96,15 @@ final class CompletionCoordinator: @unchecked Sendable {
 
         case .identifierPrefix(let prefix):
             // Soft fallback: if the prefix is non-trivial, surface objects
-            // from the user's schema. Avoids spamming on a single keystroke.
+            // across all cached schemas; the user's connected schema is
+            // sorted first as a relevance hint.
             guard prefix.count >= 2 else { return [] }
-            let objects = await dataSource.objects(prefix: prefix,
-                                                   owner: owner,
+            let objects = await dataSource.objects(search: prefix,
+                                                   owner: nil,
+                                                   preferredOwner: owner,
                                                    types: ["TABLE", "VIEW", "PACKAGE"],
                                                    limit: fetchLimit)
+            editorCompletionLog.info("identifierPrefix: prefix=\(prefix, privacy: .public) preferredOwner=\(owner, privacy: .public) → \(objects.count) objects")
             return objects.map { MacintoraCompletionItem.make(from: $0) }
         }
     }
@@ -114,7 +126,9 @@ final class CompletionCoordinator: @unchecked Sendable {
             start -= 1
         }
         let replaceRange = NSRange(location: start, length: cursor - start)
+        isInsertingCompletion = true
         textView.replaceCharacters(in: replaceRange, with: item.insertText)
+        isInsertingCompletion = false
     }
 
     // MARK: - Auto-trigger
@@ -125,19 +139,42 @@ final class CompletionCoordinator: @unchecked Sendable {
     func handleTextChange(_ textView: STTextView, replacement: String) {
         debounceTask?.cancel()
 
+        // The text change is the result of accepting a popup item — don't
+        // treat the inserted text as a fresh user keystroke and re-pop the
+        // menu. The flag is reset by `insert(_:into:)` after the call
+        // returns; STTextView fires the change notification synchronously.
+        if isInsertingCompletion {
+            editorCompletionLog.debug("auto-trigger skipped: completion insertion in progress")
+            return
+        }
+
         // Suppress while marked text (IME composition) is active.
-        if textView.hasMarkedText() { return }
+        if textView.hasMarkedText() {
+            editorCompletionLog.debug("auto-trigger skipped: marked text active")
+            return
+        }
 
         // Decide whether the keystroke is a completion trigger:
         //   * `.` after an identifier → dotted member
         //   * an identifier character with prefix length ≥ 1 → prefix typing
-        guard shouldAutoTrigger(textView: textView, replacement: replacement) else { return }
+        guard shouldAutoTrigger(textView: textView, replacement: replacement) else {
+            editorCompletionLog.debug("auto-trigger skipped: shouldAutoTrigger=false replacement=\(replacement, privacy: .public)")
+            return
+        }
 
+        editorCompletionLog.debug("auto-trigger scheduled (debounce \(self.debounceInterval)) replacement=\(replacement, privacy: .public)")
         debounceTask = Task { [weak self, weak textView] in
             guard let self else { return }
             try? await Task.sleep(for: debounceInterval)
-            if Task.isCancelled { return }
-            guard let textView else { return }
+            if Task.isCancelled {
+                editorCompletionLog.debug("auto-trigger cancelled after sleep")
+                return
+            }
+            guard let textView else {
+                editorCompletionLog.debug("auto-trigger: textView gone after sleep")
+                return
+            }
+            editorCompletionLog.debug("auto-trigger firing: textView.complete(_:)")
             textView.complete(self)
         }
     }
@@ -189,7 +226,7 @@ final class CompletionCoordinator: @unchecked Sendable {
         for resolved in aliases.values.compactMap({ $0 }) {
             let cols = await dataSource.columns(tableName: resolved.name,
                                                 owner: resolved.owner,
-                                                prefix: prefix,
+                                                search: prefix,
                                                 limit: fetchLimit)
             for c in cols where !seen.contains(c.columnName) {
                 seen.insert(c.columnName)
@@ -215,7 +252,7 @@ final class CompletionCoordinator: @unchecked Sendable {
 
         // 2) Treat as schema → list its objects (tables/views/packages).
         let objects = await dataSource.objects(
-            prefix: prefix,
+            search: prefix,
             owner: upper,
             types: ["TABLE", "VIEW", "PACKAGE"],
             limit: fetchLimit)
@@ -223,16 +260,18 @@ final class CompletionCoordinator: @unchecked Sendable {
             return objects.map { MacintoraCompletionItem.make(from: $0) }
         }
 
-        // 3) Treat as table → its columns under the user's schema.
+        // 3) Treat as table → columns of any cached table with this name,
+        // regardless of schema. The user typed an unqualified table name
+        // and may legitimately be reaching across grants.
         return await dataSource
-            .columns(tableName: upper, owner: owner, prefix: prefix, limit: fetchLimit)
+            .columns(tableName: upper, owner: nil, search: prefix, limit: fetchLimit)
             .map { MacintoraCompletionItem.make(from: $0) }
     }
 
     private func fetchColumns(table: ResolvedTable, prefix: String) async -> [MacintoraCompletionItem] {
         let cols = await dataSource.columns(tableName: table.name,
                                             owner: table.owner,
-                                            prefix: prefix,
+                                            search: prefix,
                                             limit: fetchLimit)
         return cols.map { MacintoraCompletionItem.make(from: $0) }
     }

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -25,32 +25,60 @@ actor CompletionDataSource {
         self.context.name = "completion-datasource"
     }
 
-    /// Tables/views whose name starts with `prefix`. Searches the user's
-    /// schema first; callers may run a second query for a different owner.
-    func tables(prefix: String,
-                defaultOwner: String,
+    /// Tables/views whose name **contains** `search` (case-insensitive).
+    /// Sourced from `DBCacheObject` (filtered by `type_ IN ("TABLE", "VIEW")`),
+    /// which is the comprehensive catalog the DB browser shows. Reading from
+    /// `DBCacheTable` would miss any table whose details haven't been
+    /// fetched yet.
+    ///
+    /// Returns matches across every cached schema; the connected schema is
+    /// sorted first as a relevance hint (NOT a filter), and prefix matches
+    /// rank above infix matches so a typed `EMP` still puts `EMPLOYEES`
+    /// ahead of `XYZ_EMP`. Empty `search` is scoped to `preferredOwner` only
+    /// to avoid dumping the entire cache.
+    func tables(search: String,
+                preferredOwner: String,
                 limit: Int) async -> [TableSuggestion] {
         await fetch { ctx -> [TableSuggestion] in
-            let request = DBCacheTable.fetchRequest()
-            let upperPrefix = prefix.uppercased()
-            let upperOwner = defaultOwner.uppercased()
-            if upperPrefix.isEmpty {
-                request.predicate = NSPredicate(format: "owner_ = %@", upperOwner)
+            let request = DBCacheObject.fetchRequest()
+            let upperSearch = search.uppercased()
+            let upperOwner = preferredOwner.uppercased()
+            // Anything you can SELECT from in the FROM clause. Oracle's
+            // ALL_OBJECTS.object_type uses the literal strings below; we
+            // include synonyms because they typically resolve to a table or
+            // view the user wants to query.
+            var predicates: [NSPredicate] = [
+                NSPredicate(format: "type_ IN %@",
+                            ["TABLE", "VIEW", "MATERIALIZED VIEW", "SYNONYM"])
+            ]
+            if upperSearch.isEmpty {
+                predicates.append(NSPredicate(format: "owner_ = %@", upperOwner))
             } else {
-                request.predicate = NSPredicate(
-                    format: "owner_ = %@ AND name_ BEGINSWITH[c] %@",
-                    upperOwner, upperPrefix)
+                predicates.append(NSPredicate(format: "name_ CONTAINS[c] %@", upperSearch))
             }
-            request.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
-            request.fetchLimit = limit
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "owner_", ascending: true),
+                NSSortDescriptor(key: "name_", ascending: true)
+            ]
+            // Pull a wider candidate set than the popup limit so the
+            // prefix-first / preferred-owner-first reordering done in Swift
+            // below doesn't get truncated to a noisy slice.
+            request.fetchLimit = max(limit * 4, limit)
             do {
                 let rows = try ctx.fetch(request)
-                return rows.map { row in
+                let suggestions = rows.map { row in
                     TableSuggestion(
                         owner: row.owner_ ?? "",
                         name: row.name_ ?? "",
-                        isView: row.isView)
+                        objectType: row.type_ ?? "TABLE")
                 }
+                return self.rank(suggestions,
+                                 name: \.name,
+                                 owner: \.owner,
+                                 search: upperSearch,
+                                 preferredOwner: upperOwner,
+                                 limit: limit)
             } catch {
                 self.logger.error("tables fetch failed: \(error.localizedDescription, privacy: .public)")
                 return []
@@ -58,36 +86,44 @@ actor CompletionDataSource {
         }
     }
 
-    /// Columns of a specific table. `owner` defaults to whatever was saved on
-    /// the cached row when nil.
+    /// Columns of a specific table. `search` is matched as a case-insensitive
+    /// substring against the column name. When `owner` is nil the query is
+    /// open to every schema with a matching table (relevant when the user
+    /// typed an alias whose backing table couldn't be schema-disambiguated).
     func columns(tableName: String,
                  owner: String?,
-                 prefix: String,
+                 search: String,
                  limit: Int) async -> [ColumnSuggestion] {
         await fetch { ctx -> [ColumnSuggestion] in
             let request = DBCacheTableColumn.fetchRequest()
             let upperTable = tableName.uppercased()
-            let upperPrefix = prefix.uppercased()
+            let upperSearch = search.uppercased()
             var predicates: [NSPredicate] = [
                 NSPredicate(format: "tableName_ = %@", upperTable)
             ]
             if let owner {
                 predicates.append(NSPredicate(format: "owner_ = %@", owner.uppercased()))
             }
-            if !upperPrefix.isEmpty {
-                predicates.append(NSPredicate(format: "columnName_ BEGINSWITH[c] %@", upperPrefix))
+            if !upperSearch.isEmpty {
+                predicates.append(NSPredicate(format: "columnName_ CONTAINS[c] %@", upperSearch))
             }
             request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-            request.fetchLimit = limit
+            // Wider fetch so the prefix-first re-rank below has material to
+            // sort.
+            request.fetchLimit = max(limit * 4, limit)
             do {
                 let rows = try ctx.fetch(request)
-                return rows.map { row in
+                let suggestions = rows.map { row in
                     ColumnSuggestion(
                         owner: row.owner_ ?? "",
                         tableName: row.tableName_ ?? "",
                         columnName: row.columnName_ ?? "",
                         dataType: row.dataType_ ?? "")
                 }
+                return self.rankByPrefixThenInfix(suggestions,
+                                                  name: \.columnName,
+                                                  search: upperSearch,
+                                                  limit: limit)
             } catch {
                 self.logger.error("columns fetch failed: \(error.localizedDescription, privacy: .public)")
                 return []
@@ -95,20 +131,25 @@ actor CompletionDataSource {
         }
     }
 
-    /// Objects (tables, views, packages, etc.) for `owner.prefix...` style
-    /// completion (e.g. when the user types `HR.`).
-    func objects(prefix: String,
+    /// Objects (tables, views, packages, etc.). `search` is a case-insensitive
+    /// substring match against the name. When `owner` is non-nil the query
+    /// is strictly scoped to that schema — used for `schema.<search>`. When
+    /// `owner` is nil the query spans every schema and the `preferredOwner`
+    /// (if any) is sorted first; prefix matches still rank above infix.
+    func objects(search: String,
                  owner: String?,
+                 preferredOwner: String? = nil,
                  types: [String],
                  limit: Int) async -> [ObjectSuggestion] {
         await fetch { ctx -> [ObjectSuggestion] in
             let request = DBCacheObject.fetchRequest()
+            let upperSearch = search.uppercased()
             var predicates: [NSPredicate] = []
             if let owner {
                 predicates.append(NSPredicate(format: "owner_ = %@", owner.uppercased()))
             }
-            if !prefix.isEmpty {
-                predicates.append(NSPredicate(format: "name_ BEGINSWITH[c] %@", prefix.uppercased()))
+            if !upperSearch.isEmpty {
+                predicates.append(NSPredicate(format: "name_ CONTAINS[c] %@", upperSearch))
             }
             if !types.isEmpty {
                 predicates.append(NSPredicate(format: "type_ IN %@", types))
@@ -120,20 +161,100 @@ actor CompletionDataSource {
                 NSSortDescriptor(key: "type_", ascending: true),
                 NSSortDescriptor(key: "name_", ascending: true)
             ]
-            request.fetchLimit = limit
+            request.fetchLimit = max(limit * 4, limit)
             do {
                 let rows = try ctx.fetch(request)
-                return rows.map { row in
+                let suggestions = rows.map { row in
                     ObjectSuggestion(
                         owner: row.owner_ ?? "",
                         name: row.name_ ?? "",
                         type: row.type_ ?? "")
                 }
+                if owner != nil {
+                    // Strict-owner case: just rank by prefix-vs-infix.
+                    return self.rankByPrefixThenInfix(suggestions,
+                                                     name: \.name,
+                                                     search: upperSearch,
+                                                     limit: limit)
+                }
+                let preferred = preferredOwner?.uppercased() ?? ""
+                return self.rank(suggestions,
+                                 name: \.name,
+                                 owner: \.owner,
+                                 search: upperSearch,
+                                 preferredOwner: preferred,
+                                 limit: limit)
             } catch {
                 self.logger.error("objects fetch failed: \(error.localizedDescription, privacy: .public)")
                 return []
             }
         }
+    }
+
+    /// Two-tier rank for a list returned by a `CONTAINS[c]` predicate:
+    /// 1. name-prefix matches first, infix matches after;
+    /// 2. within each tier, rows whose owner equals `preferredOwner` first.
+    /// Stable within tiers (CoreData's sort order is preserved). Truncated
+    /// to `limit`. `nonisolated` because the helper is pure and called from
+    /// the actor's background `context.perform` closure.
+    nonisolated private func rank<T>(_ rows: [T],
+                                     name: KeyPath<T, String>,
+                                     owner: KeyPath<T, String>,
+                                     search: String,
+                                     preferredOwner: String,
+                                     limit: Int) -> [T] {
+        guard !search.isEmpty else {
+            return ownerFirst(rows, owner: owner, preferredOwner: preferredOwner, limit: limit)
+        }
+        var prefixHits: [T] = []
+        var infixHits: [T] = []
+        for row in rows {
+            if row[keyPath: name].uppercased().hasPrefix(search) {
+                prefixHits.append(row)
+            } else {
+                infixHits.append(row)
+            }
+        }
+        let prefixOrdered = ownerFirst(prefixHits, owner: owner, preferredOwner: preferredOwner, limit: limit)
+        let infixOrdered = ownerFirst(infixHits, owner: owner, preferredOwner: preferredOwner, limit: limit)
+        return Array((prefixOrdered + infixOrdered).prefix(limit))
+    }
+
+    /// Same idea as `rank(_:name:owner:search:preferredOwner:limit:)` but
+    /// without the owner-tier — used when the caller has already constrained
+    /// by owner (e.g. `schema.<search>`).
+    nonisolated private func rankByPrefixThenInfix<T>(_ rows: [T],
+                                                      name: KeyPath<T, String>,
+                                                      search: String,
+                                                      limit: Int) -> [T] {
+        guard !search.isEmpty else { return Array(rows.prefix(limit)) }
+        var prefixHits: [T] = []
+        var infixHits: [T] = []
+        for row in rows {
+            if row[keyPath: name].uppercased().hasPrefix(search) {
+                prefixHits.append(row)
+            } else {
+                infixHits.append(row)
+            }
+        }
+        return Array((prefixHits + infixHits).prefix(limit))
+    }
+
+    nonisolated private func ownerFirst<T>(_ rows: [T],
+                                           owner: KeyPath<T, String>,
+                                           preferredOwner: String,
+                                           limit: Int) -> [T] {
+        guard !preferredOwner.isEmpty else { return Array(rows.prefix(limit)) }
+        var preferred: [T] = []
+        var others: [T] = []
+        for row in rows {
+            if row[keyPath: owner] == preferredOwner {
+                preferred.append(row)
+            } else {
+                others.append(row)
+            }
+        }
+        return Array((preferred + others).prefix(limit))
     }
 
     // MARK: - Background-context wrapper

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -1,0 +1,153 @@
+//
+//  CompletionDataSource.swift
+//  Macintora
+//
+//  Background-context CoreData reader for the editor's autocompletion popup.
+//  All fetches return Sendable plain structs (never `NSManagedObject`s) so
+//  results can cross actor boundaries safely. Holds its own background
+//  context for the lifetime of the editor instance.
+//
+
+import Foundation
+import CoreData
+import os
+
+actor CompletionDataSource {
+
+    private let container: NSPersistentContainer
+    private let context: NSManagedObjectContext
+    private let logger = Logger(subsystem: "com.iliasazonov.macintora",
+                                category: "completion.datasource")
+
+    init(persistenceController: PersistenceController) {
+        self.container = persistenceController.container
+        self.context = persistenceController.container.newBackgroundContext()
+        self.context.name = "completion-datasource"
+    }
+
+    /// Tables/views whose name starts with `prefix`. Searches the user's
+    /// schema first; callers may run a second query for a different owner.
+    func tables(prefix: String,
+                defaultOwner: String,
+                limit: Int) async -> [TableSuggestion] {
+        await fetch { ctx -> [TableSuggestion] in
+            let request = DBCacheTable.fetchRequest()
+            let upperPrefix = prefix.uppercased()
+            let upperOwner = defaultOwner.uppercased()
+            if upperPrefix.isEmpty {
+                request.predicate = NSPredicate(format: "owner_ = %@", upperOwner)
+            } else {
+                request.predicate = NSPredicate(
+                    format: "owner_ = %@ AND name_ BEGINSWITH[c] %@",
+                    upperOwner, upperPrefix)
+            }
+            request.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
+            request.fetchLimit = limit
+            do {
+                let rows = try ctx.fetch(request)
+                return rows.map { row in
+                    TableSuggestion(
+                        owner: row.owner_ ?? "",
+                        name: row.name_ ?? "",
+                        isView: row.isView)
+                }
+            } catch {
+                self.logger.error("tables fetch failed: \(error.localizedDescription, privacy: .public)")
+                return []
+            }
+        }
+    }
+
+    /// Columns of a specific table. `owner` defaults to whatever was saved on
+    /// the cached row when nil.
+    func columns(tableName: String,
+                 owner: String?,
+                 prefix: String,
+                 limit: Int) async -> [ColumnSuggestion] {
+        await fetch { ctx -> [ColumnSuggestion] in
+            let request = DBCacheTableColumn.fetchRequest()
+            let upperTable = tableName.uppercased()
+            let upperPrefix = prefix.uppercased()
+            var predicates: [NSPredicate] = [
+                NSPredicate(format: "tableName_ = %@", upperTable)
+            ]
+            if let owner {
+                predicates.append(NSPredicate(format: "owner_ = %@", owner.uppercased()))
+            }
+            if !upperPrefix.isEmpty {
+                predicates.append(NSPredicate(format: "columnName_ BEGINSWITH[c] %@", upperPrefix))
+            }
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+            request.fetchLimit = limit
+            do {
+                let rows = try ctx.fetch(request)
+                return rows.map { row in
+                    ColumnSuggestion(
+                        owner: row.owner_ ?? "",
+                        tableName: row.tableName_ ?? "",
+                        columnName: row.columnName_ ?? "",
+                        dataType: row.dataType_ ?? "")
+                }
+            } catch {
+                self.logger.error("columns fetch failed: \(error.localizedDescription, privacy: .public)")
+                return []
+            }
+        }
+    }
+
+    /// Objects (tables, views, packages, etc.) for `owner.prefix...` style
+    /// completion (e.g. when the user types `HR.`).
+    func objects(prefix: String,
+                 owner: String?,
+                 types: [String],
+                 limit: Int) async -> [ObjectSuggestion] {
+        await fetch { ctx -> [ObjectSuggestion] in
+            let request = DBCacheObject.fetchRequest()
+            var predicates: [NSPredicate] = []
+            if let owner {
+                predicates.append(NSPredicate(format: "owner_ = %@", owner.uppercased()))
+            }
+            if !prefix.isEmpty {
+                predicates.append(NSPredicate(format: "name_ BEGINSWITH[c] %@", prefix.uppercased()))
+            }
+            if !types.isEmpty {
+                predicates.append(NSPredicate(format: "type_ IN %@", types))
+            }
+            if !predicates.isEmpty {
+                request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+            }
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "type_", ascending: true),
+                NSSortDescriptor(key: "name_", ascending: true)
+            ]
+            request.fetchLimit = limit
+            do {
+                let rows = try ctx.fetch(request)
+                return rows.map { row in
+                    ObjectSuggestion(
+                        owner: row.owner_ ?? "",
+                        name: row.name_ ?? "",
+                        type: row.type_ ?? "")
+                }
+            } catch {
+                self.logger.error("objects fetch failed: \(error.localizedDescription, privacy: .public)")
+                return []
+            }
+        }
+    }
+
+    // MARK: - Background-context wrapper
+
+    /// Runs `body` on the background context and returns its result. Wraps
+    /// `context.perform` in a continuation so the actor can `await` the
+    /// CoreData callback.
+    private func fetch<T: Sendable>(_ body: @escaping @Sendable (NSManagedObjectContext) -> T) async -> T {
+        let context = self.context
+        return await withCheckedContinuation { continuation in
+            context.perform {
+                let result = body(context)
+                continuation.resume(returning: result)
+            }
+        }
+    }
+}

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -1,0 +1,153 @@
+//
+//  CompletionItem.swift
+//  Macintora
+//
+//  Sendable suggestion structs returned by `CompletionDataSource` plus the
+//  AppKit row view (`MacintoraCompletionItem`) that the built-in
+//  `STCompletionWindowController` renders.
+//
+
+import AppKit
+import STTextView
+
+// MARK: - Sendable suggestion structs
+
+struct TableSuggestion: Sendable, Hashable {
+    let owner: String
+    let name: String
+    let isView: Bool
+}
+
+struct ColumnSuggestion: Sendable, Hashable {
+    let owner: String
+    let tableName: String
+    let columnName: String
+    let dataType: String
+}
+
+struct ObjectSuggestion: Sendable, Hashable {
+    let owner: String
+    let name: String
+    let type: String   // "TABLE" / "VIEW" / "PACKAGE" / "PROCEDURE" / etc.
+}
+
+// MARK: - STCompletionItem implementation
+
+/// Single row in the completion popup. Marked `@unchecked Sendable` because
+/// the only mutable state is the lazy `view`, and AppKit accesses it solely
+/// from the main actor (the popup is main-actor-bound). All other properties
+/// are `let`s and trivially Sendable.
+final class MacintoraCompletionItem: NSObject, STCompletionItem, @unchecked Sendable {
+
+    enum Kind: Sendable {
+        case table
+        case view
+        case column
+        case schema
+        case packageObject
+        case generic
+    }
+
+    let id = UUID()
+    let displayText: String      // shown in the popup row
+    let insertText: String       // what gets pasted into the editor
+    let secondaryText: String?   // dim secondary (owner / data type / etc.)
+    let kind: Kind
+
+    init(displayText: String,
+         insertText: String,
+         secondaryText: String?,
+         kind: Kind) {
+        self.displayText = displayText
+        self.insertText = insertText
+        self.secondaryText = secondaryText
+        self.kind = kind
+    }
+
+    // STCompletionItem requires `view`. Built on demand on the main actor.
+    var view: NSView {
+        MainActor.assumeIsolated { makeView() }
+    }
+
+    private func makeView() -> NSView {
+        let container = NSStackView()
+        container.orientation = .horizontal
+        container.alignment = .centerY
+        container.spacing = 6
+        container.edgeInsets = NSEdgeInsets(top: 2, left: 6, bottom: 2, right: 6)
+
+        let icon = NSImageView()
+        icon.image = NSImage(systemSymbolName: kind.symbolName,
+                             accessibilityDescription: kind.symbolName)
+        icon.symbolConfiguration = .init(pointSize: 11, weight: .regular)
+        icon.contentTintColor = .secondaryLabelColor
+        icon.setContentHuggingPriority(.required, for: .horizontal)
+
+        let name = NSTextField(labelWithString: displayText)
+        name.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        name.textColor = .labelColor
+        name.lineBreakMode = .byTruncatingTail
+
+        container.addArrangedSubview(icon)
+        container.addArrangedSubview(name)
+
+        if let secondaryText {
+            let detail = NSTextField(labelWithString: secondaryText)
+            detail.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+            detail.textColor = .secondaryLabelColor
+            detail.lineBreakMode = .byTruncatingTail
+            detail.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            container.addArrangedSubview(detail)
+        }
+
+        return container
+    }
+}
+
+private extension MacintoraCompletionItem.Kind {
+    var symbolName: String {
+        switch self {
+        case .table: return "tablecells"
+        case .view: return "rectangle.stack"
+        case .column: return "list.bullet"
+        case .schema: return "person.crop.square"
+        case .packageObject: return "shippingbox"
+        case .generic: return "circle"
+        }
+    }
+}
+
+// MARK: - Mapping suggestions to STCompletionItem
+
+extension MacintoraCompletionItem {
+    static func make(from t: TableSuggestion) -> MacintoraCompletionItem {
+        MacintoraCompletionItem(
+            displayText: t.name,
+            insertText: t.name,
+            secondaryText: t.owner,
+            kind: t.isView ? .view : .table)
+    }
+
+    static func make(from c: ColumnSuggestion) -> MacintoraCompletionItem {
+        MacintoraCompletionItem(
+            displayText: c.columnName,
+            insertText: c.columnName,
+            secondaryText: c.dataType,
+            kind: .column)
+    }
+
+    static func make(from o: ObjectSuggestion) -> MacintoraCompletionItem {
+        let kind: Kind
+        switch o.type {
+        case "TABLE": kind = .table
+        case "VIEW": kind = .view
+        case "PACKAGE", "PACKAGE BODY": kind = .packageObject
+        default: kind = .generic
+        }
+        return MacintoraCompletionItem(
+            displayText: o.name,
+            insertText: o.name,
+            secondaryText: "\(o.owner) · \(o.type)",
+            kind: kind)
+    }
+}

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -137,6 +137,11 @@ private extension MacintoraCompletionItem.Kind {
 // MARK: - Mapping suggestions to STCompletionItem
 
 extension MacintoraCompletionItem {
+    // Oracle stores unquoted identifiers in upper-case, which is what the
+    // popup shows. The inserted text is lower-cased so user-written SQL
+    // stays in the lower-case style the user prefers; quoted identifiers
+    // would need a different policy and are out of scope for v1.
+
     static func make(from t: TableSuggestion) -> MacintoraCompletionItem {
         let kind: Kind
         switch t.objectType {
@@ -147,7 +152,7 @@ extension MacintoraCompletionItem {
         }
         return MacintoraCompletionItem(
             displayText: t.name,
-            insertText: t.name,
+            insertText: t.name.lowercased(),
             secondaryText: "\(t.owner) · \(t.objectType)",
             kind: kind)
     }
@@ -155,7 +160,7 @@ extension MacintoraCompletionItem {
     static func make(from c: ColumnSuggestion) -> MacintoraCompletionItem {
         MacintoraCompletionItem(
             displayText: c.columnName,
-            insertText: c.columnName,
+            insertText: c.columnName.lowercased(),
             secondaryText: c.dataType,
             kind: .column)
     }
@@ -170,7 +175,7 @@ extension MacintoraCompletionItem {
         }
         return MacintoraCompletionItem(
             displayText: o.name,
-            insertText: o.name,
+            insertText: o.name.lowercased(),
             secondaryText: "\(o.owner) · \(o.type)",
             kind: kind)
     }

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -8,6 +8,7 @@
 //
 
 import AppKit
+import SwiftUI
 import STTextView
 
 // MARK: - Sendable suggestion structs
@@ -15,7 +16,10 @@ import STTextView
 struct TableSuggestion: Sendable, Hashable {
     let owner: String
     let name: String
-    let isView: Bool
+    /// Raw `ALL_OBJECTS.object_type` from the cache — `"TABLE"`, `"VIEW"`,
+    /// `"MATERIALIZED VIEW"`, `"SYNONYM"`, etc. Drives both the popup row's
+    /// secondary text and the icon choice.
+    let objectType: String
 }
 
 struct ColumnSuggestion: Sendable, Hashable {
@@ -70,37 +74,50 @@ final class MacintoraCompletionItem: NSObject, STCompletionItem, @unchecked Send
     }
 
     private func makeView() -> NSView {
-        let container = NSStackView()
-        container.orientation = .horizontal
-        container.alignment = .centerY
-        container.spacing = 6
-        container.edgeInsets = NSEdgeInsets(top: 2, left: 6, bottom: 2, right: 6)
+        // SwiftUI inside `NSHostingView` handles row sizing/layout cleanly —
+        // an earlier raw NSStackView attempt left the stack collapsed at
+        // (0,0,0,0) inside the cell because NSTableView's autoresizing
+        // contract for plain NSViews didn't propagate to the inner stack.
+        // STTextView's own demo (`TextEdit/Mac/CompletionItem.swift`) uses
+        // the same NSHostingView pattern.
+        NSHostingView(rootView: CompletionRowView(
+            displayText: displayText,
+            secondaryText: secondaryText,
+            symbolName: kind.symbolName))
+    }
+}
 
-        let icon = NSImageView()
-        icon.image = NSImage(systemSymbolName: kind.symbolName,
-                             accessibilityDescription: kind.symbolName)
-        icon.symbolConfiguration = .init(pointSize: 11, weight: .regular)
-        icon.contentTintColor = .secondaryLabelColor
-        icon.setContentHuggingPriority(.required, for: .horizontal)
+// MARK: - SwiftUI row
 
-        let name = NSTextField(labelWithString: displayText)
-        name.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
-        name.textColor = .labelColor
-        name.lineBreakMode = .byTruncatingTail
+private struct CompletionRowView: View {
+    let displayText: String
+    let secondaryText: String?
+    let symbolName: String
 
-        container.addArrangedSubview(icon)
-        container.addArrangedSubview(name)
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: symbolName)
+                .symbolRenderingMode(.monochrome)
+                .foregroundStyle(Color(nsColor: .controlAccentColor))
+                .frame(width: 14, alignment: .center)
 
-        if let secondaryText {
-            let detail = NSTextField(labelWithString: secondaryText)
-            detail.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-            detail.textColor = .secondaryLabelColor
-            detail.lineBreakMode = .byTruncatingTail
-            detail.setContentHuggingPriority(.defaultLow, for: .horizontal)
-            container.addArrangedSubview(detail)
+            Text(displayText)
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(Color(nsColor: .labelColor))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            if let secondaryText {
+                Text(secondaryText)
+                    .font(.callout)
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 0)
         }
-
-        return container
+        .padding(.horizontal, 6)
     }
 }
 
@@ -121,11 +138,18 @@ private extension MacintoraCompletionItem.Kind {
 
 extension MacintoraCompletionItem {
     static func make(from t: TableSuggestion) -> MacintoraCompletionItem {
-        MacintoraCompletionItem(
+        let kind: Kind
+        switch t.objectType {
+        case "TABLE": kind = .table
+        case "VIEW", "MATERIALIZED VIEW": kind = .view
+        case "SYNONYM": kind = .generic
+        default: kind = .table
+        }
+        return MacintoraCompletionItem(
             displayText: t.name,
             insertText: t.name,
-            secondaryText: t.owner,
-            kind: t.isView ? .view : .table)
+            secondaryText: "\(t.owner) · \(t.objectType)",
+            kind: kind)
     }
 
     static func make(from c: ColumnSuggestion) -> MacintoraCompletionItem {

--- a/Macintora/Editor/Completion/MacintoraCompletionViewController.swift
+++ b/Macintora/Editor/Completion/MacintoraCompletionViewController.swift
@@ -1,0 +1,72 @@
+//
+//  MacintoraCompletionViewController.swift
+//  Macintora
+//
+//  STTextView's stock `STCompletionViewController` ships with two visual
+//  defaults that don't fit Macintora's editor look:
+//
+//  1. `NSVisualEffectView` material `.windowBackground` — flat and a bit
+//     heavy. We swap it for `.popover`, which is what the system uses for
+//     pop-up menus and looks softer behind the suggestion list.
+//
+//  2. Selected-row fill `NSColor.highlightColor.withAlphaComponent(1)` —
+//     paints a near-white opaque rectangle on light mode (the bug that hid
+//     row text earlier — see `CompletionItem.swift`). We replace it with
+//     `.selectedContentBackgroundColor`, the standard accent-tinted
+//     selection used in Finder, source-list sidebars, etc.
+//
+//  Wired via the `textViewCompletionViewController(_:)` delegate hook on
+//  the editor's `Coordinator`. STTextView still owns the popup window
+//  itself (positioning, key handling, dismissal); we only customise the
+//  view controller it embeds.
+//
+
+import AppKit
+import STTextView
+
+final class MacintoraCompletionViewController: STCompletionViewController {
+
+    override func loadView() {
+        super.loadView()
+        // The base controller adds a single `NSVisualEffectView` as the
+        // first subview of `view`. Find it and soften the material.
+        if let blur = view.subviews.compactMap({ $0 as? NSVisualEffectView }).first {
+            blur.material = .popover
+            blur.blendingMode = .behindWindow
+        }
+    }
+
+    override func tableView(_ tableView: NSTableView,
+                            rowViewForRow row: Int) -> NSTableRowView? {
+        MacintoraCompletionRowView(
+            parentCornerRadius: view.layer?.cornerRadius ?? 8,
+            inset: tableView.enclosingScrollView?.contentInsets.top ?? 0)
+    }
+}
+
+/// Mirrors STTextView's private `STTableRowView` but draws the selection
+/// with the system's accent-tinted selection color instead of solid white.
+private final class MacintoraCompletionRowView: NSTableRowView {
+
+    private let parentCornerRadius: CGFloat
+    private let inset: CGFloat
+
+    init(parentCornerRadius: CGFloat, inset: CGFloat) {
+        self.parentCornerRadius = parentCornerRadius * 2
+        self.inset = inset
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func drawSelection(in dirtyRect: NSRect) {
+        guard isSelected, let context = NSGraphicsContext.current?.cgContext else { return }
+        context.saveGState()
+        let radius = max(0, (parentCornerRadius - inset) / 2)
+        let path = NSBezierPath(roundedRect: bounds, xRadius: radius, yRadius: radius)
+        context.setFillColor(NSColor.alternateSelectedControlTextColor.cgColor)
+        path.fill()
+        context.restoreGState()
+    }
+}

--- a/Macintora/Editor/Completion/SQLContextAnalyzer.swift
+++ b/Macintora/Editor/Completion/SQLContextAnalyzer.swift
@@ -1,0 +1,271 @@
+//
+//  SQLContextAnalyzer.swift
+//  Macintora
+//
+//  Decides what kind of completion to offer at a given cursor position by
+//  combining a tree-sitter parse tree with a small backward-tokenizer scan
+//  over the raw source. The backward scan keeps suggestions working when the
+//  parse tree contains ERROR nodes mid-typing — common while the user is
+//  still typing the identifier we're about to complete.
+//
+
+import Foundation
+import STPluginNeon  // re-exports SwiftTreeSitter
+
+/// Where the cursor sits and what kind of names should be offered.
+enum CompletionContext: Equatable, Sendable {
+    /// Inside a FROM clause (or right after the FROM keyword) — suggest tables/views.
+    case afterFromKeyword(prefix: String)
+
+    /// Inside SELECT/WHERE/JOIN/GROUP BY/ORDER BY/HAVING/CONNECT BY/START WITH —
+    /// suggest column names. `qualifier` is nil when the user has not typed
+    /// `alias.` (in which case all in-scope columns are candidates).
+    case columnReference(qualifier: String?, prefix: String)
+
+    /// User typed `qualifier.partial` somewhere. Resolution order is
+    /// alias → table columns, schema → objects (no package members in v1).
+    case dottedMember(qualifier: String, prefix: String)
+
+    /// No structural cue; just a bare identifier prefix. Used as a soft
+    /// fallback (the data source may still surface relevant tables/objects).
+    case identifierPrefix(prefix: String)
+
+    /// Cursor is in a position where completion isn't useful (string literal,
+    /// comment, etc.). Caller should suppress the popup.
+    case none
+}
+
+struct SQLContextAnalyzer {
+
+    /// One-shot analyzer for tests: parses `source` with the Oracle SQL
+    /// grammar and runs `analyze(...)` against the resulting tree. Lets the
+    /// test target avoid linking SwiftTreeSitter directly.
+    static func parseAndAnalyze(_ source: String, utf16Offset: Int) -> CompletionContext {
+        let tree = SQLParserHelper.parse(source)
+        return SQLContextAnalyzer().analyze(source: source, tree: tree, utf16Offset: utf16Offset)
+    }
+
+    /// `source` and `tree` should describe the same buffer; some lag is
+    /// acceptable. `utf16Offset` is the cursor location in NSString units.
+    func analyze(source: String,
+                 tree: SwiftTreeSitter.Tree?,
+                 utf16Offset: Int) -> CompletionContext {
+
+        // Backward-scan for the prefix and (optional) dotted qualifier purely
+        // on the source string. This works even when the tree is broken at
+        // the cursor (ERROR node) — common during typing.
+        let scan = SourceScanner.scan(source: source, utf16Offset: utf16Offset)
+
+        if scan.insideStringOrComment {
+            return .none
+        }
+
+        if let qualifier = scan.qualifier {
+            return .dottedMember(qualifier: qualifier, prefix: scan.prefix)
+        }
+
+        // Map the cursor to a tree node to detect the enclosing clause.
+        // Parser is fed UTF-16 LE, so byte offset = `utf16Offset * 2`. Probe
+        // both the cursor byte and the preceding byte; at end-of-source the
+        // exact-cursor probe lands on the root, but the previous-byte probe
+        // sits inside the last identifier/relation we care about.
+        if let tree {
+            let cap = source.utf16.count
+            let units = max(0, min(utf16Offset, cap))
+            let target = UInt32(units * 2)
+            var probes: [UInt32] = [target]
+            if target >= 2 { probes.append(target - 2) }
+            for probe in probes {
+                guard let node = tree.rootNode?.descendant(in: probe..<probe),
+                      let kind = enclosingClauseKind(of: node) else { continue }
+                switch kind {
+                case .from:
+                    return .afterFromKeyword(prefix: scan.prefix)
+                case .columnContext:
+                    return .columnReference(qualifier: nil, prefix: scan.prefix)
+                }
+            }
+        }
+
+        // Fallback: incomplete inputs like "SELECT * FROM " don't produce
+        // a `from` node yet. Look backward in the source for the most recent
+        // SQL clause keyword to decide the context.
+        switch lastClauseKeyword(source: source, before: utf16Offset) {
+        case "FROM", "UPDATE", "INTO", "JOIN":
+            return .afterFromKeyword(prefix: scan.prefix)
+        case "WHERE", "AND", "OR", "ON", "BY", "HAVING", "SELECT":
+            return .columnReference(qualifier: nil, prefix: scan.prefix)
+        default:
+            return .identifierPrefix(prefix: scan.prefix)
+        }
+    }
+
+    /// Walks the source backwards from `cursor` looking for the most recent
+    /// SQL clause keyword (FROM/WHERE/...). Used as a fallback when the tree
+    /// fails to localise context for incomplete input.
+    private func lastClauseKeyword(source: String, before cursor: Int) -> String {
+        let utf16 = source.utf16
+        let cap = utf16.count
+        let safe = max(0, min(cursor, cap))
+        // Walk back word by word.
+        var i = safe
+        while i > 0 {
+            // Skip non-letter chars.
+            while i > 0 {
+                let ch = utf16[utf16.index(utf16.startIndex, offsetBy: i - 1)]
+                if let scalar = Unicode.Scalar(ch), scalar.properties.isAlphabetic { break }
+                i -= 1
+            }
+            // Capture the word.
+            var end = i
+            while i > 0 {
+                let ch = utf16[utf16.index(utf16.startIndex, offsetBy: i - 1)]
+                guard let scalar = Unicode.Scalar(ch), scalar.properties.isAlphabetic else { break }
+                i -= 1
+            }
+            if i == end { break }
+            let startIdx = utf16.index(utf16.startIndex, offsetBy: i)
+            let endIdx = utf16.index(utf16.startIndex, offsetBy: end)
+            if let start = startIdx.samePosition(in: source),
+               let stop = endIdx.samePosition(in: source) {
+                let word = source[start..<stop].uppercased()
+                let clauseKeywords: Set<String> = [
+                    "FROM", "WHERE", "AND", "OR", "JOIN", "ON", "BY",
+                    "GROUP", "ORDER", "HAVING", "UPDATE", "INTO", "SELECT"
+                ]
+                if clauseKeywords.contains(word) {
+                    return word
+                }
+            }
+            // Continue backwards from before this word.
+        }
+        return ""
+    }
+
+    // MARK: - Tree walk
+
+    private enum ClauseKind {
+        case from
+        case columnContext
+    }
+
+    /// Walk ancestors looking for a node type that maps to a known clause.
+    /// Returns nil when nothing meaningful is found; the caller falls back
+    /// to identifier-prefix completion.
+    private func enclosingClauseKind(of node: SwiftTreeSitter.Node) -> ClauseKind? {
+        var current: SwiftTreeSitter.Node? = node
+        while let n = current {
+            switch n.nodeType {
+            case "from", "relation":
+                return .from
+            case "where", "join", "cross_join", "lateral_join", "lateral_cross_join",
+                 "group_by", "order_by", "having", "select",
+                 "start_with_clause", "connect_by_clause":
+                return .columnContext
+            default:
+                current = n.parent
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Source scanner (tree-independent prefix / qualifier extraction)
+
+/// Looks at the raw source around the cursor to extract the identifier prefix
+/// the user is currently typing and, if the previous non-whitespace token is
+/// a `.`, the qualifier identifier preceding that dot. Tolerates the parse
+/// tree being out of date with the most recent keystroke.
+struct SourceScanner {
+    let prefix: String
+    let qualifier: String?
+    let insideStringOrComment: Bool
+
+    static func scan(source: String, utf16Offset: Int) -> SourceScanner {
+        let ns = source as NSString
+        let safeOffset = max(0, min(utf16Offset, ns.length))
+
+        // 1) Walk backward from the cursor while the character is an
+        //    identifier character — this is the prefix.
+        var prefixStart = safeOffset
+        while prefixStart > 0 {
+            let prev = ns.character(at: prefixStart - 1)
+            guard let scalar = Unicode.Scalar(prev), Self.isIdentifierChar(scalar) else { break }
+            prefixStart -= 1
+        }
+        let prefix = ns.substring(with: NSRange(location: prefixStart, length: safeOffset - prefixStart))
+
+        // 2) If the character immediately before the prefix is a `.`, walk
+        //    backward over identifier characters to grab the qualifier.
+        var qualifier: String? = nil
+        if prefixStart > 0, ns.character(at: prefixStart - 1) == 0x2E /* '.' */ {
+            var qualEnd = prefixStart - 1
+            var qualStart = qualEnd
+            while qualStart > 0 {
+                let c = ns.character(at: qualStart - 1)
+                guard let scalar = Unicode.Scalar(c), Self.isIdentifierChar(scalar) else { break }
+                qualStart -= 1
+            }
+            if qualStart < qualEnd {
+                qualifier = ns.substring(with: NSRange(location: qualStart, length: qualEnd - qualStart))
+            }
+        }
+
+        // 3) Cheap heuristic: refuse completion inside string literals or
+        //    line comments. We scan the current line backward for an
+        //    unmatched single-quote or a `--` sequence.
+        let lineStart = Self.lineStart(in: ns, before: safeOffset)
+        let inString = Self.unmatchedQuote(in: ns, from: lineStart, to: safeOffset)
+        let inComment = Self.hasLineCommentMarker(in: ns, from: lineStart, to: safeOffset)
+
+        return SourceScanner(prefix: prefix,
+                             qualifier: qualifier,
+                             insideStringOrComment: inString || inComment)
+    }
+
+    static func isIdentifierChar(_ scalar: Unicode.Scalar) -> Bool {
+        // SQL identifiers: letters, digits, underscore, '$', '#'.
+        if scalar.isASCII {
+            let v = scalar.value
+            return (v >= 0x30 && v <= 0x39) ||  // 0-9
+                   (v >= 0x41 && v <= 0x5A) ||  // A-Z
+                   (v >= 0x61 && v <= 0x7A) ||  // a-z
+                   v == 0x5F || v == 0x24 || v == 0x23
+        }
+        return scalar.properties.isAlphabetic
+    }
+
+    private static func lineStart(in ns: NSString, before offset: Int) -> Int {
+        var i = offset
+        while i > 0 {
+            let c = ns.character(at: i - 1)
+            if c == 0x0A || c == 0x0D { break }
+            i -= 1
+        }
+        return i
+    }
+
+    private static func unmatchedQuote(in ns: NSString, from start: Int, to end: Int) -> Bool {
+        var inSingle = false
+        var i = start
+        while i < end {
+            let c = ns.character(at: i)
+            if c == 0x27 /* ' */ { inSingle.toggle() }
+            i += 1
+        }
+        return inSingle
+    }
+
+    private static func hasLineCommentMarker(in ns: NSString, from start: Int, to end: Int) -> Bool {
+        guard end - start >= 2 else { return false }
+        var i = start
+        while i < end - 1 {
+            if ns.character(at: i) == 0x2D /* - */ && ns.character(at: i + 1) == 0x2D {
+                return true
+            }
+            i += 1
+        }
+        return false
+    }
+}
+

--- a/Macintora/Editor/Completion/SQLParserHelper.swift
+++ b/Macintora/Editor/Completion/SQLParserHelper.swift
@@ -1,0 +1,32 @@
+//
+//  SQLParserHelper.swift
+//  Macintora
+//
+//  One-shot parsing helper used by tests (and any code that needs an ad-hoc
+//  parse result without driving the editor). Production hot-paths get their
+//  tree from the Neon plugin via `SQLTreeStore` — they should not call this.
+//
+
+import Foundation
+import STPluginNeon  // re-exports SwiftTreeSitter
+import TreeSitterResource
+
+enum SQLParserHelper {
+    /// Parses `source` with the bundled Oracle SQL grammar and returns the
+    /// resulting tree. Crashes on parser-init or parse failure since both
+    /// indicate a programming error (grammar misconfigured, etc.) rather
+    /// than user input we can recover from.
+    static func parse(_ source: String) -> SwiftTreeSitter.Tree {
+        let parser = Parser()
+        let language = SwiftTreeSitter.Language(language: TreeSitterLanguage.sqlOrcl.parser)
+        try! parser.setLanguage(language)
+        // `parse` returns the parser's internal `MutableTree`. The `Tree`
+        // wrapper isn't directly accessible, but `copy()` produces one.
+        return parser.parse(source)!.copy()!
+    }
+
+    /// Test/debug aid: returns the tree's S-expression for the given source.
+    static func sExpression(_ source: String) -> String {
+        parse(source).rootNode?.sExpressionString ?? "<no tree>"
+    }
+}

--- a/Macintora/Editor/Completion/SQLTreeStore.swift
+++ b/Macintora/Editor/Completion/SQLTreeStore.swift
@@ -1,0 +1,32 @@
+//
+//  SQLTreeStore.swift
+//  Macintora
+//
+//  Holds the latest tree-sitter parse tree produced by the Neon highlighting
+//  plugin so completion code can run structural queries without spinning up
+//  a second `Parser`. Updated on the main actor from `NeonPlugin.onTreeUpdated`.
+//
+
+import Foundation
+import STPluginNeon  // re-exports SwiftTreeSitter
+
+@MainActor
+@Observable
+final class SQLTreeStore {
+    private(set) var tree: SwiftTreeSitter.Tree?
+
+    init() {}
+
+    func update(_ tree: SwiftTreeSitter.Tree) {
+        self.tree = tree
+    }
+
+    /// Smallest enclosing node for the given byte offset, walking down from
+    /// the root. The parser is fed UTF-16 LE, so `offset` is the byte offset
+    /// into that representation: `nsString_utf16_offset * 2`. Returns nil
+    /// when no tree has been received yet.
+    func node(atByteOffset offset: UInt32) -> SwiftTreeSitter.Node? {
+        guard let root = tree?.rootNode else { return nil }
+        return root.descendant(in: offset..<offset)
+    }
+}

--- a/Macintora/Editor/EditorLanguage.swift
+++ b/Macintora/Editor/EditorLanguage.swift
@@ -25,10 +25,11 @@ enum EditorLanguage: Sendable, Hashable {
     /// with the app-level `Theme` enum in `MacintoraApp.swift` (a light/dark
     /// `AppStorage` preference).
     @MainActor
-    func neonPlugin(theme: STPluginNeonAppKit.Theme = .default) -> NeonPlugin {
+    func neonPlugin(theme: STPluginNeonAppKit.Theme = .default,
+                    onTreeUpdated: NeonPlugin.TreeUpdateHandler? = nil) -> NeonPlugin {
         switch self {
         case .sql, .plsql:
-            return NeonPlugin(theme: theme, language: .sqlOrcl)
+            return NeonPlugin(theme: theme, language: .sqlOrcl, onTreeUpdated: onTreeUpdated)
         }
     }
 }

--- a/Macintora/Editor/MacintoraEditor+Completion.swift
+++ b/Macintora/Editor/MacintoraEditor+Completion.swift
@@ -36,17 +36,28 @@ extension MacintoraEditorRepresentable.Coordinator {
     @MainActor
     func textView(_ textView: STTextView,
                   completionItemsAtLocation location: any NSTextLocation) async -> [any STCompletionItem]? {
-        guard let coordinator = completionCoordinator else { return nil }
+        guard let coordinator = completionCoordinator else {
+            editorCompletionLog.notice("async completion: no coordinator (config not yet installed)")
+            return nil
+        }
         let utf16Offset = textView.textContentManager.offset(
             from: textView.textContentManager.documentRange.location,
             to: location)
         let items: [MacintoraCompletionItem] =
             await coordinator.items(for: textView, atUTF16Offset: utf16Offset)
+        editorCompletionLog.info("async completion: offset=\(utf16Offset) returned \(items.count) item(s)")
         return items.isEmpty ? nil : items
     }
 
     @MainActor
     func textView(_ textView: STTextView, insertCompletionItem item: any STCompletionItem) {
         completionCoordinator?.insert(item, into: textView)
+    }
+
+    /// Provide our customised view controller (softer material + accent-tinted
+    /// selection). STTextView keeps owning the popup window and key handling.
+    @MainActor
+    func textViewCompletionViewController(_ textView: STTextView) -> any STCompletionViewControllerProtocol {
+        MacintoraCompletionViewController()
     }
 }

--- a/Macintora/Editor/MacintoraEditor+Completion.swift
+++ b/Macintora/Editor/MacintoraEditor+Completion.swift
@@ -1,0 +1,52 @@
+//
+//  MacintoraEditor+Completion.swift
+//  Macintora
+//
+//  Connects the STTextView completion-delegate protocol to the host app's
+//  `CompletionCoordinator`. Kept in its own file so the completion surface
+//  is easy to audit alongside the rest of the editor delegate code.
+//
+//  AppKit invokes the delegate methods on the main thread even though the
+//  protocol declares them `nonisolated`. We use `MainActor.assumeIsolated`
+//  (a sync precondition assertion) for synchronous main-actor reads, then
+//  await the coordinator's async items() method whose return type is the
+//  concrete Sendable `MacintoraCompletionItem` so the result can cross the
+//  actor boundary cleanly.
+//
+
+import AppKit
+@preconcurrency import STTextView
+import STPluginNeon  // re-exports SwiftTreeSitter
+
+extension MacintoraEditorRepresentable.Coordinator {
+
+    /// Sync hook — prefer the async variant. Returning nil signals the
+    /// textView to fall through to `performAsyncCompletion`.
+    @MainActor
+    func textView(_ textView: STTextView,
+                  completionItemsAtLocation location: any NSTextLocation) -> [any STCompletionItem]? {
+        nil
+    }
+
+    /// Async completion provider. Marked `@MainActor` (a more-isolated witness
+    /// for the nonisolated protocol requirement, allowed in Swift 6.2) so we
+    /// can read `STTextView` state and pass non-Sendable AppKit types like
+    /// `NSTextLocation` without bridging gymnastics. AppKit always invokes
+    /// these delegate methods on the main thread, so this matches reality.
+    @MainActor
+    func textView(_ textView: STTextView,
+                  completionItemsAtLocation location: any NSTextLocation) async -> [any STCompletionItem]? {
+        guard let coordinator = completionCoordinator else { return nil }
+        let utf16Offset = textView.textContentManager.offset(
+            from: textView.textContentManager.documentRange.location,
+            to: location)
+        let items: [MacintoraCompletionItem] =
+            await coordinator.items(for: textView, atUTF16Offset: utf16Offset)
+        return items.isEmpty ? nil : items
+    }
+
+    @MainActor
+    func textView(_ textView: STTextView, insertCompletionItem item: any STCompletionItem) {
+        completionCoordinator?.insert(item, into: textView)
+    }
+}

--- a/Macintora/Editor/MacintoraEditor+Coordinator.swift
+++ b/Macintora/Editor/MacintoraEditor+Coordinator.swift
@@ -10,6 +10,10 @@
 import AppKit
 import SwiftUI
 import STTextView
+import os
+
+let editorCompletionLog = Logger(subsystem: "com.iliasazonov.macintora",
+                                 category: "editor.completion")
 
 extension MacintoraEditorRepresentable {
     /// `STTextViewDelegate` predates Swift Concurrency and isn't annotated, so
@@ -29,8 +33,18 @@ extension MacintoraEditorRepresentable {
         /// to prevent `updateNSView` from immediately writing the same value back.
         var isPushingSelection = false
 
-        /// Optional. Wired only when the editor is configured with a
-        /// `EditorCompletionConfig` (worksheet); read-only viewers leave this nil.
+        /// Always present once `makeNSView` has run; receives parse-tree
+        /// updates from the Neon plugin regardless of whether completion has
+        /// been wired yet. The CompletionCoordinator (created lazily once a
+        /// non-nil `EditorCompletionConfig` arrives) reads from this same
+        /// instance, so tree updates that fire before the coordinator exists
+        /// are not lost.
+        var treeStore: SQLTreeStore?
+
+        /// Lazily wired when `EditorCompletionConfig` arrives — typically
+        /// from `updateNSView` because SwiftUI's `.onAppear` runs the config
+        /// constructor AFTER `makeNSView`. Read-only viewers (DBBrowser
+        /// source/formatted) leave this nil for the editor's lifetime.
         var completionCoordinator: CompletionCoordinator?
 
         /// Last UTF-16 cursor location seen in the selection callback. Used to
@@ -43,15 +57,23 @@ extension MacintoraEditorRepresentable {
             self._selection = selection
         }
 
+        /// Builds the `CompletionCoordinator` using the previously installed
+        /// `treeStore`. Idempotent: subsequent calls are no-ops while a
+        /// coordinator is already in place.
         @MainActor
-        func textView(_ textView: STTextView, willChangeTextIn affectedCharRange: NSTextRange, replacementString: String?) {
-            // Capture the replacement string here so we can decide whether to
-            // auto-trigger after the change applies. STTextViewDelegate's
-            // didChange notification doesn't carry it.
-            pendingReplacement = replacementString
+        func installCompletionCoordinator(with config: EditorCompletionConfig) {
+            guard completionCoordinator == nil else { return }
+            guard let treeStore else {
+                editorCompletionLog.error("installCompletionCoordinator called before treeStore was set")
+                return
+            }
+            let dataSource = CompletionDataSource(persistenceController: config.persistenceController)
+            completionCoordinator = CompletionCoordinator(
+                treeStore: treeStore,
+                dataSource: dataSource,
+                defaultOwnerProvider: config.defaultOwnerProvider)
+            editorCompletionLog.info("installCompletionCoordinator: completion wired for editor")
         }
-
-        private var pendingReplacement: String?
 
         @MainActor
         func textViewDidChangeText(_ notification: Notification) {
@@ -62,13 +84,20 @@ extension MacintoraEditorRepresentable {
             if text != newText {
                 text = newText
             }
-            // Auto-trigger evaluation runs on every text change. The
-            // coordinator decides whether the keystroke warrants popping the
-            // completion menu and debounces accordingly.
-            if let replacement = pendingReplacement {
-                pendingReplacement = nil
-                completionCoordinator?.handleTextChange(textView, replacement: replacement)
-            }
+        }
+
+        /// `didChangeTextIn:replacementString:` is what STTextView calls with
+        /// the actual edit payload. Earlier I was capturing it via
+        /// `willChangeTextIn:replacementString:`, but my signature used
+        /// `String?` while the protocol requires `String`, so Swift never
+        /// matched it as a witness and the auto-trigger silently never fired.
+        @MainActor
+        func textView(_ textView: STTextView,
+                      didChangeTextIn affectedCharRange: NSTextRange,
+                      replacementString: String) {
+            guard !isApplyingExternalUpdate else { return }
+            editorCompletionLog.debug("didChangeTextIn replacement=\(replacementString, privacy: .public) coordinator=\(self.completionCoordinator != nil)")
+            completionCoordinator?.handleTextChange(textView, replacement: replacementString)
         }
 
         @MainActor

--- a/Macintora/Editor/MacintoraEditor+Coordinator.swift
+++ b/Macintora/Editor/MacintoraEditor+Coordinator.swift
@@ -17,7 +17,7 @@ extension MacintoraEditorRepresentable {
     /// callbacks on the main thread, so the `STTextView` reads inside are
     /// scoped with `MainActor.assumeIsolated { }` — that gives the compiler
     /// the main-actor access it needs while keeping the witness nonisolated.
-    final class Coordinator: NSObject, STTextViewDelegate {
+    final class Coordinator: NSObject, @MainActor STTextViewDelegate {
         @Binding var text: String
         @Binding var selection: Range<String.Index>
 
@@ -29,21 +29,49 @@ extension MacintoraEditorRepresentable {
         /// to prevent `updateNSView` from immediately writing the same value back.
         var isPushingSelection = false
 
+        /// Optional. Wired only when the editor is configured with a
+        /// `EditorCompletionConfig` (worksheet); read-only viewers leave this nil.
+        var completionCoordinator: CompletionCoordinator?
+
+        /// Last UTF-16 cursor location seen in the selection callback. Used to
+        /// detect when the cursor moves outside the in-progress identifier so
+        /// auto-trigger can be cancelled.
+        private var lastCursor: Int = 0
+
         init(text: Binding<String>, selection: Binding<Range<String.Index>>) {
             self._text = text
             self._selection = selection
         }
 
+        @MainActor
+        func textView(_ textView: STTextView, willChangeTextIn affectedCharRange: NSTextRange, replacementString: String?) {
+            // Capture the replacement string here so we can decide whether to
+            // auto-trigger after the change applies. STTextViewDelegate's
+            // didChange notification doesn't carry it.
+            pendingReplacement = replacementString
+        }
+
+        private var pendingReplacement: String?
+
+        @MainActor
         func textViewDidChangeText(_ notification: Notification) {
             guard !isApplyingExternalUpdate,
                   let textView = notification.object as? STTextView
             else { return }
-            let newText = MainActor.assumeIsolated { textView.text ?? "" }
+            let newText = textView.text ?? ""
             if text != newText {
                 text = newText
             }
+            // Auto-trigger evaluation runs on every text change. The
+            // coordinator decides whether the keystroke warrants popping the
+            // completion menu and debounces accordingly.
+            if let replacement = pendingReplacement {
+                pendingReplacement = nil
+                completionCoordinator?.handleTextChange(textView, replacement: replacement)
+            }
         }
 
+        @MainActor
         func textViewDidChangeSelection(_ notification: Notification) {
             guard !isApplyingExternalUpdate,
                   let textView = notification.object as? STTextView
@@ -51,9 +79,8 @@ extension MacintoraEditorRepresentable {
             // Read the upstream text from the view, not the binding: the binding may
             // still be catching up after a keystroke, which would leave the NSRange
             // out of bounds for the old value.
-            let (nsRange, source) = MainActor.assumeIsolated {
-                (textView.selectedRange(), textView.text ?? "")
-            }
+            let nsRange = textView.selectedRange()
+            let source = textView.text ?? ""
             let bridged = EditorSelectionBridge.range(for: nsRange, in: source)
                 ?? EditorSelectionBridge.emptyRange(in: source)
             if bridged != selection {
@@ -61,6 +88,12 @@ extension MacintoraEditorRepresentable {
                 selection = bridged
                 isPushingSelection = false
             }
+            // Cancel any pending auto-trigger when the cursor jumps. Without
+            // this the popup can fire after the user has clicked elsewhere.
+            if abs(nsRange.location - lastCursor) > 1 {
+                completionCoordinator?.cancelPending()
+            }
+            lastCursor = nsRange.location
         }
     }
 }

--- a/Macintora/Editor/MacintoraEditor.swift
+++ b/Macintora/Editor/MacintoraEditor.swift
@@ -20,6 +20,21 @@ import SwiftUI
 import STTextView
 import STPluginNeon
 
+/// Per-editor configuration for autocompletion. Pass `nil` to opt out
+/// (read-only viewers in DBBrowser etc.). The worksheet provides one tied
+/// to the active connection's `PersistenceController` and username.
+struct EditorCompletionConfig {
+    let persistenceController: PersistenceController
+    /// Closure so the editor picks up reconnects without rebuilding the view.
+    let defaultOwnerProvider: @MainActor () -> String
+
+    init(persistenceController: PersistenceController,
+         defaultOwnerProvider: @escaping @MainActor () -> String) {
+        self.persistenceController = persistenceController
+        self.defaultOwnerProvider = defaultOwnerProvider
+    }
+}
+
 struct MacintoraEditor: View {
     @Binding var text: String
     @Binding var selection: Range<String.Index>
@@ -30,6 +45,7 @@ struct MacintoraEditor: View {
     let showsLineNumbers: Bool
     let highlightsSelectedLine: Bool
     let accessibilityIdentifier: String
+    let completionConfig: EditorCompletionConfig?
 
     @AppStorage("editorTheme") private var editorThemeRaw: String = EditorTheme.default.rawValue
 
@@ -42,7 +58,8 @@ struct MacintoraEditor: View {
         wordWrap: Binding<Bool> = .constant(false),
         showsLineNumbers: Bool = true,
         highlightsSelectedLine: Bool = true,
-        accessibilityIdentifier: String = "editor.main"
+        accessibilityIdentifier: String = "editor.main",
+        completionConfig: EditorCompletionConfig? = nil
     ) {
         self._text = text
         self._selection = selection
@@ -53,6 +70,7 @@ struct MacintoraEditor: View {
         self.showsLineNumbers = showsLineNumbers
         self.highlightsSelectedLine = highlightsSelectedLine
         self.accessibilityIdentifier = accessibilityIdentifier
+        self.completionConfig = completionConfig
     }
 
     private var editorTheme: EditorTheme {
@@ -70,7 +88,8 @@ struct MacintoraEditor: View {
             showsLineNumbers: showsLineNumbers,
             highlightsSelectedLine: highlightsSelectedLine,
             accessibilityIdentifier: accessibilityIdentifier,
-            theme: editorTheme
+            theme: editorTheme,
+            completionConfig: completionConfig
         )
         .id(editorTheme)
     }
@@ -87,6 +106,7 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
     let highlightsSelectedLine: Bool
     let accessibilityIdentifier: String
     let theme: EditorTheme
+    let completionConfig: EditorCompletionConfig?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(text: $text, selection: $selection)
@@ -108,9 +128,30 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
         textView.setAccessibilityIdentifier(accessibilityIdentifier)
         textView.setAccessibilityRole(.textArea)
 
+        // When the host opted in to autocompletion, build the completion
+        // stack now and feed parse-tree updates from Neon directly into the
+        // shared `SQLTreeStore`. This avoids running a second tree-sitter
+        // parser inside the host process.
+        let onTreeUpdated: NeonPlugin.TreeUpdateHandler?
+        if let config = completionConfig {
+            let treeStore = SQLTreeStore()
+            let dataSource = CompletionDataSource(persistenceController: config.persistenceController)
+            let coordinator = CompletionCoordinator(
+                treeStore: treeStore,
+                dataSource: dataSource,
+                defaultOwnerProvider: config.defaultOwnerProvider)
+            context.coordinator.completionCoordinator = coordinator
+            onTreeUpdated = { [weak treeStore] tree in
+                treeStore?.update(tree)
+            }
+        } else {
+            onTreeUpdated = nil
+        }
+
         // Install the Neon syntax-highlighting plugin before the first text
         // assignment so the initial parse fires on the seeded content.
-        textView.addPlugin(language.neonPlugin(theme: theme.neonTheme()))
+        textView.addPlugin(language.neonPlugin(theme: theme.neonTheme(),
+                                               onTreeUpdated: onTreeUpdated))
 
         // Seed initial content without echoing the change back into the binding.
         context.coordinator.isApplyingExternalUpdate = true

--- a/Macintora/Editor/MacintoraEditor.swift
+++ b/Macintora/Editor/MacintoraEditor.swift
@@ -128,24 +128,18 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
         textView.setAccessibilityIdentifier(accessibilityIdentifier)
         textView.setAccessibilityRole(.textArea)
 
-        // When the host opted in to autocompletion, build the completion
-        // stack now and feed parse-tree updates from Neon directly into the
-        // shared `SQLTreeStore`. This avoids running a second tree-sitter
-        // parser inside the host process.
-        let onTreeUpdated: NeonPlugin.TreeUpdateHandler?
+        // Always create the SQLTreeStore and install Neon with a tree-update
+        // callback, even when the host hasn't (yet) opted in to autocompletion.
+        // The CompletionCoordinator is built lazily in `updateNSView` once
+        // `completionConfig` arrives — typical for SwiftUI worksheets where
+        // `.onAppear` builds the config AFTER `makeNSView` runs.
+        let treeStore = SQLTreeStore()
+        context.coordinator.treeStore = treeStore
+        let onTreeUpdated: NeonPlugin.TreeUpdateHandler = { [weak treeStore] tree in
+            treeStore?.update(tree)
+        }
         if let config = completionConfig {
-            let treeStore = SQLTreeStore()
-            let dataSource = CompletionDataSource(persistenceController: config.persistenceController)
-            let coordinator = CompletionCoordinator(
-                treeStore: treeStore,
-                dataSource: dataSource,
-                defaultOwnerProvider: config.defaultOwnerProvider)
-            context.coordinator.completionCoordinator = coordinator
-            onTreeUpdated = { [weak treeStore] tree in
-                treeStore?.update(tree)
-            }
-        } else {
-            onTreeUpdated = nil
+            context.coordinator.installCompletionCoordinator(with: config)
         }
 
         // Install the Neon syntax-highlighting plugin before the first text
@@ -166,6 +160,12 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? STTextView else { return }
+
+        // Promote a late-binding completion config (e.g. MainDocumentView's
+        // `.onAppear` runs after `makeNSView`) to a live CompletionCoordinator.
+        if let config = completionConfig, context.coordinator.completionCoordinator == nil {
+            context.coordinator.installCompletionCoordinator(with: config)
+        }
 
         if textView.isEditable != isEditable { textView.isEditable = isEditable }
         if textView.isSelectable != isSelectable { textView.isSelectable = isSelectable }

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -32,6 +32,10 @@ struct MainDocumentView: View {
 
     @State private var resultsController: ResultsController
     @State private var editorSelection: Range<String.Index> = "".startIndex..<"".endIndex
+    /// Built once per worksheet from the document's connection details so the
+    /// expensive CoreData load only happens at view construction. Reconnects
+    /// keep the same store (per-TNS); switching TNS requires a new worksheet.
+    @State private var completionConfig: EditorCompletionConfig?
 
     var selectedObject: String {
         if editorSelection.isEmpty { return "" }
@@ -81,7 +85,8 @@ struct MainDocumentView: View {
                         isSelectable: true,
                         wordWrap: $wordWrapping,
                         showsLineNumbers: true,
-                        highlightsSelectedLine: true
+                        highlightsSelectedLine: true,
+                        completionConfig: completionConfig
                     )
                         .frame(maxWidth: .infinity, minHeight: 120, idealHeight: 320, maxHeight: .infinity)
                         .focused($focusedView, equals: .codeEditor)
@@ -116,6 +121,18 @@ struct MainDocumentView: View {
             document.prepareOnAppear(store: injectedStore, keychain: keychain)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
                 self.focusedView = .codeEditor
+            }
+            if completionConfig == nil {
+                let tns = document.mainConnection.mainConnDetails.tns
+                if !tns.isEmpty {
+                    let controller = PersistenceController(name: tns)
+                    completionConfig = EditorCompletionConfig(
+                        persistenceController: controller,
+                        defaultOwnerProvider: { [weak document] in
+                            document?.mainConnection.mainConnDetails.username.uppercased() ?? ""
+                        }
+                    )
+                }
             }
         }
         

--- a/MacintoraTests/Editor/Completion/AliasResolverTests.swift
+++ b/MacintoraTests/Editor/Completion/AliasResolverTests.swift
@@ -1,0 +1,56 @@
+//
+//  AliasResolverTests.swift
+//  MacintoraTests
+//
+//  Verifies that `AliasResolver` extracts the correct alias-to-table map for
+//  the common Oracle relation shapes. Uses the production `parseAndResolve`
+//  facade so the test target doesn't need direct tree-sitter linkage.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class AliasResolverTests: XCTestCase {
+
+    // MARK: - Bare table
+
+    func test_bareTable_aliasesUnderTableName() {
+        let map = AliasResolver.parseAndResolve("SELECT * FROM employees")
+        XCTAssertEqual(map.keys.sorted(), ["EMPLOYEES"])
+        XCTAssertEqual(map["EMPLOYEES"]??.name, "EMPLOYEES")
+        XCTAssertNil(map["EMPLOYEES"]??.owner)
+    }
+
+    // MARK: - Implicit alias
+
+    func test_implicitAlias() {
+        let map = AliasResolver.parseAndResolve("SELECT * FROM employees e")
+        XCTAssertNotNil(map["E"])
+        XCTAssertEqual(map["E"]??.name, "EMPLOYEES")
+    }
+
+    // MARK: - AS alias
+
+    func test_asAlias() {
+        let map = AliasResolver.parseAndResolve("SELECT * FROM employees AS e")
+        XCTAssertNotNil(map["E"])
+        XCTAssertEqual(map["E"]??.name, "EMPLOYEES")
+    }
+
+    // MARK: - Schema-qualified
+
+    func test_schemaQualified() {
+        let map = AliasResolver.parseAndResolve("SELECT * FROM hr.employees e")
+        XCTAssertEqual(map["E"]??.name, "EMPLOYEES")
+        XCTAssertEqual(map["E"]??.owner, "HR")
+    }
+
+    // MARK: - Multiple comma-separated tables
+
+    func test_multipleTablesCommaJoin() {
+        let map = AliasResolver.parseAndResolve("SELECT * FROM employees e, departments d")
+        XCTAssertEqual(map["E"]??.name, "EMPLOYEES")
+        XCTAssertEqual(map["D"]??.name, "DEPARTMENTS")
+    }
+}

--- a/MacintoraTests/Editor/Completion/AliasResolverTests.swift
+++ b/MacintoraTests/Editor/Completion/AliasResolverTests.swift
@@ -53,4 +53,65 @@ final class AliasResolverTests: XCTestCase {
         XCTAssertEqual(map["E"]??.name, "EMPLOYEES")
         XCTAssertEqual(map["D"]??.name, "DEPARTMENTS")
     }
+
+    // MARK: - Cursor-aware lookup (production path)
+
+    /// Reproduces the bug reported during manual testing: typing
+    /// `select b.| from BILLS b` puts the cursor in the SELECT-list, where
+    /// `from` is a *sibling* of the enclosing `select` (not an ancestor).
+    /// The resolver must still find the FROM-clause aliases by inspecting
+    /// each ancestor's named children, not just walking straight up.
+    func test_cursorInSelectList_findsAliasesViaSiblingFrom() {
+        let source = "SELECT b. FROM BILLS b"
+        let cursor = (source as NSString).range(of: "b.").location + 2
+        let map = AliasResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(map["B"]??.name, "BILLS",
+                       "Cursor inside SELECT must still resolve aliases bound by the sibling FROM")
+    }
+
+    func test_cursorInWhereClause_resolvesAlias() {
+        let source = "SELECT * FROM BILLS b WHERE b."
+        let map = AliasResolver.parseAndResolve(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(map["B"]??.name, "BILLS")
+    }
+
+    func test_cursorInGroupBy_resolvesAlias() {
+        let source = "SELECT * FROM BILLS b GROUP BY b."
+        let map = AliasResolver.parseAndResolve(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(map["B"]??.name, "BILLS",
+                       "GROUP BY column reference must still resolve FROM-clause aliases")
+    }
+
+    func test_cursorInOrderBy_resolvesAlias() {
+        let source = "SELECT * FROM BILLS b ORDER BY b."
+        let map = AliasResolver.parseAndResolve(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(map["B"]??.name, "BILLS",
+                       "ORDER BY column reference must still resolve FROM-clause aliases")
+    }
+
+    /// Reproduces the multi-statement bug: when the buffer holds
+    /// `select 42 from dual;\nselect a. from BILLS a`, completion at the
+    /// cursor in stmt2 must resolve `a` against stmt2's `from BILLS a`,
+    /// not pick up stmt1's `from dual`.
+    func test_multiStatement_resolvesAliasFromOwningStatement() {
+        let stmt1 = "SELECT 42 FROM dual;\n"
+        let stmt2 = "SELECT a. FROM BILLS a"
+        let source = stmt1 + stmt2
+        let cursor = (source as NSString).range(of: "a. FROM").location + 2
+        let map = AliasResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(map["A"]??.name, "BILLS",
+                       "`a` belongs to stmt2's FROM, not stmt1's FROM dual")
+        XCTAssertNil(map["DUAL"], "stmt1's table must not leak into stmt2's alias map")
+    }
+
+    func test_multiStatement_sourceFallback_scopesToCursorStatement() {
+        // Identical semantics but force the source-text fallback by feeding
+        // a string the parser will fail on (extra noise) — the fallback
+        // alone must still scope correctly.
+        let source = "SELECT 42 FROM dual; SELECT a. FROM BILLS a;"
+        let cursorAfterADot = (source as NSString).range(of: "a. FROM").location + 2
+        let map = AliasResolver.aliasesFromSourceText(source, around: cursorAfterADot)
+        XCTAssertEqual(map["A"]??.name, "BILLS")
+        XCTAssertNil(map["DUAL"])
+    }
 }

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -1,0 +1,118 @@
+//
+//  CompletionDataSourceTests.swift
+//  MacintoraTests
+//
+//  Exercises `CompletionDataSource` against an in-memory CoreData store seeded
+//  with a handful of `DBCacheTable`/`DBCacheTableColumn`/`DBCacheObject` rows.
+//  Verifies prefix matching, owner filtering, and case-insensitive lookup.
+//
+
+import XCTest
+import CoreData
+@testable import Macintora
+
+@MainActor
+final class CompletionDataSourceTests: XCTestCase {
+
+    private var persistence: PersistenceController!
+    private var dataSource: CompletionDataSource!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistence = PersistenceController(inMemory: true)
+        seed()
+        dataSource = CompletionDataSource(persistenceController: persistence)
+    }
+
+    override func tearDown() async throws {
+        dataSource = nil
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Tables
+
+    func test_tables_prefixMatch_withinOwner() async {
+        let result = await dataSource.tables(prefix: "EMP", defaultOwner: "HR", limit: 10)
+        XCTAssertEqual(result.map(\.name).sorted(), ["EMPLOYEES", "EMP_HISTORY"])
+    }
+
+    func test_tables_excludesOtherOwners() async {
+        let result = await dataSource.tables(prefix: "DUAL", defaultOwner: "HR", limit: 10)
+        XCTAssertTrue(result.isEmpty, "DUAL is in SYS, not HR")
+    }
+
+    func test_tables_emptyPrefix_returnsAllInOwner() async {
+        let result = await dataSource.tables(prefix: "", defaultOwner: "HR", limit: 10)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    // MARK: - Columns
+
+    func test_columns_byTable() async {
+        let result = await dataSource.columns(
+            tableName: "EMPLOYEES", owner: "HR", prefix: "", limit: 50)
+        XCTAssertEqual(result.map(\.columnName).sorted(),
+                       ["EMPLOYEE_ID", "FIRST_NAME", "SALARY"])
+    }
+
+    func test_columns_byPrefix() async {
+        let result = await dataSource.columns(
+            tableName: "EMPLOYEES", owner: "HR", prefix: "FI", limit: 50)
+        XCTAssertEqual(result.map(\.columnName), ["FIRST_NAME"])
+    }
+
+    // MARK: - Objects
+
+    func test_objects_byOwnerAndType() async {
+        let result = await dataSource.objects(
+            prefix: "", owner: "HR", types: ["TABLE"], limit: 10)
+        XCTAssertEqual(Set(result.map(\.name)),
+                       Set(["EMPLOYEES", "EMP_HISTORY", "DEPARTMENTS"]))
+    }
+
+    // MARK: - Seed helpers
+
+    private func seed() {
+        let ctx = persistence.container.viewContext
+
+        addTable(in: ctx, owner: "HR", name: "EMPLOYEES", isView: false)
+        addTable(in: ctx, owner: "HR", name: "EMP_HISTORY", isView: false)
+        addTable(in: ctx, owner: "HR", name: "DEPARTMENTS", isView: false)
+        addTable(in: ctx, owner: "SYS", name: "DUAL", isView: false)
+
+        addColumn(in: ctx, owner: "HR", table: "EMPLOYEES", column: "EMPLOYEE_ID", type: "NUMBER")
+        addColumn(in: ctx, owner: "HR", table: "EMPLOYEES", column: "FIRST_NAME", type: "VARCHAR2")
+        addColumn(in: ctx, owner: "HR", table: "EMPLOYEES", column: "SALARY", type: "NUMBER")
+
+        addObject(in: ctx, owner: "HR", name: "EMPLOYEES", type: "TABLE")
+        addObject(in: ctx, owner: "HR", name: "EMP_HISTORY", type: "TABLE")
+        addObject(in: ctx, owner: "HR", name: "DEPARTMENTS", type: "TABLE")
+
+        try! ctx.save()
+    }
+
+    private func addTable(in ctx: NSManagedObjectContext, owner: String, name: String, isView: Bool) {
+        let row = DBCacheTable(context: ctx)
+        row.owner_ = owner
+        row.name_ = name
+        row.isView = isView
+    }
+
+    private func addColumn(in ctx: NSManagedObjectContext,
+                           owner: String, table: String, column: String, type: String) {
+        let row = DBCacheTableColumn(context: ctx)
+        row.owner_ = owner
+        row.tableName_ = table
+        row.columnName_ = column
+        row.dataType_ = type
+    }
+
+    private func addObject(in ctx: NSManagedObjectContext,
+                           owner: String, name: String, type: String) {
+        let row = DBCacheObject(context: ctx)
+        row.owner_ = owner
+        row.name_ = name
+        row.type_ = type
+    }
+}

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -32,43 +32,82 @@ final class CompletionDataSourceTests: XCTestCase {
 
     // MARK: - Tables
 
-    func test_tables_prefixMatch_withinOwner() async {
-        let result = await dataSource.tables(prefix: "EMP", defaultOwner: "HR", limit: 10)
-        XCTAssertEqual(result.map(\.name).sorted(), ["EMPLOYEES", "EMP_HISTORY"])
+    func test_tables_substringMatch_acrossSchemas() async {
+        // Substring match: "EMP" hits EMPLOYEES, EMP_HISTORY (HR) and
+        // BILLING.EMP_BILLS. All returned, HR rows ranked first.
+        let result = await dataSource.tables(search: "EMP", preferredOwner: "HR", limit: 10)
+        XCTAssertEqual(Set(result.map(\.name)),
+                       Set(["EMPLOYEES", "EMP_HISTORY", "EMP_BILLS"]))
+        // First entries belong to the preferred owner.
+        let firstTwoOwners = Array(result.prefix(2)).map(\.owner)
+        XCTAssertTrue(firstTwoOwners.allSatisfy { $0 == "HR" })
     }
 
-    func test_tables_excludesOtherOwners() async {
-        let result = await dataSource.tables(prefix: "DUAL", defaultOwner: "HR", limit: 10)
-        XCTAssertTrue(result.isEmpty, "DUAL is in SYS, not HR")
+    func test_tables_includesOtherOwners() async {
+        let result = await dataSource.tables(search: "DUAL", preferredOwner: "HR", limit: 10)
+        XCTAssertEqual(result.map(\.name), ["DUAL"], "Cross-schema lookup must surface SYS.DUAL")
+        XCTAssertEqual(result.first?.owner, "SYS")
     }
 
-    func test_tables_emptyPrefix_returnsAllInOwner() async {
-        let result = await dataSource.tables(prefix: "", defaultOwner: "HR", limit: 10)
-        XCTAssertEqual(result.count, 3)
+    func test_tables_emptySearch_returnsPreferredOwnerOnly() async {
+        let result = await dataSource.tables(search: "", preferredOwner: "HR", limit: 10)
+        XCTAssertEqual(result.count, 3, "Empty search must scope to preferred owner to avoid cache dump")
+    }
+
+    func test_tables_caseInsensitive() async {
+        let result = await dataSource.tables(search: "emP", preferredOwner: "HR", limit: 10)
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertTrue(result.contains { $0.name == "EMPLOYEES" })
+    }
+
+    func test_tables_prefixRanksAboveInfix() async {
+        // EMP_BILLS is a prefix match; XYZ_EMP would be an infix match if it
+        // existed — verify by adding one.
+        addObject(in: persistence.container.viewContext,
+                  owner: "HR", name: "XYZ_EMP_LOG", type: "TABLE")
+        try! persistence.container.viewContext.save()
+
+        let result = await dataSource.tables(search: "EMP", preferredOwner: "HR", limit: 10)
+        let names = result.map(\.name)
+        XCTAssertTrue(names.contains("XYZ_EMP_LOG"))
+        // All prefix-matching names appear before any infix-only name.
+        let lastPrefix = names.lastIndex(where: { $0.uppercased().hasPrefix("EMP") }) ?? -1
+        let firstInfix = names.firstIndex(of: "XYZ_EMP_LOG") ?? Int.max
+        XCTAssertLessThan(lastPrefix, firstInfix, "Prefix matches must rank before infix-only matches")
     }
 
     // MARK: - Columns
 
     func test_columns_byTable() async {
         let result = await dataSource.columns(
-            tableName: "EMPLOYEES", owner: "HR", prefix: "", limit: 50)
+            tableName: "EMPLOYEES", owner: "HR", search: "", limit: 50)
         XCTAssertEqual(result.map(\.columnName).sorted(),
                        ["EMPLOYEE_ID", "FIRST_NAME", "SALARY"])
     }
 
-    func test_columns_byPrefix() async {
+    func test_columns_substringMatch() async {
         let result = await dataSource.columns(
-            tableName: "EMPLOYEES", owner: "HR", prefix: "FI", limit: 50)
-        XCTAssertEqual(result.map(\.columnName), ["FIRST_NAME"])
+            tableName: "EMPLOYEES", owner: "HR", search: "ID", limit: 50)
+        // EMPLOYEE_ID is the only column containing "ID".
+        XCTAssertEqual(result.map(\.columnName), ["EMPLOYEE_ID"])
     }
 
     // MARK: - Objects
 
     func test_objects_byOwnerAndType() async {
         let result = await dataSource.objects(
-            prefix: "", owner: "HR", types: ["TABLE"], limit: 10)
+            search: "", owner: "HR", types: ["TABLE"], limit: 10)
         XCTAssertEqual(Set(result.map(\.name)),
                        Set(["EMPLOYEES", "EMP_HISTORY", "DEPARTMENTS"]))
+    }
+
+    func test_objects_substringAcrossSchemas() async {
+        let result = await dataSource.objects(
+            search: "EMP", owner: nil, preferredOwner: "HR",
+            types: ["TABLE"], limit: 10)
+        XCTAssertTrue(result.contains { $0.owner == "HR" && $0.name == "EMPLOYEES" })
+        XCTAssertTrue(result.contains { $0.owner == "BILLING" && $0.name == "EMP_BILLS" })
+        XCTAssertEqual(result.first?.owner, "HR")
     }
 
     // MARK: - Seed helpers
@@ -76,27 +115,21 @@ final class CompletionDataSourceTests: XCTestCase {
     private func seed() {
         let ctx = persistence.container.viewContext
 
-        addTable(in: ctx, owner: "HR", name: "EMPLOYEES", isView: false)
-        addTable(in: ctx, owner: "HR", name: "EMP_HISTORY", isView: false)
-        addTable(in: ctx, owner: "HR", name: "DEPARTMENTS", isView: false)
-        addTable(in: ctx, owner: "SYS", name: "DUAL", isView: false)
+        // tables() now reads from DBCacheObject (the comprehensive catalog).
+        // DBCacheTable rows would be ignored, so seed via DBCacheObject only.
+        addObject(in: ctx, owner: "HR", name: "EMPLOYEES", type: "TABLE")
+        addObject(in: ctx, owner: "HR", name: "EMP_HISTORY", type: "TABLE")
+        addObject(in: ctx, owner: "HR", name: "DEPARTMENTS", type: "TABLE")
+        addObject(in: ctx, owner: "SYS", name: "DUAL", type: "TABLE")
+        // BILLING.EMP_BILLS exercises cross-schema substring matching: the
+        // user is connected as HR but has access to BILLING via grant.
+        addObject(in: ctx, owner: "BILLING", name: "EMP_BILLS", type: "TABLE")
 
         addColumn(in: ctx, owner: "HR", table: "EMPLOYEES", column: "EMPLOYEE_ID", type: "NUMBER")
         addColumn(in: ctx, owner: "HR", table: "EMPLOYEES", column: "FIRST_NAME", type: "VARCHAR2")
         addColumn(in: ctx, owner: "HR", table: "EMPLOYEES", column: "SALARY", type: "NUMBER")
 
-        addObject(in: ctx, owner: "HR", name: "EMPLOYEES", type: "TABLE")
-        addObject(in: ctx, owner: "HR", name: "EMP_HISTORY", type: "TABLE")
-        addObject(in: ctx, owner: "HR", name: "DEPARTMENTS", type: "TABLE")
-
         try! ctx.save()
-    }
-
-    private func addTable(in ctx: NSManagedObjectContext, owner: String, name: String, isView: Bool) {
-        let row = DBCacheTable(context: ctx)
-        row.owner_ = owner
-        row.name_ = name
-        row.isView = isView
     }
 
     private func addColumn(in ctx: NSManagedObjectContext,

--- a/MacintoraTests/Editor/Completion/SQLContextAnalyzerTests.swift
+++ b/MacintoraTests/Editor/Completion/SQLContextAnalyzerTests.swift
@@ -1,0 +1,98 @@
+//
+//  SQLContextAnalyzerTests.swift
+//  MacintoraTests
+//
+//  Verifies that `SQLContextAnalyzer` returns the right `CompletionContext`
+//  for a representative slice of partial SQL inputs. Uses the production
+//  `parseAndAnalyze` facade so the test target doesn't have to link the
+//  plugin's tree-sitter products directly.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class SQLContextAnalyzerTests: XCTestCase {
+
+    // MARK: - FROM clause
+
+    func test_afterFromKeyword_emptyPrefix() {
+        let source = "SELECT * FROM "
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(context, .afterFromKeyword(prefix: ""))
+    }
+
+    func test_afterFromKeyword_partialIdentifier() {
+        let source = "SELECT * FROM emp"
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(context, .afterFromKeyword(prefix: "emp"))
+    }
+
+    // MARK: - WHERE clause column
+
+    func test_whereClause_columnReference() {
+        let source = "SELECT * FROM employees WHERE sa"
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        if case .columnReference(let qualifier, let prefix) = context {
+            XCTAssertNil(qualifier)
+            XCTAssertEqual(prefix, "sa")
+        } else {
+            XCTFail("expected columnReference, got \(context)")
+        }
+    }
+
+    // MARK: - Dotted member (alias.col, schema.obj)
+
+    func test_dottedMember_aliasDotColumn() {
+        let source = "SELECT e. FROM employees e"
+        // Cursor sits right after "e."
+        let cursor = (source as NSString).range(of: "e.").location + 2
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: cursor)
+        if case .dottedMember(let qualifier, let prefix) = context {
+            XCTAssertEqual(qualifier, "e")
+            XCTAssertEqual(prefix, "")
+        } else {
+            XCTFail("expected dottedMember, got \(context)")
+        }
+    }
+
+    func test_dottedMember_schemaDotPartialName() {
+        let source = "SELECT * FROM hr.emp"
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        if case .dottedMember(let qualifier, let prefix) = context {
+            XCTAssertEqual(qualifier, "hr")
+            XCTAssertEqual(prefix, "emp")
+        } else {
+            XCTFail("expected dottedMember, got \(context)")
+        }
+    }
+
+    // MARK: - String / comment suppression
+
+    func test_insideStringLiteral_returnsNone() {
+        let source = "SELECT 'hello wo"
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(context, .none)
+    }
+
+    func test_insideLineComment_returnsNone() {
+        let source = "-- pick a tab\nSELECT * FROM dual"
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: 13)
+        XCTAssertEqual(context, .none)
+    }
+
+    // MARK: - ERROR-node fallback (mid-typing tolerance)
+
+    func test_brokenSyntax_stillReturnsContext() {
+        // Missing comma; the tree may have ERROR nodes but the backward scan
+        // should still extract the prefix.
+        let source = "SELECT col1 col2 FROM tab WHERE c"
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        switch context {
+        case .columnReference(_, let prefix), .identifierPrefix(let prefix):
+            XCTAssertEqual(prefix, "c")
+        default:
+            XCTFail("expected columnReference or identifierPrefix, got \(context)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds context-aware SQL autocompletion to the worksheet editor, sourced **only** from the existing CoreData/SQLite cache (no remote DB hits).
- Reuses Neon's existing tree-sitter parser via the new `onTreeUpdated` callback (see [STTextView-Plugin-Neon@157d8ed](https://github.com/iliasaz/STTextView-Plugin-Neon/commit/157d8ed)) — no second parser in-process.
- Uses STTextView's built-in completion popup; auto-triggers on `.` and identifier characters with a 120 ms debounce, plus the standard macOS Escape key.

## Scope (v1)

- **Tables / views** in `FROM` clauses (default-owner aware).
- **Columns** in `SELECT` / `WHERE` / `JOIN` / `GROUP BY` / `ORDER BY`, with FROM-clause **alias resolution** (bare, `AS`, schema-qualified, multi-relation comma joins).
- **Schema-dot-objects** (e.g. `HR.<tab>` lists tables/views/packages in `HR`).

## Out of scope for v1

- **Package member completion** (e.g. `DBMS_OUTPUT.PUT_LINE`). The cache only stores package source text; surfacing members would require a schema extension to populate from `ALL_PROCEDURES` / `ALL_ARGUMENTS`. Tracked as a follow-up DBBrowser enhancement.
- Apple Intelligence / on-device LLM suggestions.
- Quoted identifiers, subquery column inference, multi-statement cross-context, synonym chasing.

## Architecture

New `Macintora/Editor/Completion/` directory:
- `SQLTreeStore` — `@Observable` holder updated from the Neon callback.
- `SQLContextAnalyzer` — walks ancestors for clause kind; backward source-keyword scan tolerates ERROR nodes mid-typing.
- `AliasResolver` — `[alias: ResolvedTable?]` from the smallest enclosing FROM.
- `CompletionDataSource` — `actor` over a background `NSManagedObjectContext`; returns Sendable structs only.
- `CompletionItem` — Sendable suggestion structs + `MacintoraCompletionItem` row view (icon + label + secondary).
- `CompletionCoordinator` — bridges everything, owns the debounce task.
- `SQLParserHelper` — one-shot parser used by tests and debug.
- `MacintoraEditor+Completion` — STTextView delegate methods (`@MainActor`-isolated witnesses).

`MacintoraEditor` gains an optional `EditorCompletionConfig` (per-document `PersistenceController` + `defaultOwnerProvider`); read-only viewers in DBBrowser pass nil.

## Test plan

- [x] 19 new unit tests (analyzer, alias resolver, data source) — all pass
- [x] Full unit suite (270 tests + 1 skipped) — all pass
- [x] UI tests (8) — all pass
- [ ] **Manual smoke (please verify against a real connection):**
  - [ ] Open a worksheet against a connection with a populated cache.
  - [ ] Type `select * from emp` → expect tables starting with `EMP` from the current schema.
  - [ ] Type `select e. from employees e where e.` → expect columns of `EMPLOYEES` after each `.`.
  - [ ] Type `select * from hr.` → expect objects in schema `HR`.
  - [ ] Press Esc on an identifier prefix → expect identifier-prefix completion.
  - [ ] Verify popup dismisses on Esc, cursor jump, unrelated typing, IME composition.