### PR TITLE
DB cache: capture package procedures, functions, and arguments

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -116,6 +116,11 @@
 		49EAEFA328C0493F008F0B80 /* DBDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA228C0493F008F0B80 /* DBDetailView.swift */; };
 		49EAEFA528C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA428C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift */; };
 		49EAEFA728C83685008F0B80 /* DBCacheTrigger+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA628C83685008F0B80 /* DBCacheTrigger+CoreDataProperties.swift */; };
+		49B0C0DE0000000000000011 /* DBCacheProcedure+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000001 /* DBCacheProcedure+CoreDataClass.swift */; };
+		49B0C0DE0000000000000012 /* DBCacheProcedure+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000002 /* DBCacheProcedure+CoreDataProperties.swift */; };
+		49B0C0DE0000000000000013 /* DBCacheProcedureArgument+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000003 /* DBCacheProcedureArgument+CoreDataClass.swift */; };
+		49B0C0DE0000000000000014 /* DBCacheProcedureArgument+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000004 /* DBCacheProcedureArgument+CoreDataProperties.swift */; };
+		49B0C0DE0000000000000015 /* PackageProceduresListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000005 /* PackageProceduresListView.swift */; };
 		49EAEFA928C93263008F0B80 /* DBTriggerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA828C93263008F0B80 /* DBTriggerDetailView.swift */; };
 		49EAEFAB28C9331C008F0B80 /* SourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFAA28C9331C008F0B80 /* SourceView.swift */; };
 		49EAEFC728CD5822008F0B80 /* TableTriggerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFC628CD5822008F0B80 /* TableTriggerListView.swift */; };
@@ -290,6 +295,11 @@
 		49EAEFA228C0493F008F0B80 /* DBDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBDetailView.swift; sourceTree = "<group>"; };
 		49EAEFA428C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheTrigger+CoreDataClass.swift"; sourceTree = "<group>"; };
 		49EAEFA628C83685008F0B80 /* DBCacheTrigger+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheTrigger+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000001 /* DBCacheProcedure+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedure+CoreDataClass.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000002 /* DBCacheProcedure+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedure+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000003 /* DBCacheProcedureArgument+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedureArgument+CoreDataClass.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000004 /* DBCacheProcedureArgument+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedureArgument+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000005 /* PackageProceduresListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageProceduresListView.swift; sourceTree = "<group>"; };
 		49EAEFA828C93263008F0B80 /* DBTriggerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBTriggerDetailView.swift; sourceTree = "<group>"; };
 		49EAEFAA28C9331C008F0B80 /* SourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceView.swift; sourceTree = "<group>"; };
 		49EAEFC628CD5822008F0B80 /* TableTriggerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableTriggerListView.swift; sourceTree = "<group>"; };
@@ -421,6 +431,7 @@
 				498288E428B7DCB000A28B04 /* TableIndexListView.swift */,
 				498288D028B7DCB000A28B04 /* WindowModifier.swift */,
 				49EAEFC628CD5822008F0B80 /* TableTriggerListView.swift */,
+				49B0C0DE0000000000000005 /* PackageProceduresListView.swift */,
 				498288AD28B7DC5700A28B04 /* CoreData */,
 			);
 			path = DBObjectsBrowser;
@@ -493,6 +504,10 @@
 				498288BD28B7DC5700A28B04 /* DBCacheTable+CoreDataClass.swift */,
 				49EAEFA428C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift */,
 				498288BE28B7DC5700A28B04 /* DBCacheSource+CoreDataProperties.swift */,
+				49B0C0DE0000000000000001 /* DBCacheProcedure+CoreDataClass.swift */,
+				49B0C0DE0000000000000002 /* DBCacheProcedure+CoreDataProperties.swift */,
+				49B0C0DE0000000000000003 /* DBCacheProcedureArgument+CoreDataClass.swift */,
+				49B0C0DE0000000000000004 /* DBCacheProcedureArgument+CoreDataProperties.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -928,6 +943,11 @@
 				498288CE28B7DC5700A28B04 /* DBCacheTable+CoreDataClass.swift in Sources */,
 				49EB5E0C29528995003A0E23 /* DBCacheMainView.swift in Sources */,
 				49EAEFA528C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift in Sources */,
+				49B0C0DE0000000000000011 /* DBCacheProcedure+CoreDataClass.swift in Sources */,
+				49B0C0DE0000000000000012 /* DBCacheProcedure+CoreDataProperties.swift in Sources */,
+				49B0C0DE0000000000000013 /* DBCacheProcedureArgument+CoreDataClass.swift in Sources */,
+				49B0C0DE0000000000000014 /* DBCacheProcedureArgument+CoreDataProperties.swift in Sources */,
+				49B0C0DE0000000000000015 /* PackageProceduresListView.swift in Sources */,
 				AA00000D0000000000000000 /* TnsEntry.swift in Sources */,
 				490E96C42FA4246E00DDF37F /* ScriptRunnerEvent.swift in Sources */,
 				AA0000030000000000000000 /* TnsParser.swift in Sources */,

--- a/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedure+CoreDataClass.swift
+++ b/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedure+CoreDataClass.swift
@@ -1,0 +1,12 @@
+//
+//  DBCacheProcedure+CoreDataClass.swift
+//  Macintora
+//
+
+import Foundation
+import CoreData
+
+@objc(DBCacheProcedure)
+public class DBCacheProcedure: NSManagedObject {
+
+}

--- a/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedure+CoreDataProperties.swift
+++ b/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedure+CoreDataProperties.swift
@@ -1,0 +1,77 @@
+//
+//  DBCacheProcedure+CoreDataProperties.swift
+//  Macintora
+//
+
+import Foundation
+import CoreData
+
+
+extension DBCacheProcedure {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DBCacheProcedure> {
+        return NSFetchRequest<DBCacheProcedure>(entityName: "DBCacheProcedure")
+    }
+
+    @NSManaged public var authID_: String?
+    @NSManaged public var implTypeName_: String?
+    @NSManaged public var implTypeOwner_: String?
+    @NSManaged public var isAggregate: Bool
+    @NSManaged public var isDeterministic: Bool
+    @NSManaged public var isParallel: Bool
+    @NSManaged public var isPipelined: Bool
+    @NSManaged public var isResultCache: Bool
+    @NSManaged public var objectName_: String?
+    @NSManaged public var objectType_: String?
+    @NSManaged public var overload_: String?
+    @NSManaged public var owner_: String?
+    @NSManaged public var procedureName_: String?
+    @NSManaged public var subprogramId: Int32
+}
+
+
+extension DBCacheProcedure: Identifiable {
+
+}
+
+extension DBCacheProcedure {
+    var owner: String {
+        get { self.owner_ ?? "(null)" }
+        set { self.owner_ = newValue }
+    }
+
+    var objectName: String {
+        get { self.objectName_ ?? "(null)" }
+        set { self.objectName_ = newValue }
+    }
+
+    var procedureName: String {
+        get { self.procedureName_ ?? "" }
+        set { self.procedureName_ = newValue }
+    }
+
+    var objectType: String {
+        get { self.objectType_ ?? "(null)" }
+        set { self.objectType_ = newValue }
+    }
+
+    var overload: String {
+        get { self.overload_ ?? "" }
+        set { self.overload_ = newValue }
+    }
+
+    var authID: String {
+        get { self.authID_ ?? "" }
+        set { self.authID_ = newValue }
+    }
+}
+
+extension DBCacheProcedure {
+    @MainActor static var example: DBCacheProcedure {
+        let context = PersistenceController.preview.container.viewContext
+        let request = DBCacheProcedure.fetchRequest()
+        request.fetchLimit = 1
+        let results = try? context.fetch(request)
+        return (results?.first!)!
+    }
+}

--- a/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedureArgument+CoreDataClass.swift
+++ b/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedureArgument+CoreDataClass.swift
@@ -1,0 +1,12 @@
+//
+//  DBCacheProcedureArgument+CoreDataClass.swift
+//  Macintora
+//
+
+import Foundation
+import CoreData
+
+@objc(DBCacheProcedureArgument)
+public class DBCacheProcedureArgument: NSManagedObject {
+
+}

--- a/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedureArgument+CoreDataProperties.swift
+++ b/Macintora/DBObjectsBrowser/CoreData/DBCacheProcedureArgument+CoreDataProperties.swift
@@ -1,0 +1,94 @@
+//
+//  DBCacheProcedureArgument+CoreDataProperties.swift
+//  Macintora
+//
+
+import Foundation
+import CoreData
+
+
+extension DBCacheProcedureArgument {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DBCacheProcedureArgument> {
+        return NSFetchRequest<DBCacheProcedureArgument>(entityName: "DBCacheProcedureArgument")
+    }
+
+    @NSManaged public var argumentName_: String?
+    @NSManaged public var charLength: Int32
+    @NSManaged public var dataLength: Int32
+    @NSManaged public var dataLevel: Int16
+    @NSManaged public var dataPrecision: Int16
+    @NSManaged public var dataScale: Int16
+    @NSManaged public var dataType_: String?
+    @NSManaged public var defaultValue_: String?
+    @NSManaged public var defaulted: Bool
+    @NSManaged public var inOut_: String?
+    @NSManaged public var objectName_: String?
+    @NSManaged public var overload_: String?
+    @NSManaged public var owner_: String?
+    @NSManaged public var plsType_: String?
+    @NSManaged public var position: Int16
+    @NSManaged public var procedureName_: String?
+    @NSManaged public var sequence: Int16
+    @NSManaged public var subprogramId: Int32
+    @NSManaged public var typeName_: String?
+    @NSManaged public var typeOwner_: String?
+    @NSManaged public var typeSubname_: String?
+}
+
+
+extension DBCacheProcedureArgument: Identifiable {
+
+}
+
+extension DBCacheProcedureArgument {
+    var owner: String {
+        get { self.owner_ ?? "(null)" }
+        set { self.owner_ = newValue }
+    }
+
+    var objectName: String {
+        get { self.objectName_ ?? "(null)" }
+        set { self.objectName_ = newValue }
+    }
+
+    var procedureName: String {
+        get { self.procedureName_ ?? "" }
+        set { self.procedureName_ = newValue }
+    }
+
+    var argumentName: String {
+        get { self.argumentName_ ?? "" }
+        set { self.argumentName_ = newValue }
+    }
+
+    var dataType: String {
+        get { self.dataType_ ?? "" }
+        set { self.dataType_ = newValue }
+    }
+
+    var inOut: String {
+        get { self.inOut_ ?? "IN" }
+        set { self.inOut_ = newValue }
+    }
+
+    var overload: String {
+        get { self.overload_ ?? "" }
+        set { self.overload_ = newValue }
+    }
+
+    var defaultValue: String {
+        get { self.defaultValue_ ?? "" }
+        set { self.defaultValue_ = newValue }
+    }
+}
+
+extension DBCacheProcedureArgument {
+    @MainActor static var example: DBCacheProcedureArgument {
+        let context = PersistenceController.preview.container.viewContext
+        let request = DBCacheProcedureArgument.fetchRequest()
+        request.fetchLimit = 1
+        let results = try? context.fetch(request)
+        return (results?.first!)!
+    }
+}

--- a/Macintora/DBObjectsBrowser/CoreData/DatabaseCacheModel.xcdatamodeld/DatabaseCacheModel.xcdatamodel/contents
+++ b/Macintora/DBObjectsBrowser/CoreData/DatabaseCacheModel.xcdatamodeld/DatabaseCacheModel.xcdatamodel/contents
@@ -146,6 +146,61 @@
             <fetchIndexElement property="objectOwner" type="Binary" order="ascending"/>
         </fetchIndex>
     </entity>
+    <entity name="DBCacheProcedure" representedClassName="DBCacheProcedure" syncable="YES">
+        <attribute name="authID_" optional="YES" attributeType="String"/>
+        <attribute name="implTypeName_" optional="YES" attributeType="String"/>
+        <attribute name="implTypeOwner_" optional="YES" attributeType="String"/>
+        <attribute name="isAggregate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isDeterministic" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isParallel" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isPipelined" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isResultCache" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="objectName_" optional="YES" attributeType="String"/>
+        <attribute name="objectType_" optional="YES" attributeType="String"/>
+        <attribute name="overload_" optional="YES" attributeType="String"/>
+        <attribute name="owner_" optional="YES" attributeType="String"/>
+        <attribute name="procedureName_" optional="YES" attributeType="String"/>
+        <attribute name="subprogramId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <fetchIndex name="byPackage">
+            <fetchIndexElement property="owner_" type="Binary" order="ascending"/>
+            <fetchIndexElement property="objectName_" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="bySubprogram">
+            <fetchIndexElement property="owner_" type="Binary" order="ascending"/>
+            <fetchIndexElement property="objectName_" type="Binary" order="ascending"/>
+            <fetchIndexElement property="subprogramId" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="DBCacheProcedureArgument" representedClassName="DBCacheProcedureArgument" syncable="YES">
+        <attribute name="argumentName_" optional="YES" attributeType="String"/>
+        <attribute name="charLength" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dataLength" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dataLevel" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dataPrecision" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dataScale" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dataType_" optional="YES" attributeType="String"/>
+        <attribute name="defaultValue_" optional="YES" attributeType="String"/>
+        <attribute name="defaulted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="inOut_" optional="YES" attributeType="String"/>
+        <attribute name="objectName_" optional="YES" attributeType="String"/>
+        <attribute name="overload_" optional="YES" attributeType="String"/>
+        <attribute name="owner_" optional="YES" attributeType="String"/>
+        <attribute name="plsType_" optional="YES" attributeType="String"/>
+        <attribute name="position" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="procedureName_" optional="YES" attributeType="String"/>
+        <attribute name="sequence" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subprogramId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="typeName_" optional="YES" attributeType="String"/>
+        <attribute name="typeOwner_" optional="YES" attributeType="String"/>
+        <attribute name="typeSubname_" optional="YES" attributeType="String"/>
+        <fetchIndex name="byProcedure">
+            <fetchIndexElement property="owner_" type="Binary" order="ascending"/>
+            <fetchIndexElement property="objectName_" type="Binary" order="ascending"/>
+            <fetchIndexElement property="procedureName_" type="Binary" order="ascending"/>
+            <fetchIndexElement property="overload_" type="Binary" order="ascending"/>
+            <fetchIndexElement property="sequence" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
     <entity name="Item" representedClassName="Item" syncable="YES">
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>

--- a/Macintora/DBObjectsBrowser/DBCacheVM.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheVM.swift
@@ -167,6 +167,47 @@ struct SourceRowDTO: Sendable {
     let text: String
 }
 
+struct ProcedureDTO: Sendable {
+    let owner: String
+    let objectName: String
+    let procedureName: String?
+    let objectType: String
+    let subprogramId: Int
+    let overload: String?
+    let isAggregate: Bool
+    let isPipelined: Bool
+    let isParallel: Bool
+    let isDeterministic: Bool
+    let isResultCache: Bool
+    let authID: String?
+    let implTypeOwner: String?
+    let implTypeName: String?
+}
+
+struct ProcedureArgumentDTO: Sendable {
+    let owner: String
+    let objectName: String
+    let procedureName: String
+    let overload: String?
+    let subprogramId: Int
+    let position: Int
+    let sequence: Int
+    let dataLevel: Int
+    let argumentName: String?
+    let dataType: String?
+    let inOut: String?
+    let dataLength: Int
+    let dataPrecision: Int?
+    let dataScale: Int?
+    let charLength: Int
+    let defaulted: Bool
+    let defaultValue: String?
+    let typeOwner: String?
+    let typeName: String?
+    let typeSubname: String?
+    let plsType: String?
+}
+
 // MARK: - Row access helpers
 
 extension OracleRandomAccessRow {
@@ -266,6 +307,8 @@ final class DBCacheVM: nonisolated ObservableObject {
                 try await deleteAll(from: "DBCacheIndexColumn")
                 try await deleteAll(from: "DBCacheIndex")
                 try await deleteAll(from: "DBCacheSource")
+                try await deleteAll(from: "DBCacheProcedureArgument")
+                try await deleteAll(from: "DBCacheProcedure")
                 try await deleteAll(from: "DBCacheObject")
                 try await deleteAll(from: "DBCacheTrigger")
             } catch {
@@ -506,6 +549,9 @@ from dba_objects o
                     } else {
                         await self.processChunkOfObjects(objstemp, objectType: objectType)
                     }
+                    if objectType == .package || objectType == .procedure || objectType == .function {
+                        await self.processProceduresChunk(objstemp)
+                    }
                     await cacheState.completeSession()
                     objs.removeAll()
                 }
@@ -521,6 +567,9 @@ from dba_objects o
                     await self.processSourceChunk(objstemp)
                 } else {
                     await self.processChunkOfObjects(objstemp, objectType: objectType)
+                }
+                if objectType == .package || objectType == .procedure || objectType == .function {
+                    await self.processProceduresChunk(objstemp)
                 }
                 await cacheState.completeSession()
                 objs.removeAll()
@@ -1059,6 +1108,204 @@ from dba_objects o
         }
     }
 
+    // MARK: - Procedures and arguments
+
+    func processProceduresChunk(_ objs: [OracleObject]) async {
+        guard !objs.isEmpty, objs.count < 1000 else { return }
+        let procedures = (try? await fetchProcedures(objs)) ?? []
+        let arguments = (try? await fetchProcedureArguments(objs)) ?? []
+        await persistProcedures(procedures, arguments: arguments, objs: objs)
+    }
+
+    private func fetchProcedures(_ objs: [OracleObject]) async throws -> [ProcedureDTO] {
+        guard !objs.isEmpty else { return [] }
+        var sql = "select owner, object_name, procedure_name, object_type, subprogram_id, overload, aggregate, pipelined, parallel, deterministic, result_cache, authid, impltypeowner, impltypename from all_procedures where (owner, object_name) in ("
+        var bindings = OracleBindings()
+        var placeholders: [String] = []
+        for (i, obj) in objs.enumerated() {
+            placeholders.append("(:o\(i), :n\(i))")
+            bindings.append(obj.owner, context: .default, bindName: "o\(i)")
+            bindings.append(obj.name, context: .default, bindName: "n\(i)")
+        }
+        sql += placeholders.joined(separator: ",")
+        sql += ")"
+
+        let logger = oracleLogger
+        let finalSQL = sql
+        let finalBindings = bindings
+        return try await withClient { conn in
+            var options = StatementOptions()
+            options.prefetchRows = 5000
+            let stream = try await conn.execute(
+                OracleStatement(unsafeSQL: finalSQL, binds: finalBindings),
+                options: options,
+                logger: logger
+            )
+            var rows: [ProcedureDTO] = []
+            for try await row in stream {
+                let rr = row.makeRandomAccess()
+                guard let owner = rr.optString("OWNER"),
+                      let name = rr.optString("OBJECT_NAME") else { continue }
+                rows.append(ProcedureDTO(
+                    owner: owner,
+                    objectName: name,
+                    procedureName: rr.optString("PROCEDURE_NAME"),
+                    objectType: rr.optString("OBJECT_TYPE") ?? "",
+                    subprogramId: rr.optInt("SUBPROGRAM_ID") ?? 0,
+                    overload: rr.optString("OVERLOAD"),
+                    isAggregate: rr.optString("AGGREGATE") == "YES",
+                    isPipelined: rr.optString("PIPELINED") == "YES",
+                    isParallel: rr.optString("PARALLEL") == "YES",
+                    isDeterministic: rr.optString("DETERMINISTIC") == "YES",
+                    isResultCache: rr.optString("RESULT_CACHE") == "YES",
+                    authID: rr.optString("AUTHID"),
+                    implTypeOwner: rr.optString("IMPLTYPEOWNER"),
+                    implTypeName: rr.optString("IMPLTYPENAME")
+                ))
+            }
+            return rows
+        }
+    }
+
+    private func fetchProcedureArguments(_ objs: [OracleObject]) async throws -> [ProcedureArgumentDTO] {
+        guard !objs.isEmpty else { return [] }
+        var sql = "select owner, package_name, object_name, subprogram_id, overload, argument_name, position, sequence, data_level, data_type, in_out, data_length, data_precision, data_scale, char_length, defaulted, default_value, type_owner, type_name, type_subname, pls_type from all_arguments where (owner, nvl(package_name, object_name)) in ("
+        var bindings = OracleBindings()
+        var placeholders: [String] = []
+        for (i, obj) in objs.enumerated() {
+            placeholders.append("(:o\(i), :n\(i))")
+            bindings.append(obj.owner, context: .default, bindName: "o\(i)")
+            bindings.append(obj.name, context: .default, bindName: "n\(i)")
+        }
+        sql += placeholders.joined(separator: ",")
+        sql += ") order by owner, package_name nulls first, object_name, subprogram_id, sequence"
+
+        let logger = oracleLogger
+        let finalSQL = sql
+        let finalBindings = bindings
+        return try await withClient { conn in
+            var options = StatementOptions()
+            options.prefetchRows = 10_000
+            let stream = try await conn.execute(
+                OracleStatement(unsafeSQL: finalSQL, binds: finalBindings),
+                options: options,
+                logger: logger
+            )
+            var rows: [ProcedureArgumentDTO] = []
+            for try await row in stream {
+                let rr = row.makeRandomAccess()
+                guard let owner = rr.optString("OWNER") else { continue }
+                let packageName = rr.optString("PACKAGE_NAME")
+                let memberName = rr.optString("OBJECT_NAME") ?? ""
+                let parentName = packageName ?? memberName
+                rows.append(ProcedureArgumentDTO(
+                    owner: owner,
+                    objectName: parentName,
+                    procedureName: memberName,
+                    overload: rr.optString("OVERLOAD"),
+                    subprogramId: rr.optInt("SUBPROGRAM_ID") ?? 0,
+                    position: rr.optInt("POSITION") ?? 0,
+                    sequence: rr.optInt("SEQUENCE") ?? 0,
+                    dataLevel: rr.optInt("DATA_LEVEL") ?? 0,
+                    argumentName: rr.optString("ARGUMENT_NAME"),
+                    dataType: rr.optString("DATA_TYPE"),
+                    inOut: rr.optString("IN_OUT"),
+                    dataLength: rr.optInt("DATA_LENGTH") ?? 0,
+                    dataPrecision: rr.optInt("DATA_PRECISION"),
+                    dataScale: rr.optInt("DATA_SCALE"),
+                    charLength: rr.optInt("CHAR_LENGTH") ?? 0,
+                    defaulted: rr.optString("DEFAULTED") == "Y",
+                    defaultValue: rr.optString("DEFAULT_VALUE"),
+                    typeOwner: rr.optString("TYPE_OWNER"),
+                    typeName: rr.optString("TYPE_NAME"),
+                    typeSubname: rr.optString("TYPE_SUBNAME"),
+                    plsType: rr.optString("PLS_TYPE")
+                ))
+            }
+            return rows
+        }
+    }
+
+    private func persistProcedures(_ procedures: [ProcedureDTO], arguments: [ProcedureArgumentDTO], objs: [OracleObject]) async {
+        await self.backgroundPerform { context in
+            // Drop prior rows for the in-scope (owner, objectName) pairs so
+            // overload removal and signature changes are handled atomically.
+            for obj in objs {
+                try? self.deleteProcedures(forOwner: obj.owner, name: obj.name, in: context)
+                try? self.deleteProcedureArguments(forOwner: obj.owner, name: obj.name, in: context)
+            }
+            for proc in procedures {
+                let entity = DBCacheProcedure(context: context)
+                entity.owner_ = proc.owner
+                entity.objectName_ = proc.objectName
+                entity.procedureName_ = proc.procedureName
+                entity.objectType_ = proc.objectType
+                entity.subprogramId = Int32(proc.subprogramId)
+                entity.overload_ = proc.overload
+                entity.isAggregate = proc.isAggregate
+                entity.isPipelined = proc.isPipelined
+                entity.isParallel = proc.isParallel
+                entity.isDeterministic = proc.isDeterministic
+                entity.isResultCache = proc.isResultCache
+                entity.authID_ = proc.authID
+                entity.implTypeOwner_ = proc.implTypeOwner
+                entity.implTypeName_ = proc.implTypeName
+            }
+            for arg in arguments {
+                let entity = DBCacheProcedureArgument(context: context)
+                entity.owner_ = arg.owner
+                entity.objectName_ = arg.objectName
+                entity.procedureName_ = arg.procedureName
+                entity.overload_ = arg.overload
+                entity.subprogramId = Int32(arg.subprogramId)
+                entity.position = Int16(arg.position)
+                entity.sequence = Int16(arg.sequence)
+                entity.dataLevel = Int16(arg.dataLevel)
+                entity.argumentName_ = arg.argumentName
+                entity.dataType_ = arg.dataType
+                entity.inOut_ = arg.inOut
+                entity.dataLength = Int32(arg.dataLength)
+                entity.dataPrecision = Int16(arg.dataPrecision ?? 0)
+                entity.dataScale = Int16(arg.dataScale ?? 0)
+                entity.charLength = Int32(arg.charLength)
+                entity.defaulted = arg.defaulted
+                entity.defaultValue_ = arg.defaultValue
+                entity.typeOwner_ = arg.typeOwner
+                entity.typeName_ = arg.typeName
+                entity.typeSubname_ = arg.typeSubname
+                entity.plsType_ = arg.plsType
+            }
+            self.processObjects(objs, context: context)
+            try? context.save()
+        }
+    }
+
+    nonisolated func deleteProcedures(forOwner owner: String, name: String, in context: NSManagedObjectContext) throws {
+        let fetchRequest: NSFetchRequest<any NSFetchRequestResult> = NSFetchRequest(entityName: "DBCacheProcedure")
+        fetchRequest.predicate = NSPredicate(format: "owner_ = %@ and objectName_ = %@", owner, name)
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        deleteRequest.resultType = .resultTypeObjectIDs
+        let batchDelete = try context.execute(deleteRequest) as? NSBatchDeleteResult
+        guard let deleteResult = batchDelete?.result else { return }
+        let changes: [AnyHashable: Any] = [NSDeletedObjectsKey: deleteResult as! [NSManagedObjectID]]
+        if !changes.isEmpty {
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [context])
+        }
+    }
+
+    nonisolated func deleteProcedureArguments(forOwner owner: String, name: String, in context: NSManagedObjectContext) throws {
+        let fetchRequest: NSFetchRequest<any NSFetchRequestResult> = NSFetchRequest(entityName: "DBCacheProcedureArgument")
+        fetchRequest.predicate = NSPredicate(format: "owner_ = %@ and objectName_ = %@", owner, name)
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        deleteRequest.resultType = .resultTypeObjectIDs
+        let batchDelete = try context.execute(deleteRequest) as? NSBatchDeleteResult
+        guard let deleteResult = batchDelete?.result else { return }
+        let changes: [AnyHashable: Any] = [NSDeletedObjectsKey: deleteResult as! [NSManagedObjectID]]
+        if !changes.isEmpty {
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [context])
+        }
+    }
+
     // MARK: - Cleanup dropped objects
 
     func cleanupDroppedObjects() async {
@@ -1204,10 +1451,13 @@ from dba_objects o
             log.cache.error("refreshObject failed: \(error.localizedDescription, privacy: .public)")
         }
         if let obj = fetchedObj {
-            if currentObj.type == .package || currentObj.type == .type {
+            if currentObj.type == .package || currentObj.type == .type || currentObj.type == .procedure || currentObj.type == .function {
                 await self.processSourceChunk([obj])
             } else {
                 await self.processChunkOfObjects([obj], objectType: obj.type)
+            }
+            if currentObj.type == .package || currentObj.type == .procedure || currentObj.type == .function {
+                await self.processProceduresChunk([obj])
             }
         } else {
             await dropLocalObject(currentObj)
@@ -1251,11 +1501,15 @@ from dba_objects o
             let index = (try? context.fetch(request))?.first
             try? deleteIndexColumns(for: index, in: context)
             dropManagedObject(index, with: context)
-        case .type, .package:
+        case .type, .package, .procedure, .function:
             let request = DBCacheSource.fetchRequest()
             request.predicate = NSPredicate(format: "name_ = %@ and owner_ = %@", obj.name, obj.owner)
             let src = (try? context.fetch(request))?.first
             dropManagedObject(src, with: context)
+            if OracleObjectType(rawValue: obj.type) != .type {
+                try? deleteProcedureArguments(forOwner: obj.owner, name: obj.name, in: context)
+                try? deleteProcedures(forOwner: obj.owner, name: obj.name, in: context)
+            }
         default:
             break
         }

--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -10,6 +10,18 @@ import os
 
 struct DBDetailObjectMainView: View {
     @Binding var dbObject: DBCacheObject
+
+    private var hasProcedureContent: Bool {
+        switch dbObject.type {
+        case OracleObjectType.package.rawValue,
+             OracleObjectType.procedure.rawValue,
+             OracleObjectType.function.rawValue:
+            return true
+        default:
+            return false
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0.0) {
             Form {
@@ -28,7 +40,11 @@ struct DBDetailObjectMainView: View {
                     .stroke(.quaternary, lineWidth: 2)
             )
             .padding([.top, .leading, .trailing])
-            Spacer()
+            if hasProcedureContent {
+                PackageProceduresListView(dbObject: dbObject)
+            } else {
+                Spacer()
+            }
         }
     }
 }

--- a/Macintora/DBObjectsBrowser/PackageProceduresListView.swift
+++ b/Macintora/DBObjectsBrowser/PackageProceduresListView.swift
@@ -1,0 +1,187 @@
+//
+//  PackageProceduresListView.swift
+//  Macintora
+//
+
+import SwiftUI
+import CoreData
+
+struct PackageProceduresListView: View {
+    @FetchRequest private var procedures: FetchedResults<DBCacheProcedure>
+    @FetchRequest private var arguments: FetchedResults<DBCacheProcedureArgument>
+
+    init(dbObject: DBCacheObject) {
+        let predicate = NSPredicate(format: "owner_ = %@ and objectName_ = %@", dbObject.owner, dbObject.name)
+        _procedures = FetchRequest<DBCacheProcedure>(
+            sortDescriptors: [
+                NSSortDescriptor(key: "procedureName_", ascending: true),
+                NSSortDescriptor(key: "overload_", ascending: true)
+            ],
+            predicate: predicate
+        )
+        _arguments = FetchRequest<DBCacheProcedureArgument>(
+            sortDescriptors: [
+                NSSortDescriptor(key: "procedureName_", ascending: true),
+                NSSortDescriptor(key: "overload_", ascending: true),
+                NSSortDescriptor(key: "sequence", ascending: true)
+            ],
+            predicate: predicate
+        )
+    }
+
+    private var groups: [ProcedureGroup] {
+        // Build (procedureName, overload, subprogramId) groups, drop the
+        // SUBPROGRAM_ID = 0 package-itself row (procedureName == "" or equal
+        // to package name with no procedureName).
+        var byKey: [GroupKey: ProcedureGroup] = [:]
+        for proc in procedures {
+            let procName = proc.procedureName_ ?? ""
+            guard !procName.isEmpty else { continue }
+            // Skip the package self row: ALL_PROCEDURES emits a row with
+            // PROCEDURE_NAME = NULL for the package itself; once stored in
+            // CoreData, that field is nil and filtered above. The remaining
+            // edge case is a row where PROCEDURE_NAME equals the package name
+            // (rare but possible for a standalone listing) — keep it.
+            let key = GroupKey(name: procName, overload: proc.overload_ ?? "", subprogramId: proc.subprogramId)
+            if byKey[key] == nil {
+                byKey[key] = ProcedureGroup(
+                    key: key,
+                    objectType: proc.objectType_ ?? "",
+                    isPipelined: proc.isPipelined,
+                    isDeterministic: proc.isDeterministic,
+                    parameters: [],
+                    returnType: nil
+                )
+            }
+        }
+        for arg in arguments {
+            guard arg.dataLevel == 0 else { continue }
+            let procName = arg.procedureName_ ?? ""
+            guard !procName.isEmpty else { continue }
+            // Match the matching procedure group by (name, overload). The
+            // subprogramId may differ across schemas/overloads, so we key
+            // primarily by name + overload and fold subprogramId in if a
+            // match exists.
+            let candidate = byKey.keys.first {
+                $0.name == procName && $0.overload == (arg.overload_ ?? "")
+            }
+            guard let key = candidate else { continue }
+            if arg.position == 0 && arg.argumentName_ == nil {
+                byKey[key]?.returnType = arg.dataType_
+            } else if arg.position > 0 {
+                byKey[key]?.parameters.append(arg)
+            }
+        }
+        return byKey.values.sorted { lhs, rhs in
+            if lhs.key.name != rhs.key.name { return lhs.key.name < rhs.key.name }
+            return lhs.key.overload < rhs.key.overload
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if procedures.isEmpty {
+                Text("No procedures or functions cached for this object.")
+                    .foregroundStyle(.secondary)
+                    .padding()
+            } else {
+                List {
+                    ForEach(groups) { group in
+                        Section {
+                            if group.parameters.isEmpty {
+                                Text("(no parameters)")
+                                    .foregroundStyle(.secondary)
+                                    .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+                            } else {
+                                ForEach(group.parameters) { arg in
+                                    ArgumentRow(argument: arg)
+                                }
+                            }
+                        } header: {
+                            ProcedureHeader(group: group)
+                        }
+                    }
+                }
+                .listStyle(.inset)
+                .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+            }
+        }
+        .padding()
+        .overlay(
+            RoundedRectangle(cornerRadius: 25)
+                .stroke(.quaternary, lineWidth: 2)
+        )
+        .padding([.top, .leading, .trailing])
+    }
+}
+
+private struct GroupKey: Hashable {
+    let name: String
+    let overload: String
+    let subprogramId: Int32
+}
+
+private struct ProcedureGroup: Identifiable {
+    let key: GroupKey
+    let objectType: String
+    let isPipelined: Bool
+    let isDeterministic: Bool
+    var parameters: [DBCacheProcedureArgument]
+    var returnType: String?
+
+    var id: GroupKey { key }
+    var isFunction: Bool { returnType != nil }
+}
+
+private struct ProcedureHeader: View {
+    let group: ProcedureGroup
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: group.isFunction ? "f.cursive" : "curlybraces")
+                .foregroundStyle(.tint)
+            Text(group.key.name)
+                .bold()
+            if !group.key.overload.isEmpty {
+                Text("#\(group.key.overload)")
+                    .foregroundStyle(.secondary)
+            }
+            if let returnType = group.returnType {
+                Text("→ \(returnType)")
+                    .foregroundStyle(.secondary)
+            }
+            if group.isPipelined {
+                Text("[pipelined]").foregroundStyle(.secondary)
+            }
+            if group.isDeterministic {
+                Text("[deterministic]").foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+    }
+}
+
+private struct ArgumentRow: View {
+    let argument: DBCacheProcedureArgument
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(argument.argumentName_ ?? "(positional)")
+                .foregroundStyle(.primary)
+            Text(":")
+                .foregroundStyle(.secondary)
+            Text(argument.dataType_ ?? "")
+                .foregroundStyle(.secondary)
+            Text("[\(argument.inOut_ ?? "IN")]")
+                .foregroundStyle(.tertiary)
+            if argument.defaulted, let value = argument.defaultValue_, !value.isEmpty {
+                Text("DEFAULT \(value)")
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer()
+        }
+    }
+}

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -191,6 +191,148 @@ actor CompletionDataSource {
         }
     }
 
+    /// Procedures and functions that belong to `packageName` (for package
+    /// members) or whose own object name equals `packageName` (for standalones).
+    /// `search` is matched as a case-insensitive substring against the member
+    /// name. The kind ("PROCEDURE" / "FUNCTION") and `returnType` are derived
+    /// from a parallel fetch on `DBCacheProcedureArgument` rows where
+    /// `position == 0 && dataLevel == 0` — that row exists only for functions
+    /// and carries the return type, so its absence flags a procedure.
+    func procedures(packageName: String,
+                    owner: String?,
+                    search: String,
+                    limit: Int) async -> [ProcedureSuggestion] {
+        await fetch { ctx -> [ProcedureSuggestion] in
+            let upperPkg = packageName.uppercased()
+            let upperSearch = search.uppercased()
+
+            // 1. Procedures.
+            let procRequest = DBCacheProcedure.fetchRequest()
+            var procPredicates: [NSPredicate] = [
+                NSPredicate(format: "objectName_ = %@", upperPkg),
+                NSPredicate(format: "procedureName_ != nil")
+            ]
+            if let owner {
+                procPredicates.append(NSPredicate(format: "owner_ = %@", owner.uppercased()))
+            }
+            if !upperSearch.isEmpty {
+                procPredicates.append(NSPredicate(format: "procedureName_ CONTAINS[c] %@", upperSearch))
+            }
+            procRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: procPredicates)
+            procRequest.sortDescriptors = [
+                NSSortDescriptor(key: "procedureName_", ascending: true),
+                NSSortDescriptor(key: "overload_", ascending: true)
+            ]
+            procRequest.fetchLimit = max(limit * 4, limit)
+
+            // 2. Return-type rows (one fetch, dictionary-keyed lookup below).
+            let argRequest = DBCacheProcedureArgument.fetchRequest()
+            var argPredicates: [NSPredicate] = [
+                NSPredicate(format: "objectName_ = %@", upperPkg),
+                NSPredicate(format: "position == 0"),
+                NSPredicate(format: "dataLevel == 0"),
+                NSPredicate(format: "argumentName_ == nil")
+            ]
+            if let owner {
+                argPredicates.append(NSPredicate(format: "owner_ = %@", owner.uppercased()))
+            }
+            argRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: argPredicates)
+
+            do {
+                let procRows = try ctx.fetch(procRequest)
+                let argRows = try ctx.fetch(argRequest)
+                struct ReturnKey: Hashable { let owner, name, overload: String }
+                var returnTypes: [ReturnKey: String] = [:]
+                for arg in argRows {
+                    let key = ReturnKey(
+                        owner: arg.owner_ ?? "",
+                        name: arg.procedureName_ ?? "",
+                        overload: arg.overload_ ?? ""
+                    )
+                    returnTypes[key] = arg.dataType_ ?? ""
+                }
+                let suggestions: [ProcedureSuggestion] = procRows.compactMap { row in
+                    guard let procName = row.procedureName_, !procName.isEmpty,
+                          let pkg = row.objectName_ else { return nil }
+                    // Skip the SUBPROGRAM_ID = 0 package-itself row that
+                    // ALL_PROCEDURES emits (procedureName == objectName).
+                    if procName == pkg && (row.objectType_ ?? "") == "PACKAGE" {
+                        return nil
+                    }
+                    let key = ReturnKey(
+                        owner: row.owner_ ?? "",
+                        name: procName,
+                        overload: row.overload_ ?? ""
+                    )
+                    let returnType = returnTypes[key]
+                    return ProcedureSuggestion(
+                        owner: row.owner_ ?? "",
+                        packageName: pkg,
+                        procedureName: procName,
+                        overload: row.overload_,
+                        subprogramId: Int(row.subprogramId),
+                        kind: returnType != nil ? "FUNCTION" : "PROCEDURE",
+                        parentType: row.objectType_ ?? "",
+                        returnType: returnType
+                    )
+                }
+                return self.rankByPrefixThenInfix(suggestions,
+                                                  name: \.procedureName,
+                                                  search: upperSearch,
+                                                  limit: limit)
+            } catch {
+                self.logger.error("procedures fetch failed: \(error.localizedDescription, privacy: .public)")
+                return []
+            }
+        }
+    }
+
+    /// Arguments of a single procedure / function invocation. Excludes the
+    /// `position == 0` return-value row (callers consume return type via
+    /// `procedures(...).returnType`) and `dataLevel > 0` composite expansions.
+    func procedureArguments(owner: String,
+                            packageName: String,
+                            procedureName: String,
+                            overload: String?) async -> [ProcedureArgumentSuggestion] {
+        await fetch { ctx -> [ProcedureArgumentSuggestion] in
+            let request = DBCacheProcedureArgument.fetchRequest()
+            var predicates: [NSPredicate] = [
+                NSPredicate(format: "owner_ = %@", owner.uppercased()),
+                NSPredicate(format: "objectName_ = %@", packageName.uppercased()),
+                NSPredicate(format: "procedureName_ = %@", procedureName.uppercased()),
+                NSPredicate(format: "dataLevel == 0"),
+                NSPredicate(format: "position > 0")
+            ]
+            if let overload, !overload.isEmpty {
+                predicates.append(NSPredicate(format: "overload_ = %@", overload))
+            } else {
+                predicates.append(NSPredicate(format: "overload_ == nil OR overload_ = %@", ""))
+            }
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+            request.sortDescriptors = [NSSortDescriptor(key: "sequence", ascending: true)]
+            do {
+                let rows = try ctx.fetch(request)
+                return rows.map { row in
+                    ProcedureArgumentSuggestion(
+                        owner: row.owner_ ?? "",
+                        packageName: row.objectName_ ?? "",
+                        procedureName: row.procedureName_ ?? "",
+                        overload: row.overload_,
+                        position: Int(row.position),
+                        argumentName: row.argumentName_,
+                        dataType: row.dataType_ ?? "",
+                        inOut: row.inOut_ ?? "IN",
+                        defaulted: row.defaulted,
+                        defaultValue: row.defaultValue_
+                    )
+                }
+            } catch {
+                self.logger.error("procedureArguments fetch failed: \(error.localizedDescription, privacy: .public)")
+                return []
+            }
+        }
+    }
+
     /// Two-tier rank for a list returned by a `CONTAINS[c]` predicate:
     /// 1. name-prefix matches first, infix matches after;
     /// 2. within each tier, rows whose owner equals `preferredOwner` first.

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -35,6 +35,36 @@ struct ObjectSuggestion: Sendable, Hashable {
     let type: String   // "TABLE" / "VIEW" / "PACKAGE" / "PROCEDURE" / etc.
 }
 
+struct ProcedureSuggestion: Sendable, Hashable {
+    let owner: String
+    /// Package name for package members; the standalone proc/func name otherwise.
+    let packageName: String
+    let procedureName: String
+    let overload: String?
+    let subprogramId: Int
+    /// `"PROCEDURE"` or `"FUNCTION"` — the ALL_PROCEDURES.OBJECT_TYPE of the
+    /// parent (PACKAGE for members) is on `parentType`.
+    let kind: String
+    let parentType: String
+    /// Non-nil when the row is a function — read off the `position == 0`
+    /// argument row.
+    let returnType: String?
+}
+
+struct ProcedureArgumentSuggestion: Sendable, Hashable {
+    let owner: String
+    let packageName: String
+    let procedureName: String
+    let overload: String?
+    let position: Int
+    let argumentName: String?
+    let dataType: String
+    /// `"IN"` / `"OUT"` / `"IN/OUT"`.
+    let inOut: String
+    let defaulted: Bool
+    let defaultValue: String?
+}
+
 // MARK: - STCompletionItem implementation
 
 /// Single row in the completion popup. Marked `@unchecked Sendable` because
@@ -49,6 +79,8 @@ final class MacintoraCompletionItem: NSObject, STCompletionItem, @unchecked Send
         case column
         case schema
         case packageObject
+        case procedure
+        case function
         case generic
     }
 
@@ -129,6 +161,8 @@ private extension MacintoraCompletionItem.Kind {
         case .column: return "list.bullet"
         case .schema: return "person.crop.square"
         case .packageObject: return "shippingbox"
+        case .procedure: return "curlybraces"
+        case .function: return "f.cursive"
         case .generic: return "circle"
         }
     }
@@ -177,6 +211,22 @@ extension MacintoraCompletionItem {
             displayText: o.name,
             insertText: o.name.lowercased(),
             secondaryText: "\(o.owner) · \(o.type)",
+            kind: kind)
+    }
+
+    static func make(from p: ProcedureSuggestion) -> MacintoraCompletionItem {
+        let kind: Kind = p.kind == "FUNCTION" ? .function : .procedure
+        var secondary = p.kind
+        if let overload = p.overload, !overload.isEmpty {
+            secondary += " #\(overload)"
+        }
+        if let returnType = p.returnType, !returnType.isEmpty {
+            secondary += " → \(returnType)"
+        }
+        return MacintoraCompletionItem(
+            displayText: p.procedureName,
+            insertText: p.procedureName.lowercased(),
+            secondaryText: secondary,
             kind: kind)
     }
 }

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -60,6 +60,12 @@ extension MacintoraAppDelegate: nonisolated NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // When the app is launched as an XCTest host, skip session restore
+        // and snapshot wiring entirely. Otherwise the test launch would
+        // clobber the user's persisted session list with whatever the test
+        // bundle happens to leave behind.
+        if Self.isRunningInTestHost { return }
+
         // `OperationQueue.main` runs callbacks on the main thread, but the
         // closure type isn't compile-time MainActor — wrap each body with
         // `MainActor.assumeIsolated`.
@@ -79,6 +85,10 @@ extension MacintoraAppDelegate: nonisolated NSApplicationDelegate {
         restoreSessionIfNeeded()
     }
 
+    private static var isRunningInTestHost: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
         // SwiftUI's DocumentGroup typically auto-creates the Untitled doc
         // before this hook fires on cold launch, so its return value is
@@ -89,6 +99,7 @@ extension MacintoraAppDelegate: nonisolated NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         // Final save on clean ⌘Q. Force through even if a restore was still
         // in flight so we capture the user's actual final state.
+        if Self.isRunningInTestHost { return }
         restoreInProgress = false
         snapshotSession()
     }

--- a/Macintora/MainApp/WindowLayoutPersister.swift
+++ b/Macintora/MainApp/WindowLayoutPersister.swift
@@ -44,12 +44,22 @@ struct WindowLayoutPersister: NSViewRepresentable {
             // We're on the main actor here, so reading it is fine.
             guard !didConfigure, let window = unsafe self.window else { return }
             didConfigure = true
+            // Skip persistence wiring entirely under XCTest. The autosave
+            // round-trip can replay an off-screen frame from a prior session
+            // (e.g., a disconnected secondary display), which sends AppKit's
+            // constraint engine into a runaway update-pass loop and aborts
+            // the host app before the test runner finishes bootstrapping.
+            if Self.isRunningInTestHost { return }
             configureWindow(window)
             // Defer split-view discovery: SwiftUI may not have laid out the
             // NSSplitView descendants by the time this view enters the window.
             DispatchQueue.main.async { [weak self] in
                 self?.configureSplitViews()
             }
+        }
+
+        private static var isRunningInTestHost: Bool {
+            ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
         }
 
         override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -79,6 +89,35 @@ struct WindowLayoutPersister: NSViewRepresentable {
                 window.setFrame(NSRect(x: x, y: y, width: w, height: h), display: true)
             }
             window.setFrameAutosaveName(windowAutosaveName)
+            // setFrameAutosaveName has already replayed any persisted frame.
+            // If the persisted frame lived on a now-disconnected display, the
+            // window can land entirely off-screen — at which point AppKit's
+            // constraint engine thrashes ("more Update Constraints in Window
+            // passes than there are views") and may even throw. Detect that
+            // and snap the window back onto a visible screen.
+            ensureFrameIsOnScreen(window)
+        }
+
+        /// If the window's frame doesn't intersect any connected screen by a
+        /// reasonable margin, recenter it on the main screen at the default
+        /// size and rewrite the autosave entry so the next launch is clean.
+        private func ensureFrameIsOnScreen(_ window: NSWindow) {
+            let frame = window.frame
+            let screens = NSScreen.screens
+            let minVisibleArea: CGFloat = 100 * 100
+            let onScreen = screens.contains { screen in
+                let intersection = frame.intersection(screen.visibleFrame)
+                guard !intersection.isNull else { return false }
+                return intersection.width * intersection.height >= minVisibleArea
+            }
+            guard !onScreen, let target = NSScreen.main ?? screens.first else { return }
+            let visible = target.visibleFrame
+            let width = min(frame.width > 0 ? frame.width : 1100, visible.width)
+            let height = min(frame.height > 0 ? frame.height : 700, visible.height)
+            let originX = visible.minX + (visible.width - width) / 2
+            let originY = visible.minY + (visible.height - height) / 2
+            window.setFrame(NSRect(x: originX, y: originY, width: width, height: height), display: true)
+            window.saveFrame(usingName: windowAutosaveName)
         }
 
         // MARK: - Split-view dividers

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -110,6 +110,45 @@ final class CompletionDataSourceTests: XCTestCase {
         XCTAssertEqual(result.first?.owner, "HR")
     }
 
+    // MARK: - Procedures
+
+    func test_procedures_listsPackageMembers_skipsSelfRow() async {
+        seedAccountsPackage()
+        let result = await dataSource.procedures(
+            packageName: "ACCOUNTS_PKG", owner: "HR", search: "", limit: 10)
+        // Three subprograms: get_balance (function), debit (procedure with two
+        // overloads). The SUBPROGRAM_ID = 0 self-row is excluded.
+        XCTAssertEqual(Set(result.map(\.procedureName)), Set(["GET_BALANCE", "DEBIT"]))
+    }
+
+    func test_procedures_classifiesFunctionByReturnRow() async {
+        seedAccountsPackage()
+        let result = await dataSource.procedures(
+            packageName: "ACCOUNTS_PKG", owner: "HR", search: "GET", limit: 10)
+        let getBalance = result.first { $0.procedureName == "GET_BALANCE" }
+        XCTAssertEqual(getBalance?.kind, "FUNCTION")
+        XCTAssertEqual(getBalance?.returnType, "NUMBER")
+    }
+
+    func test_procedures_classifiesProcedureWhenNoReturnRow() async {
+        seedAccountsPackage()
+        let result = await dataSource.procedures(
+            packageName: "ACCOUNTS_PKG", owner: "HR", search: "DEBIT", limit: 10)
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertTrue(result.allSatisfy { $0.kind == "PROCEDURE" })
+        XCTAssertTrue(result.allSatisfy { $0.returnType == nil })
+    }
+
+    func test_procedureArguments_filtersByOverload_excludesReturnRow() async {
+        seedAccountsPackage()
+        let args = await dataSource.procedureArguments(
+            owner: "HR", packageName: "ACCOUNTS_PKG",
+            procedureName: "DEBIT", overload: "1")
+        // Overload 1 has a single AMOUNT parameter; overload 2 has two.
+        XCTAssertEqual(args.map(\.argumentName), ["AMOUNT"])
+        XCTAssertTrue(args.allSatisfy { $0.position > 0 })
+    }
+
     // MARK: - Seed helpers
 
     private func seed() {
@@ -147,5 +186,80 @@ final class CompletionDataSourceTests: XCTestCase {
         row.owner_ = owner
         row.name_ = name
         row.type_ = type
+    }
+
+    /// Seeds a package `HR.ACCOUNTS_PKG` with three subprograms:
+    /// - `GET_BALANCE` (FUNCTION): return NUMBER, one IN parameter ACCT_ID.
+    /// - `DEBIT` overload 1 (PROCEDURE): one IN parameter AMOUNT.
+    /// - `DEBIT` overload 2 (PROCEDURE): two parameters AMOUNT and CURRENCY.
+    /// Plus a SUBPROGRAM_ID=0 self-row that the data source must skip.
+    private func seedAccountsPackage() {
+        let ctx = persistence.container.viewContext
+
+        addProcedure(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG",
+                     name: nil, subprogramId: 0, overload: nil,
+                     parentType: "PACKAGE")
+        addProcedure(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG",
+                     name: "GET_BALANCE", subprogramId: 1, overload: nil,
+                     parentType: "PACKAGE")
+        addProcedure(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG",
+                     name: "DEBIT", subprogramId: 2, overload: "1",
+                     parentType: "PACKAGE")
+        addProcedure(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG",
+                     name: "DEBIT", subprogramId: 2, overload: "2",
+                     parentType: "PACKAGE")
+
+        // GET_BALANCE return row + IN parameter.
+        addArgument(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 0, sequence: 1, name: nil,
+                    dataType: "NUMBER", inOut: "OUT")
+        addArgument(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 1, sequence: 2, name: "ACCT_ID",
+                    dataType: "NUMBER", inOut: "IN")
+
+        // DEBIT overload 1 — single parameter.
+        addArgument(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "1", position: 1, sequence: 1, name: "AMOUNT",
+                    dataType: "NUMBER", inOut: "IN")
+
+        // DEBIT overload 2 — two parameters.
+        addArgument(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "2", position: 1, sequence: 1, name: "AMOUNT",
+                    dataType: "NUMBER", inOut: "IN")
+        addArgument(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "2", position: 2, sequence: 2, name: "CURRENCY",
+                    dataType: "VARCHAR2", inOut: "IN")
+
+        try! ctx.save()
+    }
+
+    private func addProcedure(in ctx: NSManagedObjectContext,
+                              owner: String, pkg: String, name: String?,
+                              subprogramId: Int32, overload: String?,
+                              parentType: String) {
+        let row = DBCacheProcedure(context: ctx)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = name
+        row.objectType_ = parentType
+        row.subprogramId = subprogramId
+        row.overload_ = overload
+    }
+
+    private func addArgument(in ctx: NSManagedObjectContext,
+                             owner: String, pkg: String, proc: String,
+                             overload: String?, position: Int16, sequence: Int16,
+                             name: String?, dataType: String, inOut: String) {
+        let row = DBCacheProcedureArgument(context: ctx)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = proc
+        row.overload_ = overload
+        row.position = position
+        row.sequence = sequence
+        row.dataLevel = 0
+        row.argumentName_ = name
+        row.dataType_ = dataType
+        row.inOut_ = inOut
     }
 }


### PR DESCRIPTION
## Summary

- Adds structured procedure / argument metadata to the DB cache from `ALL_PROCEDURES` and `ALL_ARGUMENTS`, with chunked ingestion piggybacking on the existing incremental-refresh watermark.
- Package detail Main tab now lists procedures and functions grouped by `(name, overload)` with return types and `IN`/`OUT`/default annotations.
- `CompletionDataSource` exposes `procedures(...)` and `procedureArguments(...)` so future completion work can consume the data without going through CoreData directly. Wiring into the editor popup is tracked in #10.
- Fixes a latent host-app crash (refs #4) that was preventing unit tests from bootstrapping: `setFrameAutosaveName` was replaying an off-screen frame from a prior multi-monitor session. Added an on-screen clamp and an XCTest short-circuit.

## Test plan

- [x] `xcodebuild build -scheme Macintora -destination 'platform=macOS'` — clean
- [x] `xcodebuild test -scheme Macintora -destination 'platform=macOS' -only-testing:MacintoraTests` — 283 passed, 1 skipped, 0 failures
- [x] Manual: full refresh against a live Oracle DB; `ZDBCACHEPROCEDURE` and `ZDBCACHEPROCEDUREARGUMENT` populated for packages, standalone procs, and standalone functions
- [x] Manual: Package Main tab renders member list with overloads, return types, IN/OUT/default annotations
- [x] Manual: incremental refresh after recompiling a package body re-ingests procedures/arguments

## Follow-up issues

- #4 — Hardened restore: validate autosaved window frame (closed-eligible once this merges)
- #8 — Hardened session restore: detect unclean previous launch
- #9 — Hardened restore: validate split-view divider sizes
- #10 — Code completion: surface package procedures, functions, and arguments