### PR TITLE
Editor: Quick View popover for DB objects at the cursor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,26 @@ Macintora is a SQL IDE tool for Oracle databases. It is written for Developers b
 - Connections manager where a user may choose a database connection, connect and disconnect from the database.
 
 ## Dependencies
-- STTextView
-- STTextView-Plugin-Neon
-- STTextKitPlus
-The dependencies are Swift SPM repositories that live next to the project directory. For example, STTextView repository is located in /Users/ilia/Developer/STTextView
+
+The following dependencies are **forked or owned by `iliasaz`** and consumed by Macintora as Swift SPM remote source-control packages. Their `git push origin macintora` is what ships changes back to the app — Macintora's `Package.resolved` pins each to a specific commit on the `macintora` branch, so a local SHA bump is required after pushing fixes upstream.
+
+| Repo | iliasaz role | Local checkout | Branch | Notes |
+|---|---|---|---|---|
+| [iliasaz/oracle-nio](https://github.com/iliasaz/oracle-nio) | fork of `lovetodream/oracle-nio` | `/Users/ilia/Developer/oracle-nio` | `macintora` | Pure-Swift Oracle TTC/TNS driver. |
+| [iliasaz/STTextView](https://github.com/iliasaz/STTextView) | fork of `krzyzanowskim/STTextView` | `/Users/ilia/Developer/STTextView` | `macintora` | TextKit 2 source editor. |
+| [iliasaz/STTextView-Plugin-Neon](https://github.com/iliasaz/STTextView-Plugin-Neon) | fork of `krzyzanowskim/STTextView-Plugin-Neon` | `/Users/ilia/Developer/STTextView-Plugin-Neon` | `macintora` | Tree-sitter highlighting plugin. Vendors `tree-sitter-sql-orcl` as the `TreeSitterSQLOrcl` SPM target. |
+| [iliasaz/STTextKitPlus](https://github.com/iliasaz/STTextKitPlus) | fork of `krzyzanowskim/STTextKitPlus` | `/Users/ilia/Developer/STTextKitPlus` | `macintora` | TextKit 2 range / location helpers. |
+| [iliasaz/tree-sitter-sql-orcl](https://github.com/iliasaz/tree-sitter-sql-orcl) | owned (no upstream) | `/Users/ilia/Developer/tree-sitter-sql-orcl` | `main` | Oracle SQL & PL/SQL grammar. Powers syntax highlighting, code completion, and the Quick View object resolver. |
+
+### Editing a fork
+
+1. Edit files in the local checkout (`/Users/ilia/Developer/<repo>`).
+2. `git checkout macintora` if not already on it.
+3. Commit and push: `git push origin macintora`.
+4. Update Macintora's pinned revision in `Macintora.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` so the next build picks up the new commit.
+5. Build Macintora and verify.
+
+Other dependencies (Apple `swift-*`, `vapor/postgres-nio`, `ChimeHQ/SwiftTreeSitter`, etc.) are remote and not forked — they're listed in `Package.resolved`.
 
 ## Role
 
@@ -48,6 +64,7 @@ This project uses Swift 6.2 approachable concurrency, which means:
 - Use `@concurrent` to explicitly run async functions on the concurrent thread pool when parallelism is needed.
 - Do not manually mark classes with `@MainActor` unless they need to be isolated from default main actor context.
 - Rely on the compiler's automatic `@Sendable` inference from captures.
+- Always review swift compiler concurrency and memory safety warnings and do best effort attempt to resolve them. Use swift-concurrency skill.
 
 ### General Swift guidelines
 

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -20,6 +20,11 @@
 		49DB100A0000000A /* STDBObjectQuickViewPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */; };
 		49DB100B0000000B /* EditorQuickViewBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000B0000000B /* EditorQuickViewBox.swift */; };
 		49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000C0000000C /* ObjectAtCursorResolverTests.swift */; };
+		49DB301000000010 /* QuickViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001000000010 /* QuickViewControllerTests.swift */; };
+		49DB301100000011 /* QuickViewHotkeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001100000011 /* QuickViewHotkeyTests.swift */; };
+		49DB301200000012 /* EditorQuickViewBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001200000012 /* EditorQuickViewBoxTests.swift */; };
+		49DB301300000013 /* QuickViewContentRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001300000013 /* QuickViewContentRenderTests.swift */; };
+		49DB301500000015 /* QuickViewEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001500000015 /* QuickViewEndToEndTests.swift */; };
 		490E96B62FA4217200DDF37F /* SqlPlusDirective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B52FA4217200DDF37F /* SqlPlusDirective.swift */; };
 		490E96B82FA4217700DDF37F /* ScriptError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B72FA4217700DDF37F /* ScriptError.swift */; };
 		490E96BA2FA4225300DDF37F /* ScriptLexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B92FA4225300DDF37F /* ScriptLexer.swift */; };
@@ -172,6 +177,7 @@
 		AA0001000000000000000000 /* SessionRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000000 /* SessionRestorer.swift */; };
 		AA0001020000000000000000 /* SessionRestorerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001030000000000000000 /* SessionRestorerTests.swift */; };
 		BB0000010000000000000000 /* MacintoraUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000020000000000000000 /* MacintoraUITests.swift */; };
+		49DB401400000014 /* QuickViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001400000014 /* QuickViewUITests.swift */; };
 		C1C1C1C100000000000000A1 /* STTextView in Frameworks */ = {isa = PBXBuildFile; productRef = B1B1B1B100000000000000A1 /* STTextView */; };
 		C2C2C2C200000000000000B2 /* STTextView-Plugin-Neon in Frameworks */ = {isa = PBXBuildFile; productRef = B2B2B2B200000000000000B2 /* STTextView-Plugin-Neon */; };
 		C3C3C3C300000000000000C3 /* STTextKitPlus in Frameworks */ = {isa = PBXBuildFile; productRef = B3B3B3B300000000000000C3 /* STTextKitPlus */; };
@@ -310,6 +316,11 @@
 		49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STDBObjectQuickViewPlugin.swift; sourceTree = "<group>"; };
 		49DB000B0000000B /* EditorQuickViewBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorQuickViewBox.swift; sourceTree = "<group>"; };
 		49DB000C0000000C /* ObjectAtCursorResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectAtCursorResolverTests.swift; sourceTree = "<group>"; };
+		49DB001000000010 /* QuickViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewControllerTests.swift; sourceTree = "<group>"; };
+		49DB001100000011 /* QuickViewHotkeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewHotkeyTests.swift; sourceTree = "<group>"; };
+		49DB001200000012 /* EditorQuickViewBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorQuickViewBoxTests.swift; sourceTree = "<group>"; };
+		49DB001300000013 /* QuickViewContentRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewContentRenderTests.swift; sourceTree = "<group>"; };
+		49DB001500000015 /* QuickViewEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewEndToEndTests.swift; sourceTree = "<group>"; };
 		49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentVM.swift; sourceTree = "<group>"; };
 		49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionListView.swift; sourceTree = "<group>"; };
 		49CE5FEF27279F3A009C2A94 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
@@ -363,6 +374,7 @@
 		AA0001010000000000000000 /* SessionRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorer.swift; sourceTree = "<group>"; };
 		AA0001030000000000000000 /* SessionRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorerTests.swift; sourceTree = "<group>"; };
 		BB0000020000000000000000 /* MacintoraUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacintoraUITests.swift; sourceTree = "<group>"; };
+		49DB001400000014 /* QuickViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewUITests.swift; sourceTree = "<group>"; };
 		BB0000030000000000000000 /* MacintoraUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacintoraUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -645,6 +657,26 @@
 			path = Completion;
 			sourceTree = "<group>";
 		};
+		49DB001E0000001E /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				49DB001F0000001F /* QuickView */,
+			);
+			path = Plugins;
+			sourceTree = "<group>";
+		};
+		49DB001F0000001F /* QuickView */ = {
+			isa = PBXGroup;
+			children = (
+				49DB001000000010 /* QuickViewControllerTests.swift */,
+				49DB001100000011 /* QuickViewHotkeyTests.swift */,
+				49DB001200000012 /* EditorQuickViewBoxTests.swift */,
+				49DB001300000013 /* QuickViewContentRenderTests.swift */,
+				49DB001500000015 /* QuickViewEndToEndTests.swift */,
+			);
+			path = QuickView;
+			sourceTree = "<group>";
+		};
 		49CE5FEE27279F09009C2A94 /* Results */ = {
 			isa = PBXGroup;
 			children = (
@@ -690,6 +722,7 @@
 				49D0ECF32F9C1E1E0047540A /* EditorSelectionBridgeTests.swift */,
 				49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */,
 				49C0300000000010 /* Completion */,
+				49DB001E0000001E /* Plugins */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -742,6 +775,7 @@
 				BB0000020000000000000000 /* MacintoraUITests.swift */,
 				490E96E52FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift */,
 				490E96E92FA43C6300DDF37F /* ScriptRunnerUXTests.swift */,
+				49DB001400000014 /* QuickViewUITests.swift */,
 			);
 			path = MacintoraUITests;
 			sourceTree = "<group>";
@@ -895,6 +929,11 @@
 				49C0301500000015 /* AliasResolverTests.swift in Sources */,
 				49C0301700000017 /* CompletionDataSourceTests.swift in Sources */,
 				49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */,
+				49DB301000000010 /* QuickViewControllerTests.swift in Sources */,
+				49DB301100000011 /* QuickViewHotkeyTests.swift in Sources */,
+				49DB301200000012 /* EditorQuickViewBoxTests.swift in Sources */,
+				49DB301300000013 /* QuickViewContentRenderTests.swift in Sources */,
+				49DB301500000015 /* QuickViewEndToEndTests.swift in Sources */,
 				4982889F28B41F3A00A28B04 /* MacintoraTests.swift in Sources */,
 				AA0000130000000000000000 /* TnsParserTests.swift in Sources */,
 				490E96BC2FA422AF00DDF37F /* ScriptLexerTests.swift in Sources */,
@@ -1064,6 +1103,7 @@
 				BB0000010000000000000000 /* MacintoraUITests.swift in Sources */,
 				490E96E62FA42DD700DDF37F /* SidebarToggleCrashRegressionTests.swift in Sources */,
 				490E96EA2FA43C6300DDF37F /* ScriptRunnerUXTests.swift in Sources */,
+				49DB401400000014 /* QuickViewUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		49DB301200000012 /* EditorQuickViewBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001200000012 /* EditorQuickViewBoxTests.swift */; };
 		49DB301300000013 /* QuickViewContentRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001300000013 /* QuickViewContentRenderTests.swift */; };
 		49DB301500000015 /* QuickViewEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001500000015 /* QuickViewEndToEndTests.swift */; };
+		49DB301600000016 /* QuickViewClickGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001600000016 /* QuickViewClickGateTests.swift */; };
 		490E96B62FA4217200DDF37F /* SqlPlusDirective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B52FA4217200DDF37F /* SqlPlusDirective.swift */; };
 		490E96B82FA4217700DDF37F /* ScriptError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B72FA4217700DDF37F /* ScriptError.swift */; };
 		490E96BA2FA4225300DDF37F /* ScriptLexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B92FA4225300DDF37F /* ScriptLexer.swift */; };
@@ -325,6 +326,7 @@
 		49DB001200000012 /* EditorQuickViewBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorQuickViewBoxTests.swift; sourceTree = "<group>"; };
 		49DB001300000013 /* QuickViewContentRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewContentRenderTests.swift; sourceTree = "<group>"; };
 		49DB001500000015 /* QuickViewEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewEndToEndTests.swift; sourceTree = "<group>"; };
+		49DB001600000016 /* QuickViewClickGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewClickGateTests.swift; sourceTree = "<group>"; };
 		49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentVM.swift; sourceTree = "<group>"; };
 		49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionListView.swift; sourceTree = "<group>"; };
 		49CE5FEF27279F3A009C2A94 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
@@ -679,6 +681,7 @@
 				49DB001200000012 /* EditorQuickViewBoxTests.swift */,
 				49DB001300000013 /* QuickViewContentRenderTests.swift */,
 				49DB001500000015 /* QuickViewEndToEndTests.swift */,
+				49DB001600000016 /* QuickViewClickGateTests.swift */,
 			);
 			path = QuickView;
 			sourceTree = "<group>";
@@ -940,6 +943,7 @@
 				49DB301200000012 /* EditorQuickViewBoxTests.swift in Sources */,
 				49DB301300000013 /* QuickViewContentRenderTests.swift in Sources */,
 				49DB301500000015 /* QuickViewEndToEndTests.swift in Sources */,
+				49DB301600000016 /* QuickViewClickGateTests.swift in Sources */,
 				4982889F28B41F3A00A28B04 /* MacintoraTests.swift in Sources */,
 				AA0000130000000000000000 /* TnsParserTests.swift in Sources */,
 				490E96BC2FA422AF00DDF37F /* ScriptLexerTests.swift in Sources */,

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		49DB100900000009 /* QuickViewHotkey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000900000009 /* QuickViewHotkey.swift */; };
 		49DB100A0000000A /* STDBObjectQuickViewPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */; };
 		49DB100B0000000B /* EditorQuickViewBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000B0000000B /* EditorQuickViewBox.swift */; };
+		49DB102000000020 /* WindowFrameSanitiser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002000000020 /* WindowFrameSanitiser.swift */; };
+		49DB302100000021 /* WindowFrameSanitiserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002100000021 /* WindowFrameSanitiserTests.swift */; };
 		49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000C0000000C /* ObjectAtCursorResolverTests.swift */; };
 		49DB301000000010 /* QuickViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001000000010 /* QuickViewControllerTests.swift */; };
 		49DB301100000011 /* QuickViewHotkeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001100000011 /* QuickViewHotkeyTests.swift */; };
@@ -315,6 +317,8 @@
 		49DB000900000009 /* QuickViewHotkey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewHotkey.swift; sourceTree = "<group>"; };
 		49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STDBObjectQuickViewPlugin.swift; sourceTree = "<group>"; };
 		49DB000B0000000B /* EditorQuickViewBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorQuickViewBox.swift; sourceTree = "<group>"; };
+		49DB002000000020 /* WindowFrameSanitiser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowFrameSanitiser.swift; sourceTree = "<group>"; };
+		49DB002100000021 /* WindowFrameSanitiserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowFrameSanitiserTests.swift; sourceTree = "<group>"; };
 		49DB000C0000000C /* ObjectAtCursorResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectAtCursorResolverTests.swift; sourceTree = "<group>"; };
 		49DB001000000010 /* QuickViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewControllerTests.swift; sourceTree = "<group>"; };
 		49DB001100000011 /* QuickViewHotkeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewHotkeyTests.swift; sourceTree = "<group>"; };
@@ -493,6 +497,7 @@
 				AA0000410000000000000000 /* ConnectionDetailsCodableTests.swift */,
 				AA0000C10000000000000000 /* LegacyDocumentMigrationTests.swift */,
 				AA0000F10000000000000000 /* FullRefreshReproTests.swift */,
+				49DB002100000021 /* WindowFrameSanitiserTests.swift */,
 				49D0ECF22F9C1E070047540A /* Editor */,
 				49D0ED042F9C34410047540A /* Results */,
 				490E96B42FA4216800DDF37F /* Script */,
@@ -509,6 +514,7 @@
 				4982890428B7EF5E00A28B04 /* ConnectionDetails.swift */,
 				49B55F35270ADD8B00CFB3C7 /* MainDocumentView.swift */,
 				49D0ED312F9C50000047540A /* WindowLayoutPersister.swift */,
+				49DB002000000020 /* WindowFrameSanitiser.swift */,
 				AA0001010000000000000000 /* SessionRestorer.swift */,
 				4982889628B1C41700A28B04 /* Formatter.swift */,
 				49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */,
@@ -952,6 +958,7 @@
 				490E96E42FA42AC500DDF37F /* ScriptRunnerDirectivesLiveTests.swift in Sources */,
 				AA00003E0000000000000000 /* ConnectionStoreTests.swift in Sources */,
 				AA0001020000000000000000 /* SessionRestorerTests.swift in Sources */,
+				49DB302100000021 /* WindowFrameSanitiserTests.swift in Sources */,
 				490E96E02FA429E100DDF37F /* SqlPlusInterpreterTests.swift in Sources */,
 				AA0000400000000000000000 /* ConnectionDetailsCodableTests.swift in Sources */,
 				AA0000C00000000000000000 /* LegacyDocumentMigrationTests.swift in Sources */,
@@ -1093,6 +1100,7 @@
 				49DB100900000009 /* QuickViewHotkey.swift in Sources */,
 				49DB100A0000000A /* STDBObjectQuickViewPlugin.swift in Sources */,
 				49DB100B0000000B /* EditorQuickViewBox.swift in Sources */,
+				49DB102000000020 /* WindowFrameSanitiser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		490BF02C2FA58E310098476F /* ObjectAtCursorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490BF02B2FA58E310098476F /* ObjectAtCursorResolver.swift */; };
+		49DB100100000001 /* QuickViewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000100000001 /* QuickViewPayload.swift */; };
+		49DB100200000002 /* QuickViewColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000200000002 /* QuickViewColumnView.swift */; };
+		49DB100300000003 /* QuickViewTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000300000003 /* QuickViewTableView.swift */; };
+		49DB100400000004 /* QuickViewProcedureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000400000004 /* QuickViewProcedureView.swift */; };
+		49DB100500000005 /* QuickViewPackageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000500000005 /* QuickViewPackageView.swift */; };
+		49DB100600000006 /* QuickViewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000600000006 /* QuickViewContent.swift */; };
+		49DB100700000007 /* QuickViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000700000007 /* QuickViewPresenter.swift */; };
+		49DB100800000008 /* QuickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000800000008 /* QuickViewController.swift */; };
+		49DB100900000009 /* QuickViewHotkey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000900000009 /* QuickViewHotkey.swift */; };
+		49DB100A0000000A /* STDBObjectQuickViewPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */; };
+		49DB100B0000000B /* EditorQuickViewBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000B0000000B /* EditorQuickViewBox.swift */; };
+		49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000C0000000C /* ObjectAtCursorResolverTests.swift */; };
 		490E96B62FA4217200DDF37F /* SqlPlusDirective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B52FA4217200DDF37F /* SqlPlusDirective.swift */; };
 		490E96B82FA4217700DDF37F /* ScriptError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B72FA4217700DDF37F /* ScriptError.swift */; };
 		490E96BA2FA4225300DDF37F /* ScriptLexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E96B92FA4225300DDF37F /* ScriptLexer.swift */; };
@@ -82,19 +95,17 @@
 		4982890528B7EF5E00A28B04 /* ConnectionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4982890428B7EF5E00A28B04 /* ConnectionDetails.swift */; };
 		4982890D28B95BC100A28B04 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4982890C28B95BC100A28B04 /* SettingsView.swift */; };
 		4999469427E1777700C62AB7 /* LogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999469327E1777700C62AB7 /* LogView.swift */; };
+		49B0C0DE0000000000000011 /* DBCacheProcedure+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000001 /* DBCacheProcedure+CoreDataClass.swift */; };
+		49B0C0DE0000000000000012 /* DBCacheProcedure+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000002 /* DBCacheProcedure+CoreDataProperties.swift */; };
+		49B0C0DE0000000000000013 /* DBCacheProcedureArgument+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000003 /* DBCacheProcedureArgument+CoreDataClass.swift */; };
+		49B0C0DE0000000000000014 /* DBCacheProcedureArgument+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000004 /* DBCacheProcedureArgument+CoreDataProperties.swift */; };
+		49B0C0DE0000000000000015 /* PackageProceduresListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000005 /* PackageProceduresListView.swift */; };
 		49B55F32270ADD8B00CFB3C7 /* MacintoraApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B55F31270ADD8B00CFB3C7 /* MacintoraApp.swift */; };
 		49B55F36270ADD8B00CFB3C7 /* MainDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B55F35270ADD8B00CFB3C7 /* MainDocumentView.swift */; };
 		49B55F38270ADD8D00CFB3C7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49B55F37270ADD8D00CFB3C7 /* Assets.xcassets */; };
 		49B55F3B270ADD8D00CFB3C7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49B55F3A270ADD8D00CFB3C7 /* Preview Assets.xcassets */; };
 		49B55F60270ADFE300CFB3C7 /* MainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B55F5F270ADFE300CFB3C7 /* MainModel.swift */; };
 		49B6D13327335FF400D9D788 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B6D13227335FF400D9D788 /* Utils.swift */; };
-		49C62C1C27DD7BAF00DE69E4 /* MainDocumentVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */; };
-		49C62C2427E010AE00DE69E4 /* ConnectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */; };
-		49CE5FF027279F3A009C2A94 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CE5FEF27279F3A009C2A94 /* ResultView.swift */; };
-		49D0ECEB2F9C1D970047540A /* EditorSelectionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEA2F9C1D970047540A /* EditorSelectionBridge.swift */; };
-		49D0ECED2F9C1D9D0047540A /* EditorLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */; };
-		49D0ECEF2F9C1DB20047540A /* MacintoraEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */; };
-		49D0ECF12F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */; };
 		49C0100100000001 /* SQLTreeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000100000001 /* SQLTreeStore.swift */; };
 		49C0100200000002 /* SQLContextAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000200000002 /* SQLContextAnalyzer.swift */; };
 		49C0100300000003 /* AliasResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0000300000003 /* AliasResolver.swift */; };
@@ -107,6 +118,13 @@
 		49C0301300000013 /* SQLContextAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301200000013 /* SQLContextAnalyzerTests.swift */; };
 		49C0301500000015 /* AliasResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301400000015 /* AliasResolverTests.swift */; };
 		49C0301700000017 /* CompletionDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301600000017 /* CompletionDataSourceTests.swift */; };
+		49C62C1C27DD7BAF00DE69E4 /* MainDocumentVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */; };
+		49C62C2427E010AE00DE69E4 /* ConnectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */; };
+		49CE5FF027279F3A009C2A94 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CE5FEF27279F3A009C2A94 /* ResultView.swift */; };
+		49D0ECEB2F9C1D970047540A /* EditorSelectionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEA2F9C1D970047540A /* EditorSelectionBridge.swift */; };
+		49D0ECED2F9C1D9D0047540A /* EditorLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */; };
+		49D0ECEF2F9C1DB20047540A /* MacintoraEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */; };
+		49D0ECF12F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */; };
 		49D0ECF42F9C1E1E0047540A /* EditorSelectionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECF32F9C1E1E0047540A /* EditorSelectionBridgeTests.swift */; };
 		49D0ECF62F9C1EB90047540A /* GetCurrentSqlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */; };
 		49D0ED062F9C346B0047540A /* ResultViewModelIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ED052F9C346B0047540A /* ResultViewModelIntegrationTests.swift */; };
@@ -116,11 +134,6 @@
 		49EAEFA328C0493F008F0B80 /* DBDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA228C0493F008F0B80 /* DBDetailView.swift */; };
 		49EAEFA528C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA428C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift */; };
 		49EAEFA728C83685008F0B80 /* DBCacheTrigger+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA628C83685008F0B80 /* DBCacheTrigger+CoreDataProperties.swift */; };
-		49B0C0DE0000000000000011 /* DBCacheProcedure+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000001 /* DBCacheProcedure+CoreDataClass.swift */; };
-		49B0C0DE0000000000000012 /* DBCacheProcedure+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000002 /* DBCacheProcedure+CoreDataProperties.swift */; };
-		49B0C0DE0000000000000013 /* DBCacheProcedureArgument+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000003 /* DBCacheProcedureArgument+CoreDataClass.swift */; };
-		49B0C0DE0000000000000014 /* DBCacheProcedureArgument+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000004 /* DBCacheProcedureArgument+CoreDataProperties.swift */; };
-		49B0C0DE0000000000000015 /* PackageProceduresListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000005 /* PackageProceduresListView.swift */; };
 		49EAEFA928C93263008F0B80 /* DBTriggerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFA828C93263008F0B80 /* DBTriggerDetailView.swift */; };
 		49EAEFAB28C9331C008F0B80 /* SourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFAA28C9331C008F0B80 /* SourceView.swift */; };
 		49EAEFC728CD5822008F0B80 /* TableTriggerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EAEFC628CD5822008F0B80 /* TableTriggerListView.swift */; };
@@ -182,6 +195,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		490BF02B2FA58E310098476F /* ObjectAtCursorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectAtCursorResolver.swift; sourceTree = "<group>"; };
 		490E96B52FA4217200DDF37F /* SqlPlusDirective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SqlPlusDirective.swift; sourceTree = "<group>"; };
 		490E96B72FA4217700DDF37F /* ScriptError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptError.swift; sourceTree = "<group>"; };
 		490E96B92FA4225300DDF37F /* ScriptLexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptLexer.swift; sourceTree = "<group>"; };
@@ -258,6 +272,11 @@
 		4982890428B7EF5E00A28B04 /* ConnectionDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionDetails.swift; sourceTree = "<group>"; };
 		4982890C28B95BC100A28B04 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		4999469327E1777700C62AB7 /* LogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogView.swift; sourceTree = "<group>"; };
+		49B0C0DE0000000000000001 /* DBCacheProcedure+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedure+CoreDataClass.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000002 /* DBCacheProcedure+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedure+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000003 /* DBCacheProcedureArgument+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedureArgument+CoreDataClass.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000004 /* DBCacheProcedureArgument+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedureArgument+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		49B0C0DE0000000000000005 /* PackageProceduresListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageProceduresListView.swift; sourceTree = "<group>"; };
 		49B55F2E270ADD8B00CFB3C7 /* Macintora.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Macintora.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		49B55F31270ADD8B00CFB3C7 /* MacintoraApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MacintoraApp.swift; sourceTree = "<group>"; };
 		49B55F35270ADD8B00CFB3C7 /* MainDocumentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentView.swift; sourceTree = "<group>"; };
@@ -267,13 +286,6 @@
 		49B55F3D270ADD8D00CFB3C7 /* Macintora.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Macintora.entitlements; sourceTree = "<group>"; };
 		49B55F5F270ADFE300CFB3C7 /* MainModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainModel.swift; sourceTree = "<group>"; };
 		49B6D13227335FF400D9D788 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
-		49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentVM.swift; sourceTree = "<group>"; };
-		49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionListView.swift; sourceTree = "<group>"; };
-		49CE5FEF27279F3A009C2A94 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
-		49D0ECEA2F9C1D970047540A /* EditorSelectionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSelectionBridge.swift; sourceTree = "<group>"; };
-		49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLanguage.swift; sourceTree = "<group>"; };
-		49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacintoraEditor.swift; sourceTree = "<group>"; };
-		49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MacintoraEditor+Coordinator.swift"; sourceTree = "<group>"; };
 		49C0000100000001 /* SQLTreeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLTreeStore.swift; sourceTree = "<group>"; };
 		49C0000200000002 /* SQLContextAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLContextAnalyzer.swift; sourceTree = "<group>"; };
 		49C0000300000003 /* AliasResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasResolver.swift; sourceTree = "<group>"; };
@@ -286,6 +298,25 @@
 		49C0301200000013 /* SQLContextAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLContextAnalyzerTests.swift; sourceTree = "<group>"; };
 		49C0301400000015 /* AliasResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasResolverTests.swift; sourceTree = "<group>"; };
 		49C0301600000017 /* CompletionDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDataSourceTests.swift; sourceTree = "<group>"; };
+		49DB000100000001 /* QuickViewPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewPayload.swift; sourceTree = "<group>"; };
+		49DB000200000002 /* QuickViewColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewColumnView.swift; sourceTree = "<group>"; };
+		49DB000300000003 /* QuickViewTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewTableView.swift; sourceTree = "<group>"; };
+		49DB000400000004 /* QuickViewProcedureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewProcedureView.swift; sourceTree = "<group>"; };
+		49DB000500000005 /* QuickViewPackageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewPackageView.swift; sourceTree = "<group>"; };
+		49DB000600000006 /* QuickViewContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewContent.swift; sourceTree = "<group>"; };
+		49DB000700000007 /* QuickViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewPresenter.swift; sourceTree = "<group>"; };
+		49DB000800000008 /* QuickViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewController.swift; sourceTree = "<group>"; };
+		49DB000900000009 /* QuickViewHotkey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewHotkey.swift; sourceTree = "<group>"; };
+		49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STDBObjectQuickViewPlugin.swift; sourceTree = "<group>"; };
+		49DB000B0000000B /* EditorQuickViewBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorQuickViewBox.swift; sourceTree = "<group>"; };
+		49DB000C0000000C /* ObjectAtCursorResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectAtCursorResolverTests.swift; sourceTree = "<group>"; };
+		49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentVM.swift; sourceTree = "<group>"; };
+		49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionListView.swift; sourceTree = "<group>"; };
+		49CE5FEF27279F3A009C2A94 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
+		49D0ECEA2F9C1D970047540A /* EditorSelectionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSelectionBridge.swift; sourceTree = "<group>"; };
+		49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLanguage.swift; sourceTree = "<group>"; };
+		49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacintoraEditor.swift; sourceTree = "<group>"; };
+		49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MacintoraEditor+Coordinator.swift"; sourceTree = "<group>"; };
 		49D0ECF32F9C1E1E0047540A /* EditorSelectionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSelectionBridgeTests.swift; sourceTree = "<group>"; };
 		49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentSqlTests.swift; sourceTree = "<group>"; };
 		49D0ED052F9C346B0047540A /* ResultViewModelIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewModelIntegrationTests.swift; sourceTree = "<group>"; };
@@ -295,11 +326,6 @@
 		49EAEFA228C0493F008F0B80 /* DBDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBDetailView.swift; sourceTree = "<group>"; };
 		49EAEFA428C83633008F0B80 /* DBCacheTrigger+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheTrigger+CoreDataClass.swift"; sourceTree = "<group>"; };
 		49EAEFA628C83685008F0B80 /* DBCacheTrigger+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheTrigger+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		49B0C0DE0000000000000001 /* DBCacheProcedure+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedure+CoreDataClass.swift"; sourceTree = "<group>"; };
-		49B0C0DE0000000000000002 /* DBCacheProcedure+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedure+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		49B0C0DE0000000000000003 /* DBCacheProcedureArgument+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedureArgument+CoreDataClass.swift"; sourceTree = "<group>"; };
-		49B0C0DE0000000000000004 /* DBCacheProcedureArgument+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBCacheProcedureArgument+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		49B0C0DE0000000000000005 /* PackageProceduresListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageProceduresListView.swift; sourceTree = "<group>"; };
 		49EAEFA828C93263008F0B80 /* DBTriggerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBTriggerDetailView.swift; sourceTree = "<group>"; };
 		49EAEFAA28C9331C008F0B80 /* SourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceView.swift; sourceTree = "<group>"; };
 		49EAEFC628CD5822008F0B80 /* TableTriggerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableTriggerListView.swift; sourceTree = "<group>"; };
@@ -566,6 +592,59 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		49C0200000000000 /* Completion */ = {
+			isa = PBXGroup;
+			children = (
+				49C0000100000001 /* SQLTreeStore.swift */,
+				49C0000200000002 /* SQLContextAnalyzer.swift */,
+				49C0000300000003 /* AliasResolver.swift */,
+				49C0000400000004 /* CompletionItem.swift */,
+				49C0000500000005 /* CompletionDataSource.swift */,
+				49C0000600000006 /* CompletionCoordinator.swift */,
+				49C0000800000008 /* SQLParserHelper.swift */,
+				49C0000900000009 /* MacintoraCompletionViewController.swift */,
+				490BF02B2FA58E310098476F /* ObjectAtCursorResolver.swift */,
+			);
+			path = Completion;
+			sourceTree = "<group>";
+		};
+		49DB000D0000000D /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				49DB000E0000000E /* QuickView */,
+			);
+			path = Plugins;
+			sourceTree = "<group>";
+		};
+		49DB000E0000000E /* QuickView */ = {
+			isa = PBXGroup;
+			children = (
+				49DB000100000001 /* QuickViewPayload.swift */,
+				49DB000200000002 /* QuickViewColumnView.swift */,
+				49DB000300000003 /* QuickViewTableView.swift */,
+				49DB000400000004 /* QuickViewProcedureView.swift */,
+				49DB000500000005 /* QuickViewPackageView.swift */,
+				49DB000600000006 /* QuickViewContent.swift */,
+				49DB000700000007 /* QuickViewPresenter.swift */,
+				49DB000800000008 /* QuickViewController.swift */,
+				49DB000900000009 /* QuickViewHotkey.swift */,
+				49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */,
+				49DB000B0000000B /* EditorQuickViewBox.swift */,
+			);
+			path = QuickView;
+			sourceTree = "<group>";
+		};
+		49C0300000000010 /* Completion */ = {
+			isa = PBXGroup;
+			children = (
+				49C0301200000013 /* SQLContextAnalyzerTests.swift */,
+				49C0301400000015 /* AliasResolverTests.swift */,
+				49C0301600000017 /* CompletionDataSourceTests.swift */,
+				49DB000C0000000C /* ObjectAtCursorResolverTests.swift */,
+			);
+			path = Completion;
+			sourceTree = "<group>";
+		};
 		49CE5FEE27279F09009C2A94 /* Results */ = {
 			isa = PBXGroup;
 			children = (
@@ -600,23 +679,9 @@
 				49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */,
 				49C0000700000007 /* MacintoraEditor+Completion.swift */,
 				49C0200000000000 /* Completion */,
+				49DB000D0000000D /* Plugins */,
 			);
 			path = Editor;
-			sourceTree = "<group>";
-		};
-		49C0200000000000 /* Completion */ = {
-			isa = PBXGroup;
-			children = (
-				49C0000100000001 /* SQLTreeStore.swift */,
-				49C0000200000002 /* SQLContextAnalyzer.swift */,
-				49C0000300000003 /* AliasResolver.swift */,
-				49C0000400000004 /* CompletionItem.swift */,
-				49C0000500000005 /* CompletionDataSource.swift */,
-				49C0000600000006 /* CompletionCoordinator.swift */,
-				49C0000800000008 /* SQLParserHelper.swift */,
-				49C0000900000009 /* MacintoraCompletionViewController.swift */,
-			);
-			path = Completion;
 			sourceTree = "<group>";
 		};
 		49D0ECF22F9C1E070047540A /* Editor */ = {
@@ -627,16 +692,6 @@
 				49C0300000000010 /* Completion */,
 			);
 			path = Editor;
-			sourceTree = "<group>";
-		};
-		49C0300000000010 /* Completion */ = {
-			isa = PBXGroup;
-			children = (
-				49C0301200000013 /* SQLContextAnalyzerTests.swift */,
-				49C0301400000015 /* AliasResolverTests.swift */,
-				49C0301600000017 /* CompletionDataSourceTests.swift */,
-			);
-			path = Completion;
 			sourceTree = "<group>";
 		};
 		49D0ED042F9C34410047540A /* Results */ = {
@@ -839,6 +894,7 @@
 				49C0301300000013 /* SQLContextAnalyzerTests.swift in Sources */,
 				49C0301500000015 /* AliasResolverTests.swift in Sources */,
 				49C0301700000017 /* CompletionDataSourceTests.swift in Sources */,
+				49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */,
 				4982889F28B41F3A00A28B04 /* MacintoraTests.swift in Sources */,
 				AA0000130000000000000000 /* TnsParserTests.swift in Sources */,
 				490E96BC2FA422AF00DDF37F /* ScriptLexerTests.swift in Sources */,
@@ -936,6 +992,7 @@
 				498288C528B7DC5700A28B04 /* DBCacheTable+CoreDataProperties.swift in Sources */,
 				498288FE28B7DCB000A28B04 /* Persistence.swift in Sources */,
 				498288CA28B7DC5700A28B04 /* Item+CoreDataProperties.swift in Sources */,
+				490BF02C2FA58E310098476F /* ObjectAtCursorResolver.swift in Sources */,
 				49C62C1C27DD7BAF00DE69E4 /* MainDocumentVM.swift in Sources */,
 				498288CB28B7DC5700A28B04 /* ConnDatabase+CoreDataClass.swift in Sources */,
 				4947FEAA286FA73B00AEBE60 /* RunnableSQL.swift in Sources */,
@@ -986,6 +1043,17 @@
 				49C0100700000007 /* MacintoraEditor+Completion.swift in Sources */,
 				49C0100800000008 /* SQLParserHelper.swift in Sources */,
 				49C0100900000009 /* MacintoraCompletionViewController.swift in Sources */,
+				49DB100100000001 /* QuickViewPayload.swift in Sources */,
+				49DB100200000002 /* QuickViewColumnView.swift in Sources */,
+				49DB100300000003 /* QuickViewTableView.swift in Sources */,
+				49DB100400000004 /* QuickViewProcedureView.swift in Sources */,
+				49DB100500000005 /* QuickViewPackageView.swift in Sources */,
+				49DB100600000006 /* QuickViewContent.swift in Sources */,
+				49DB100700000007 /* QuickViewPresenter.swift in Sources */,
+				49DB100800000008 /* QuickViewController.swift in Sources */,
+				49DB100900000009 /* QuickViewHotkey.swift in Sources */,
+				49DB100A0000000A /* STDBObjectQuickViewPlugin.swift in Sources */,
+				49DB100B0000000B /* EditorQuickViewBox.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -177,7 +177,7 @@ struct DBDetailViewHeaderImage: View {
             case .view:
                 Label("View", systemImage: "tablecells.badge.ellipsis")
             case .index:
-                Label("Index", systemImage: "ecrease.indent")
+                Label("Index", systemImage: "decrease.indent")
             case .type:
                 Label("Type", systemImage: "t.square")
             case .package:

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -493,8 +493,12 @@ actor CompletionDataSource {
                                                  upperOwner, upperName)
             indexRequest.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
 
+            // `DBCacheTrigger` keys the parent table via `objectOwner` /
+            // `objectName` (no trailing underscore on either) — it stores the
+            // ALL_TRIGGERS BASE_OBJECT columns rather than mirroring the
+            // table-side naming.
             let triggerRequest = DBCacheTrigger.fetchRequest()
-            triggerRequest.predicate = NSPredicate(format: "tableOwner = %@ AND objectName_ = %@",
+            triggerRequest.predicate = NSPredicate(format: "objectOwner = %@ AND objectName = %@",
                                                    upperOwner, upperName)
             triggerRequest.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
 

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -413,4 +413,447 @@ actor CompletionDataSource {
             }
         }
     }
+
+    // MARK: - Quick View detail fetchers
+    //
+    // These read deeper than the completion popup needs and never participate
+    // in autocompletion. They power the Quick View popover: one fetch per
+    // user-triggered popup, returning a single Sendable struct that crosses
+    // back to the main actor for SwiftUI rendering.
+
+    /// Resolves a 1- or 2-part schema-object name to a concrete `(owner, name,
+    /// type)` triple by consulting `DBCacheObject`. When `owner` is nil the
+    /// preferred owner is tried first; if that misses, any cached schema is
+    /// accepted (sorted by owner, name) and the first match wins.
+    ///
+    /// Returns `nil` when nothing matches — callers surface "not cached".
+    func resolveSchemaObject(owner: String?,
+                             name: String,
+                             preferredOwner: String) async -> ResolvedSchemaObject? {
+        await fetch { ctx -> ResolvedSchemaObject? in
+            let upperName = name.uppercased()
+            let upperPreferred = preferredOwner.uppercased()
+            let request = DBCacheObject.fetchRequest()
+            var predicates: [NSPredicate] = [
+                NSPredicate(format: "name_ = %@", upperName)
+            ]
+            if let owner {
+                predicates.append(NSPredicate(format: "owner_ = %@", owner.uppercased()))
+            }
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "owner_", ascending: true),
+                NSSortDescriptor(key: "name_", ascending: true)
+            ]
+            do {
+                let rows = try ctx.fetch(request)
+                guard !rows.isEmpty else { return nil }
+                // Prefer the connected schema if no explicit owner was given.
+                let chosen: DBCacheObject = {
+                    if owner != nil { return rows[0] }
+                    return rows.first { ($0.owner_ ?? "") == upperPreferred } ?? rows[0]
+                }()
+                return ResolvedSchemaObject(
+                    owner: chosen.owner_ ?? "",
+                    name: chosen.name_ ?? "",
+                    objectType: chosen.type_ ?? "UNKNOWN",
+                    isValid: chosen.isValid,
+                    lastDDLDate: chosen.lastDDLDate)
+            } catch {
+                self.logger.error("resolveSchemaObject fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    /// Full table/view payload: row metadata + columns + indexes + triggers.
+    /// Pass `highlightedColumn` to flag a specific column in the popover (used
+    /// when the Quick View was triggered from a column reference).
+    func tableDetail(owner: String,
+                     name: String,
+                     highlightedColumn: String?) async -> TableDetailPayload? {
+        await fetch { ctx -> TableDetailPayload? in
+            let upperOwner = owner.uppercased()
+            let upperName = name.uppercased()
+
+            let tableRequest = DBCacheTable.fetchRequest()
+            tableRequest.predicate = NSPredicate(format: "owner_ = %@ AND name_ = %@",
+                                                 upperOwner, upperName)
+            tableRequest.fetchLimit = 1
+
+            let columnRequest = DBCacheTableColumn.fetchRequest()
+            columnRequest.predicate = NSPredicate(format: "owner_ = %@ AND tableName_ = %@",
+                                                  upperOwner, upperName)
+            columnRequest.sortDescriptors = [
+                NSSortDescriptor(key: "internalColumnID", ascending: true)
+            ]
+
+            let indexRequest = DBCacheIndex.fetchRequest()
+            indexRequest.predicate = NSPredicate(format: "tableOwner_ = %@ AND tableName_ = %@",
+                                                 upperOwner, upperName)
+            indexRequest.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
+
+            let triggerRequest = DBCacheTrigger.fetchRequest()
+            triggerRequest.predicate = NSPredicate(format: "tableOwner = %@ AND objectName_ = %@",
+                                                   upperOwner, upperName)
+            triggerRequest.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
+
+            do {
+                let tableRow = try ctx.fetch(tableRequest).first
+                let columnRows = try ctx.fetch(columnRequest)
+                let indexRows = try ctx.fetch(indexRequest)
+                let triggerRows = try ctx.fetch(triggerRequest)
+
+                let columns = columnRows.map(self.makeColumn(from:))
+                let indexes = indexRows.map { row in
+                    QuickViewIndex(owner: row.owner_ ?? "",
+                                   name: row.name_ ?? "",
+                                   type: row.type_,
+                                   isUnique: row.isUnique,
+                                   isValid: row.isValid)
+                }
+                let triggers = triggerRows.map { row in
+                    QuickViewTrigger(owner: row.owner_ ?? "",
+                                     name: row.name_ ?? "",
+                                     event: row.event_,
+                                     isEnabled: row.isEnabled)
+                }
+
+                return TableDetailPayload(
+                    owner: upperOwner,
+                    name: upperName,
+                    isView: tableRow?.isView ?? false,
+                    isEditioning: tableRow?.isEditioning ?? false,
+                    isReadOnly: tableRow?.isReadOnly ?? false,
+                    isPartitioned: tableRow?.isPartitioned ?? false,
+                    numRows: tableRow.flatMap { $0.numRows == 0 ? nil : Int64($0.numRows) },
+                    lastAnalyzed: tableRow?.lastAnalyzed,
+                    sqlText: tableRow?.sqltext,
+                    columns: columns,
+                    indexes: indexes,
+                    triggers: triggers,
+                    highlightedColumn: highlightedColumn?.uppercased())
+            } catch {
+                self.logger.error("tableDetail fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    /// Single-column payload for the column mini-popover.
+    func columnDetail(tableOwner: String?,
+                      tableName: String,
+                      columnName: String) async -> ColumnDetailPayload? {
+        await fetch { ctx -> ColumnDetailPayload? in
+            let upperTable = tableName.uppercased()
+            let upperColumn = columnName.uppercased()
+            let request = DBCacheTableColumn.fetchRequest()
+            var predicates: [NSPredicate] = [
+                NSPredicate(format: "tableName_ = %@", upperTable),
+                NSPredicate(format: "columnName_ = %@", upperColumn)
+            ]
+            if let tableOwner {
+                predicates.append(NSPredicate(format: "owner_ = %@", tableOwner.uppercased()))
+            }
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+            request.fetchLimit = 1
+            do {
+                guard let row = try ctx.fetch(request).first else { return nil }
+                return ColumnDetailPayload(
+                    tableOwner: row.owner_ ?? "",
+                    tableName: row.tableName_ ?? "",
+                    column: self.makeColumn(from: row))
+            } catch {
+                self.logger.error("columnDetail fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    /// Package or user-defined-type payload: spec source + member procedures
+    /// with their argument signatures collapsed into a single Sendable struct.
+    func packageDetail(owner: String, name: String) async -> PackageDetailPayload? {
+        await fetch { ctx -> PackageDetailPayload? in
+            let upperOwner = owner.uppercased()
+            let upperName = name.uppercased()
+
+            let objectRequest = DBCacheObject.fetchRequest()
+            objectRequest.predicate = NSPredicate(format: "owner_ = %@ AND name_ = %@",
+                                                  upperOwner, upperName)
+            objectRequest.fetchLimit = 1
+
+            let sourceRequest = DBCacheSource.fetchRequest()
+            sourceRequest.predicate = NSPredicate(format: "owner_ = %@ AND name_ = %@",
+                                                  upperOwner, upperName)
+            sourceRequest.fetchLimit = 1
+
+            let procRequest = DBCacheProcedure.fetchRequest()
+            procRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "owner_ = %@", upperOwner),
+                NSPredicate(format: "objectName_ = %@", upperName),
+                NSPredicate(format: "procedureName_ != nil")
+            ])
+            procRequest.sortDescriptors = [
+                NSSortDescriptor(key: "procedureName_", ascending: true),
+                NSSortDescriptor(key: "overload_", ascending: true)
+            ]
+
+            let argRequest = DBCacheProcedureArgument.fetchRequest()
+            argRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "owner_ = %@", upperOwner),
+                NSPredicate(format: "objectName_ = %@", upperName),
+                NSPredicate(format: "dataLevel == 0")
+            ])
+            argRequest.sortDescriptors = [
+                NSSortDescriptor(key: "procedureName_", ascending: true),
+                NSSortDescriptor(key: "overload_", ascending: true),
+                NSSortDescriptor(key: "sequence", ascending: true)
+            ]
+
+            do {
+                let objectRow = try ctx.fetch(objectRequest).first
+                let sourceRow = try ctx.fetch(sourceRequest).first
+                let procRows = try ctx.fetch(procRequest)
+                let argRows = try ctx.fetch(argRequest)
+
+                let procedures = self.assemblePackageProcedures(procRows: procRows,
+                                                                argRows: argRows)
+                let kind = objectRow?.type_ ?? "PACKAGE"
+                return PackageDetailPayload(
+                    owner: upperOwner,
+                    name: upperName,
+                    objectType: kind,
+                    isValid: objectRow?.isValid ?? true,
+                    specSource: sourceRow?.textSpec,
+                    procedures: procedures)
+            } catch {
+                self.logger.error("packageDetail fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    /// Single procedure / function payload — used both for standalone
+    /// procedures (where `packageName` is nil) and package members. When
+    /// multiple overloads exist and `overload` is nil, the lowest-numbered
+    /// overload is returned (ALL_PROCEDURES.subprogram_id ordering).
+    func procedureDetail(owner: String,
+                         packageName: String?,
+                         procedureName: String,
+                         overload: String?) async -> ProcedureDetailPayload? {
+        await fetch { ctx -> ProcedureDetailPayload? in
+            let upperOwner = owner.uppercased()
+            let upperProc = procedureName.uppercased()
+            let upperPkgOrSelf = (packageName ?? procedureName).uppercased()
+
+            let procRequest = DBCacheProcedure.fetchRequest()
+            var procPredicates: [NSPredicate] = [
+                NSPredicate(format: "owner_ = %@", upperOwner),
+                NSPredicate(format: "objectName_ = %@", upperPkgOrSelf),
+                NSPredicate(format: "procedureName_ = %@", upperProc)
+            ]
+            if let overload, !overload.isEmpty {
+                procPredicates.append(NSPredicate(format: "overload_ = %@", overload))
+            }
+            procRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: procPredicates)
+            procRequest.sortDescriptors = [NSSortDescriptor(key: "subprogramId", ascending: true)]
+            procRequest.fetchLimit = 1
+
+            do {
+                guard let procRow = try ctx.fetch(procRequest).first else { return nil }
+                let procRowOverload = procRow.overload_
+
+                let argRequest = DBCacheProcedureArgument.fetchRequest()
+                var argPredicates: [NSPredicate] = [
+                    NSPredicate(format: "owner_ = %@", upperOwner),
+                    NSPredicate(format: "objectName_ = %@", upperPkgOrSelf),
+                    NSPredicate(format: "procedureName_ = %@", upperProc),
+                    NSPredicate(format: "dataLevel == 0")
+                ]
+                if let procRowOverload, !procRowOverload.isEmpty {
+                    argPredicates.append(NSPredicate(format: "overload_ = %@", procRowOverload))
+                } else {
+                    argPredicates.append(NSPredicate(format: "overload_ == nil OR overload_ = %@", ""))
+                }
+                argRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: argPredicates)
+                argRequest.sortDescriptors = [NSSortDescriptor(key: "sequence", ascending: true)]
+                let argRows = try ctx.fetch(argRequest)
+
+                var returnType: String? = nil
+                var parameters: [QuickViewProcedureArgument] = []
+                for arg in argRows {
+                    if arg.position == 0, arg.argumentName_ == nil {
+                        returnType = arg.dataType_
+                        continue
+                    }
+                    parameters.append(QuickViewProcedureArgument(
+                        sequence: Int(arg.sequence),
+                        position: Int(arg.position),
+                        name: arg.argumentName_,
+                        dataType: arg.dataType_ ?? "",
+                        inOut: arg.inOut_ ?? "IN",
+                        defaulted: arg.defaulted,
+                        defaultValue: arg.defaultValue_))
+                }
+
+                return ProcedureDetailPayload(
+                    owner: procRow.owner_ ?? upperOwner,
+                    name: procRow.procedureName_ ?? upperProc,
+                    packageName: packageName.map { $0.uppercased() },
+                    kind: returnType != nil ? "FUNCTION" : "PROCEDURE",
+                    overload: procRowOverload,
+                    returnType: returnType,
+                    parameters: parameters,
+                    isValid: true)
+            } catch {
+                self.logger.error("procedureDetail fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    /// Returns metadata-only payload for object types we don't render in
+    /// detail (TYPE, INDEX, TRIGGER, etc. when no specialised view exists).
+    func unknownObjectDetail(owner: String, name: String) async -> UnknownObjectPayload? {
+        await fetch { ctx -> UnknownObjectPayload? in
+            let request = DBCacheObject.fetchRequest()
+            request.predicate = NSPredicate(format: "owner_ = %@ AND name_ = %@",
+                                            owner.uppercased(), name.uppercased())
+            request.fetchLimit = 1
+            do {
+                guard let row = try ctx.fetch(request).first else { return nil }
+                return UnknownObjectPayload(
+                    owner: row.owner_ ?? "",
+                    name: row.name_ ?? "",
+                    objectType: row.type_ ?? "UNKNOWN",
+                    isValid: row.isValid,
+                    lastDDLDate: row.lastDDLDate)
+            } catch {
+                self.logger.error("unknownObjectDetail fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    // MARK: - Internal helpers
+
+    /// Translates a `DBCacheTableColumn` row into the Sendable view-model the
+    /// popover renders. `nonisolated` because it operates entirely on `let`
+    /// inputs and produces a value type — the actor's background context
+    /// invokes it from inside `context.perform`.
+    nonisolated private func makeColumn(from row: DBCacheTableColumn) -> QuickViewColumn {
+        QuickViewColumn(
+            columnID: Int32(row.columnID?.intValue ?? 0),
+            columnName: row.columnName_ ?? "",
+            dataType: row.dataType_ ?? "",
+            dataTypeFormatted: Self.formatDataType(
+                base: row.dataType_ ?? "",
+                length: row.length,
+                precision: row.precision?.int32Value ?? 0,
+                scale: row.scale?.int32Value ?? 0),
+            isNullable: row.isNullable,
+            defaultValue: row.defaultValue,
+            isIdentity: row.isIdentity,
+            isVirtual: row.isVirtual,
+            isHidden: row.isHidden)
+    }
+
+    /// Folds `(DBCacheProcedure, DBCacheProcedureArgument)` rows into the
+    /// Sendable `QuickViewPackageProcedure` list. Skips the SUBPROGRAM_ID = 0
+    /// "package itself" row that ALL_PROCEDURES emits and groups arguments
+    /// by `(procedureName, overload)` so overloaded members render distinctly.
+    nonisolated private func assemblePackageProcedures(
+        procRows: [DBCacheProcedure],
+        argRows: [DBCacheProcedureArgument]
+    ) -> [QuickViewPackageProcedure] {
+        struct Key: Hashable { let name: String; let overload: String }
+        var groups: [Key: (kind: String,
+                           overload: String?,
+                           returnType: String?,
+                           args: [QuickViewProcedureArgument])] = [:]
+        for proc in procRows {
+            guard let procName = proc.procedureName_, !procName.isEmpty else { continue }
+            // Skip the package-self row (procedureName == package name AND
+            // type == PACKAGE). Defensive — the predicate already excludes
+            // procedureName_ == nil rows.
+            if procName == proc.objectName_ && (proc.objectType_ ?? "") == "PACKAGE" {
+                continue
+            }
+            let key = Key(name: procName, overload: proc.overload_ ?? "")
+            if groups[key] == nil {
+                groups[key] = (kind: "PROCEDURE",
+                               overload: proc.overload_,
+                               returnType: nil,
+                               args: [])
+            }
+        }
+        for arg in argRows {
+            guard let procName = arg.procedureName_, !procName.isEmpty else { continue }
+            let key = Key(name: procName, overload: arg.overload_ ?? "")
+            guard var bucket = groups[key] else { continue }
+            if arg.position == 0, arg.argumentName_ == nil {
+                bucket.returnType = arg.dataType_
+                bucket.kind = "FUNCTION"
+            } else if arg.position > 0 {
+                bucket.args.append(QuickViewProcedureArgument(
+                    sequence: Int(arg.sequence),
+                    position: Int(arg.position),
+                    name: arg.argumentName_,
+                    dataType: arg.dataType_ ?? "",
+                    inOut: arg.inOut_ ?? "IN",
+                    defaulted: arg.defaulted,
+                    defaultValue: arg.defaultValue_))
+            }
+            groups[key] = bucket
+        }
+        return groups
+            .map { key, value in
+                QuickViewPackageProcedure(
+                    name: key.name,
+                    kind: value.kind,
+                    overload: value.overload,
+                    returnType: value.returnType,
+                    parameters: value.args)
+            }
+            .sorted { lhs, rhs in
+                if lhs.name != rhs.name { return lhs.name < rhs.name }
+                return (lhs.overload ?? "") < (rhs.overload ?? "")
+            }
+    }
+
+    /// Oracle-style data-type pretty-printer. Returns `VARCHAR2(120)`,
+    /// `NUMBER(10,2)`, `NUMBER`, etc. — a compact form that fits the popover.
+    nonisolated static func formatDataType(base: String,
+                                           length: Int32,
+                                           precision: Int32,
+                                           scale: Int32) -> String {
+        let upper = base.uppercased()
+        switch upper {
+        case "VARCHAR2", "VARCHAR", "CHAR", "NVARCHAR2", "NCHAR", "RAW":
+            return length > 0 ? "\(upper)(\(length))" : upper
+        case "NUMBER":
+            if precision > 0 && scale > 0 {
+                return "NUMBER(\(precision),\(scale))"
+            }
+            if precision > 0 {
+                return "NUMBER(\(precision))"
+            }
+            return "NUMBER"
+        case "FLOAT":
+            return precision > 0 ? "FLOAT(\(precision))" : "FLOAT"
+        default:
+            return upper
+        }
+    }
+}
+
+/// Lightweight result of `resolveSchemaObject(...)` — what the cache says
+/// about a schema-qualified name lookup. Quick View's controller pivots on
+/// `objectType` to pick which detail fetch to run next.
+struct ResolvedSchemaObject: Sendable, Equatable {
+    let owner: String
+    let name: String
+    let objectType: String
+    let isValid: Bool
+    let lastDDLDate: Date?
 }

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -663,8 +663,18 @@ actor CompletionDataSource {
             procRequest.sortDescriptors = [NSSortDescriptor(key: "subprogramId", ascending: true)]
             procRequest.fetchLimit = 1
 
+            // Parent DBCacheObject carries the validity bit. For package
+            // members the parent is the package; for standalones it's the
+            // procedure/function row itself. Treat a missing parent as
+            // valid — same fallback as `packageDetail`.
+            let objectRequest = DBCacheObject.fetchRequest()
+            objectRequest.predicate = NSPredicate(format: "owner_ = %@ AND name_ = %@",
+                                                  upperOwner, upperPkgOrSelf)
+            objectRequest.fetchLimit = 1
+
             do {
                 guard let procRow = try ctx.fetch(procRequest).first else { return nil }
+                let objectRow = try ctx.fetch(objectRequest).first
                 let procRowOverload = procRow.overload_
 
                 let argRequest = DBCacheProcedureArgument.fetchRequest()
@@ -708,7 +718,7 @@ actor CompletionDataSource {
                     overload: procRowOverload,
                     returnType: returnType,
                     parameters: parameters,
-                    isValid: true)
+                    isValid: objectRow?.isValid ?? true)
             } catch {
                 self.logger.error("procedureDetail fetch failed: \(error.localizedDescription, privacy: .public)")
                 return nil

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -105,6 +105,7 @@ final class MacintoraCompletionItem: NSObject, STCompletionItem, @unchecked Send
         MainActor.assumeIsolated { makeView() }
     }
 
+    @MainActor
     private func makeView() -> NSView {
         // SwiftUI inside `NSHostingView` handles row sizing/layout cleanly —
         // an earlier raw NSStackView attempt left the stack collapsed at

--- a/Macintora/Editor/Completion/ObjectAtCursorResolver.swift
+++ b/Macintora/Editor/Completion/ObjectAtCursorResolver.swift
@@ -286,7 +286,6 @@ struct ObjectAtCursorResolver {
             return .unresolved
         }
         let start = token.start
-        let end = token.end
         let name = token.text
 
         // Look back for `qualifier.` immediately preceding the name. Skip a

--- a/Macintora/Editor/Completion/ObjectAtCursorResolver.swift
+++ b/Macintora/Editor/Completion/ObjectAtCursorResolver.swift
@@ -1,0 +1,494 @@
+//
+//  ObjectAtCursorResolver.swift
+//  Macintora
+//
+//  Maps a cursor offset (UTF-16 NSString units) to a `ResolvedDBReference` —
+//  the Quick View feature's input. Walks the tree-sitter parse tree to find
+//  the smallest enclosing identifier-bearing node, classifies it, and
+//  delegates alias→table mapping to `AliasResolver`.
+//
+//  The resolver is intentionally a pure function: pass `(offset, source, tree)`
+//  in, get a value out. No DB access; the data layer disambiguates between
+//  table-vs-view-vs-package-vs-…-vs-synonym via cache lookup.
+//
+
+import Foundation
+import STPluginNeon  // re-exports SwiftTreeSitter
+
+/// What the Quick View pipeline should look up next. Authored at parse time;
+/// the cache fetcher decides between table/view/package/procedure based on
+/// what it finds (or doesn't).
+enum ResolvedDBReference: Equatable, Sendable {
+
+    /// A 1- or 2-part schema-object name. `owner == nil` means the cursor was
+    /// on an unqualified identifier — the fetcher tries the user's default
+    /// schema first, then any cached schema. Covers tables, views, packages,
+    /// standalone procedures/functions, types, indexes, triggers — the cache
+    /// row's `type_` field decides which detail view to render.
+    case schemaObject(owner: String?, name: String)
+
+    /// A package-member call (`[owner.]package.member(...)` or `package.member`
+    /// outside an invocation context). The fetcher first looks for a package
+    /// named `packageName` owning a procedure/function `memberName`. If that
+    /// misses, it falls back to treating `(packageOwner, packageName, …)` as
+    /// `(schema, standaloneObject)` because two-part names are ambiguous.
+    case packageMember(packageOwner: String?, packageName: String, memberName: String)
+
+    /// A column reference. Always carries a concrete table — when the
+    /// AliasResolver can't map an alias to a real table, the resolver emits
+    /// `.unresolved` instead of guessing.
+    case column(tableOwner: String?, tableName: String, columnName: String)
+
+    /// Cursor isn't on something we can resolve (whitespace, punctuation,
+    /// inside a string literal or comment, on an unknown alias, etc.).
+    case unresolved
+}
+
+@MainActor
+struct ObjectAtCursorResolver {
+
+    private let aliasResolver = AliasResolver()
+
+    /// Production entry point. Operates on the live parse tree from
+    /// `SQLTreeStore`. `tree` may be `nil` (no parse yet); in that case we
+    /// fall back to a source-text scan that mirrors `SourceScanner`.
+    func resolve(utf16Offset: Int,
+                 source: String,
+                 tree: SwiftTreeSitter.Tree?) -> ResolvedDBReference {
+        // Cheap rejection: cursor in string/comment never resolves.
+        let scan = SourceScanner.scan(source: source, utf16Offset: utf16Offset)
+        if scan.insideStringOrComment { return .unresolved }
+
+        if let tree {
+            if let result = resolveFromTree(tree: tree,
+                                            source: source,
+                                            utf16Offset: utf16Offset) {
+                return result
+            }
+        }
+
+        // Tree miss: fall back to a source-text-only resolution. Lets Quick
+        // View work mid-typing or when the parser has produced an ERROR node
+        // around the identifier we care about.
+        return resolveFromSourceText(scan: scan,
+                                     source: source,
+                                     utf16Offset: utf16Offset,
+                                     tree: tree)
+    }
+
+    /// Test-friendly facade: parses `source` once with `SQLParserHelper` and
+    /// resolves at `utf16Offset`. Mirrors `AliasResolver.parseAndResolve(_:utf16Offset:)`.
+    static func parseAndResolve(_ source: String, utf16Offset: Int) -> ResolvedDBReference {
+        let tree = SQLParserHelper.parse(source)
+        return ObjectAtCursorResolver().resolve(utf16Offset: utf16Offset,
+                                                source: source,
+                                                tree: tree)
+    }
+
+    // MARK: - Tree-driven resolution
+
+    /// Walks ancestors from the cursor node looking for an `object_reference`,
+    /// `invocation`, or `column_reference`-shaped node. Returns nil when the
+    /// tree path doesn't yield anything we can classify (caller falls back to
+    /// the source-text scan).
+    private func resolveFromTree(tree: SwiftTreeSitter.Tree,
+                                 source: String,
+                                 utf16Offset: Int) -> ResolvedDBReference? {
+        let cap = source.utf16.count
+        let units = max(0, min(utf16Offset, cap))
+        let target = UInt32(units * 2)
+
+        // Probe the cursor byte and one byte before — at end-of-token the
+        // exact-cursor probe lands on the surrounding statement node, but
+        // the previous-byte probe sits inside the identifier we want.
+        var probes: [UInt32] = [target]
+        if target >= 2 { probes.append(target - 2) }
+
+        for probe in probes {
+            guard let node = tree.rootNode?.descendant(in: probe..<probe) else { continue }
+
+            // Inside a string/comment? Refuse — the source scanner already
+            // checked the line, but the tree gives a more precise answer for
+            // multi-line literals.
+            if isLiteralOrCommentNode(node) { return .unresolved }
+
+            if let result = classify(node: node, source: source, utf16Offset: utf16Offset) {
+                return result
+            }
+        }
+        return nil
+    }
+
+    /// Walks `node` upward through ancestors looking for the first classifiable
+    /// container. Stops at statement boundaries to avoid escaping into a
+    /// sibling statement's syntax.
+    private func classify(node: SwiftTreeSitter.Node,
+                          source: String,
+                          utf16Offset: Int) -> ResolvedDBReference? {
+        var current: SwiftTreeSitter.Node? = node
+        while let n = current {
+            switch n.nodeType {
+            case "invocation":
+                return classifyInvocation(n, source: source, utf16Offset: utf16Offset)
+            case "object_reference":
+                return classifyObjectReference(n, source: source, utf16Offset: utf16Offset)
+            case "column_reference", "field":
+                if let result = classifyColumnReference(n, source: source, utf16Offset: utf16Offset) {
+                    return result
+                }
+                // Structural extraction came up empty — let the source-text
+                // fallback in `resolve(...)` try, since the surrounding text
+                // typically still has `qualifier.name` we can lex.
+                return nil
+            case "identifier":
+                // Bare identifier. Defer decision — keep walking up to see if
+                // a richer parent (object_reference / invocation / column_reference)
+                // provides better context. If we hit a query-shaped node first,
+                // treat the identifier itself as the reference.
+                if let ancestor = n.parent,
+                   ["object_reference", "invocation", "column_reference", "field"].contains(ancestor.nodeType ?? "") {
+                    current = ancestor
+                    continue
+                }
+                if let raw = text(of: n, in: source) {
+                    return classifyBareIdentifier(raw,
+                                                  cursorByte: n.byteRange.lowerBound,
+                                                  source: source)
+                }
+                return nil
+            default:
+                if Self.isQueryBoundary(n.nodeType) { return nil }
+                current = n.parent
+            }
+        }
+        return nil
+    }
+
+    private func classifyObjectReference(_ node: SwiftTreeSitter.Node,
+                                         source: String,
+                                         utf16Offset: Int) -> ResolvedDBReference {
+        // If this object_reference is the callee of an invocation, the user
+        // is on a function/procedure call — defer to the invocation handler
+        // so we route to package-member or standalone-procedure semantics.
+        if let parent = node.parent, parent.nodeType == "invocation" {
+            return classifyInvocation(parent, source: source, utf16Offset: utf16Offset)
+        }
+        let parts = objectReferenceParts(node, source: source)
+        // 2-part `qualifier.name`: if qualifier resolves through the
+        // surrounding query's FROM-clause alias map, the user is pointing
+        // at a column. Otherwise, fall through to the schema-object path.
+        if let qualifier = parts.qualifier, parts.owner == nil {
+            let aliases = aliasResolver.aliases(near: node, source: source)
+            if let resolved = aliases[qualifier.uppercased()] ?? nil {
+                return .column(tableOwner: resolved.owner,
+                               tableName: resolved.name,
+                               columnName: parts.name.uppercased())
+            }
+        }
+        return referenceFromParts(parts, source: source, cursorByte: node.byteRange.lowerBound)
+    }
+
+    private func classifyInvocation(_ node: SwiftTreeSitter.Node,
+                                    source: String,
+                                    utf16Offset: Int) -> ResolvedDBReference {
+        // First named child of `invocation` is the callee — usually an
+        // `object_reference`, occasionally a bare `identifier`.
+        guard let callee = firstNamedChild(of: node) else { return .unresolved }
+        let parts: ObjectParts
+        switch callee.nodeType {
+        case "object_reference":
+            parts = objectReferenceParts(callee, source: source)
+        case "identifier":
+            guard let name = text(of: callee, in: source) else { return .unresolved }
+            parts = ObjectParts(owner: nil, qualifier: nil, name: name)
+        default:
+            return .unresolved
+        }
+
+        // 1-part `f(…)` → schema object lookup (procedure/function/synonym).
+        if parts.owner == nil, parts.qualifier == nil {
+            return .schemaObject(owner: nil, name: parts.name.uppercased())
+        }
+        // 2-part `[pkg.]proc(…)` → package member is the most likely interpretation.
+        if parts.owner == nil, let qualifier = parts.qualifier {
+            return .packageMember(packageOwner: nil,
+                                  packageName: qualifier.uppercased(),
+                                  memberName: parts.name.uppercased())
+        }
+        // 3-part `owner.pkg.proc(…)` → owner-qualified package member.
+        if let owner = parts.owner, let qualifier = parts.qualifier {
+            return .packageMember(packageOwner: owner.uppercased(),
+                                  packageName: qualifier.uppercased(),
+                                  memberName: parts.name.uppercased())
+        }
+        return .schemaObject(owner: parts.owner?.uppercased(),
+                             name: parts.name.uppercased())
+    }
+
+    /// Classifies a `column_reference` / `field` node. Returns nil when the
+    /// node's structural fields don't expose a `qualifier.name` shape — the
+    /// caller then falls back to a source-text scan (which works mid-typing
+    /// and across grammar variants where field names differ).
+    private func classifyColumnReference(_ node: SwiftTreeSitter.Node,
+                                         source: String,
+                                         utf16Offset: Int) -> ResolvedDBReference? {
+        let parts = objectReferenceParts(node, source: source)
+        guard let qualifier = parts.qualifier ?? parts.owner else {
+            return nil
+        }
+        let column = parts.name
+        guard !column.isEmpty else { return nil }
+        let aliases = aliasResolver.aliases(near: node, source: source)
+        if let resolved = aliases[qualifier.uppercased()] ?? nil {
+            return .column(tableOwner: resolved.owner,
+                           tableName: resolved.name,
+                           columnName: column.uppercased())
+        }
+        // Unknown qualifier — could still be `schema.column` in a SELECT-list
+        // hint we can't disambiguate. Defer to schemaObject so the popover
+        // can at least show what the qualifier resolves to.
+        return .schemaObject(owner: nil, name: qualifier.uppercased())
+    }
+
+    /// 1-part bare identifier with no qualifying parent. Could be:
+    ///   * a table/view/package referenced without a qualifier — handle as
+    ///     `.schemaObject` and let the cache choose the right kind;
+    ///   * a column name whose alias is implicit — handled by the aliases
+    ///     lookup; only returned as `.column` when exactly one in-scope table
+    ///     would carry it (we do NOT fetch here, so the fetcher resolves the
+    ///     ambiguity later via cache + alias map).
+    private func classifyBareIdentifier(_ raw: String,
+                                        cursorByte: UInt32,
+                                        source: String) -> ResolvedDBReference {
+        let upper = raw.uppercased()
+        // Don't try to be clever with bare identifiers — return them as
+        // schema objects; the fetcher's table+package multi-probe is the
+        // right place to make the call.
+        return .schemaObject(owner: nil, name: upper)
+    }
+
+    // MARK: - Source-text fallback
+
+    /// When the parse tree isn't usable at the cursor (typical mid-typing,
+    /// ERROR nodes, etc.) but the surrounding text still encodes a usable
+    /// identifier. Mirrors `SourceScanner` to extract `[qualifier.]name` and
+    /// classifies the result the same way as the tree path.
+    private func resolveFromSourceText(scan: SourceScanner,
+                                       source: String,
+                                       utf16Offset: Int,
+                                       tree: SwiftTreeSitter.Tree?) -> ResolvedDBReference {
+        // Identifier at cursor: walk both ways from `utf16Offset` to capture
+        // the full token, not just the prefix to the cursor. `SourceScanner`
+        // gives us only the leading half; mirror it forward.
+        let nsSource = source as NSString
+        let safeCursor = max(0, min(utf16Offset, nsSource.length))
+
+        var start = safeCursor
+        while start > 0 {
+            let c = nsSource.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            start -= 1
+        }
+        var end = safeCursor
+        while end < nsSource.length {
+            let c = nsSource.character(at: end)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            end += 1
+        }
+        guard end > start else { return .unresolved }
+        let name = nsSource.substring(with: NSRange(location: start, length: end - start))
+
+        // Look back for `qualifier.` immediately preceding the name.
+        var qualifier: String? = nil
+        if start > 0, nsSource.character(at: start - 1) == 0x2E {
+            let qEnd = start - 1
+            var qStart = qEnd
+            while qStart > 0 {
+                let c = nsSource.character(at: qStart - 1)
+                guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+                qStart -= 1
+            }
+            if qStart < qEnd {
+                qualifier = nsSource.substring(with: NSRange(location: qStart, length: qEnd - qStart))
+            }
+        }
+
+        // Look back for an outer schema qualifier `owner.qualifier.name`.
+        var owner: String? = nil
+        if let q = qualifier {
+            // Locate the start of the qualifier substring we already pulled.
+            // `qualifier.length + 1` (for the dot) gives us a probe before it.
+            let qLen = q.utf16.count
+            let probe = start - 1 - qLen
+            if probe > 0, nsSource.character(at: probe - 1) == 0x2E {
+                let oEnd = probe - 1
+                var oStart = oEnd
+                while oStart > 0 {
+                    let c = nsSource.character(at: oStart - 1)
+                    guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+                    oStart -= 1
+                }
+                if oStart < oEnd {
+                    owner = nsSource.substring(with: NSRange(location: oStart, length: oEnd - oStart))
+                }
+            }
+        }
+
+        // If a qualifier exists, it could be either an alias (resolve via
+        // AliasResolver to upgrade to `.column`) or a schema/package.
+        if let qualifier {
+            // Try alias map first; the source-text fallback inside AliasResolver
+            // tolerates a missing tree.
+            let aliases: [String: ResolvedTable?]
+            if let tree, let cursorNode = tree.rootNode?.descendant(in: UInt32(safeCursor * 2)..<UInt32(safeCursor * 2)) {
+                aliases = aliasResolver.aliases(near: cursorNode, source: source)
+            } else {
+                aliases = AliasResolver.aliasesFromSourceText(source, around: safeCursor)
+            }
+            if let resolved = aliases[qualifier.uppercased()] ?? nil {
+                return .column(tableOwner: resolved.owner,
+                               tableName: resolved.name,
+                               columnName: name.uppercased())
+            }
+            // Not an alias — treat as schema-or-package.
+            if let owner {
+                return .packageMember(packageOwner: owner.uppercased(),
+                                      packageName: qualifier.uppercased(),
+                                      memberName: name.uppercased())
+            }
+            return .packageMember(packageOwner: nil,
+                                  packageName: qualifier.uppercased(),
+                                  memberName: name.uppercased())
+        }
+
+        // No qualifier — return the bare identifier as a schema object lookup.
+        return .schemaObject(owner: nil, name: name.uppercased())
+    }
+
+    // MARK: - Helpers
+
+    private struct ObjectParts {
+        let owner: String?
+        let qualifier: String?  // for 3-part names: the middle segment
+        let name: String
+
+        static var empty: ObjectParts { ObjectParts(owner: nil, qualifier: nil, name: "") }
+    }
+
+    /// Pulls 1-, 2-, and 3-part name pieces out of an `object_reference`
+    /// node. The grammar exposes `name` always, `schema` for the 2-part form,
+    /// and a third unnamed identifier for `db.schema.name`. This helper falls
+    /// back to walking children when the named fields aren't present.
+    private func objectReferenceParts(_ node: SwiftTreeSitter.Node,
+                                      source: String) -> ObjectParts {
+        let nameNode = node.child(byFieldName: "name")
+        let schemaNode = node.child(byFieldName: "schema")
+
+        if let nameText = nameNode.flatMap({ text(of: $0, in: source) }),
+           let schemaNode,
+           let schemaText = text(of: schemaNode, in: source) {
+            // Could be 2-part (schema.name) or 3-part (db.schema.name). Look
+            // for a third sibling identifier that isn't the name or schema.
+            let outer = identifierBefore(schema: schemaNode, in: node, source: source)
+            return ObjectParts(owner: outer,
+                               qualifier: schemaText,
+                               name: nameText)
+        }
+        if let nameText = nameNode.flatMap({ text(of: $0, in: source) }) {
+            return ObjectParts(owner: nil, qualifier: nil, name: nameText)
+        }
+        // Fallback: treat children as positional `[a.][b.]c`.
+        var idents: [String] = []
+        for i in 0..<node.namedChildCount {
+            if let child = node.namedChild(at: i),
+               child.nodeType == "identifier",
+               let txt = text(of: child, in: source) {
+                idents.append(txt)
+            }
+        }
+        switch idents.count {
+        case 0: return .empty
+        case 1: return ObjectParts(owner: nil, qualifier: nil, name: idents[0])
+        case 2: return ObjectParts(owner: nil, qualifier: idents[0], name: idents[1])
+        default: return ObjectParts(owner: idents[0],
+                                    qualifier: idents[idents.count - 2],
+                                    name: idents[idents.count - 1])
+        }
+    }
+
+    /// For a 3-part `db.schema.name`, returns the leftmost identifier (the
+    /// "db" segment). The grammar marks `schema` and `name` via field names
+    /// but the outer segment is anonymous, so we fish it out by position.
+    private func identifierBefore(schema: SwiftTreeSitter.Node,
+                                  in parent: SwiftTreeSitter.Node,
+                                  source: String) -> String? {
+        for i in 0..<parent.namedChildCount {
+            guard let child = parent.namedChild(at: i),
+                  child.nodeType == "identifier" else { continue }
+            // Stop at the schema's position; whatever came before is the outer.
+            if child.byteRange.lowerBound >= schema.byteRange.lowerBound { break }
+            if let txt = text(of: child, in: source) { return txt }
+        }
+        return nil
+    }
+
+    private func referenceFromParts(_ parts: ObjectParts,
+                                    source: String,
+                                    cursorByte: UInt32) -> ResolvedDBReference {
+        let nameUpper = parts.name.uppercased()
+        guard !nameUpper.isEmpty else { return .unresolved }
+
+        if let qualifier = parts.qualifier {
+            // 2-part `qualifier.name`: ambiguous between `schema.object` and
+            // `package.member`. Default to schema-object; the fetcher tries
+            // package-member as a fallback. This keeps the simple table
+            // case (`hr.employees`) cheap.
+            return .schemaObject(owner: qualifier.uppercased(), name: nameUpper)
+        }
+        return .schemaObject(owner: parts.owner?.uppercased(), name: nameUpper)
+    }
+
+    private func firstNamedChild(of node: SwiftTreeSitter.Node) -> SwiftTreeSitter.Node? {
+        guard node.namedChildCount > 0 else { return nil }
+        return node.namedChild(at: 0)
+    }
+
+    private func isLiteralOrCommentNode(_ node: SwiftTreeSitter.Node) -> Bool {
+        switch node.nodeType {
+        case "string", "string_literal", "literal_string",
+             "comment", "block_comment", "line_comment":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isQueryBoundary(_ type: String?) -> Bool {
+        switch type {
+        case "statement", "subquery", "block", "plsql_block",
+             "with", "with_query", "common_table_expression",
+             "program", "source_file":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Converts a node's UTF-16-LE byte range to a `String` slice. Mirrors
+    /// the helper in `AliasResolver`.
+    private func text(of node: SwiftTreeSitter.Node, in source: String) -> String? {
+        let lowerByte = Int(node.byteRange.lowerBound)
+        let upperByte = Int(node.byteRange.upperBound)
+        guard lowerByte >= 0, lowerByte <= upperByte,
+              lowerByte.isMultiple(of: 2), upperByte.isMultiple(of: 2) else { return nil }
+        let utf16 = source.utf16
+        let lowerUnits = lowerByte / 2
+        let upperUnits = upperByte / 2
+        guard lowerUnits >= 0, upperUnits <= utf16.count else { return nil }
+        guard let startUTF16 = utf16.index(utf16.startIndex, offsetBy: lowerUnits, limitedBy: utf16.endIndex),
+              let endUTF16 = utf16.index(utf16.startIndex, offsetBy: upperUnits, limitedBy: utf16.endIndex),
+              let start = startUTF16.samePosition(in: source),
+              let end = endUTF16.samePosition(in: source) else { return nil }
+        return String(source[start..<end])
+    }
+}

--- a/Macintora/Editor/Completion/ObjectAtCursorResolver.swift
+++ b/Macintora/Editor/Completion/ObjectAtCursorResolver.swift
@@ -151,9 +151,7 @@ struct ObjectAtCursorResolver {
                     continue
                 }
                 if let raw = text(of: n, in: source) {
-                    return classifyBareIdentifier(raw,
-                                                  cursorByte: n.byteRange.lowerBound,
-                                                  source: source)
+                    return classifyBareIdentifier(raw)
                 }
                 return nil
             default:
@@ -179,10 +177,13 @@ struct ObjectAtCursorResolver {
         // at a column. Otherwise, fall through to the schema-object path.
         if let qualifier = parts.qualifier, parts.owner == nil {
             let aliases = aliasResolver.aliases(near: node, source: source)
+            // Alias map is keyed by Oracle-folded uppercase, so we always
+            // probe with the uppercase form of the qualifier text — even
+            // when the qualifier is itself a quoted identifier.
             if let resolved = aliases[qualifier.uppercased()] ?? nil {
                 return .column(tableOwner: resolved.owner,
                                tableName: resolved.name,
-                               columnName: parts.name.uppercased())
+                               columnName: Self.normalizeIdentifier(parts.name))
             }
         }
         return referenceFromParts(parts, source: source, cursorByte: node.byteRange.lowerBound)
@@ -207,22 +208,22 @@ struct ObjectAtCursorResolver {
 
         // 1-part `f(…)` → schema object lookup (procedure/function/synonym).
         if parts.owner == nil, parts.qualifier == nil {
-            return .schemaObject(owner: nil, name: parts.name.uppercased())
+            return .schemaObject(owner: nil, name: Self.normalizeIdentifier(parts.name))
         }
         // 2-part `[pkg.]proc(…)` → package member is the most likely interpretation.
         if parts.owner == nil, let qualifier = parts.qualifier {
             return .packageMember(packageOwner: nil,
-                                  packageName: qualifier.uppercased(),
-                                  memberName: parts.name.uppercased())
+                                  packageName: Self.normalizeIdentifier(qualifier),
+                                  memberName: Self.normalizeIdentifier(parts.name))
         }
         // 3-part `owner.pkg.proc(…)` → owner-qualified package member.
         if let owner = parts.owner, let qualifier = parts.qualifier {
-            return .packageMember(packageOwner: owner.uppercased(),
-                                  packageName: qualifier.uppercased(),
-                                  memberName: parts.name.uppercased())
+            return .packageMember(packageOwner: Self.normalizeIdentifier(owner),
+                                  packageName: Self.normalizeIdentifier(qualifier),
+                                  memberName: Self.normalizeIdentifier(parts.name))
         }
-        return .schemaObject(owner: parts.owner?.uppercased(),
-                             name: parts.name.uppercased())
+        return .schemaObject(owner: parts.owner.map(Self.normalizeIdentifier),
+                             name: Self.normalizeIdentifier(parts.name))
     }
 
     /// Classifies a `column_reference` / `field` node. Returns nil when the
@@ -242,12 +243,12 @@ struct ObjectAtCursorResolver {
         if let resolved = aliases[qualifier.uppercased()] ?? nil {
             return .column(tableOwner: resolved.owner,
                            tableName: resolved.name,
-                           columnName: column.uppercased())
+                           columnName: Self.normalizeIdentifier(column))
         }
         // Unknown qualifier — could still be `schema.column` in a SELECT-list
         // hint we can't disambiguate. Defer to schemaObject so the popover
         // can at least show what the qualifier resolves to.
-        return .schemaObject(owner: nil, name: qualifier.uppercased())
+        return .schemaObject(owner: nil, name: Self.normalizeIdentifier(qualifier))
     }
 
     /// 1-part bare identifier with no qualifying parent. Could be:
@@ -257,14 +258,11 @@ struct ObjectAtCursorResolver {
     ///     lookup; only returned as `.column` when exactly one in-scope table
     ///     would carry it (we do NOT fetch here, so the fetcher resolves the
     ///     ambiguity later via cache + alias map).
-    private func classifyBareIdentifier(_ raw: String,
-                                        cursorByte: UInt32,
-                                        source: String) -> ResolvedDBReference {
-        let upper = raw.uppercased()
+    private func classifyBareIdentifier(_ raw: String) -> ResolvedDBReference {
         // Don't try to be clever with bare identifiers — return them as
         // schema objects; the fetcher's table+package multi-probe is the
         // right place to make the call.
-        return .schemaObject(owner: nil, name: upper)
+        return .schemaObject(owner: nil, name: Self.normalizeIdentifier(raw))
     }
 
     // MARK: - Source-text fallback
@@ -278,60 +276,34 @@ struct ObjectAtCursorResolver {
                                        utf16Offset: Int,
                                        tree: SwiftTreeSitter.Tree?) -> ResolvedDBReference {
         // Identifier at cursor: walk both ways from `utf16Offset` to capture
-        // the full token, not just the prefix to the cursor. `SourceScanner`
-        // gives us only the leading half; mirror it forward.
+        // the full token, not just the prefix to the cursor. Quoted
+        // identifiers (`"MixedCase"`) are walked as a unit so the quotes
+        // survive into the normalizer below.
         let nsSource = source as NSString
         let safeCursor = max(0, min(utf16Offset, nsSource.length))
 
-        var start = safeCursor
-        while start > 0 {
-            let c = nsSource.character(at: start - 1)
-            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
-            start -= 1
+        guard let token = Self.identifierToken(in: nsSource, around: safeCursor) else {
+            return .unresolved
         }
-        var end = safeCursor
-        while end < nsSource.length {
-            let c = nsSource.character(at: end)
-            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
-            end += 1
-        }
-        guard end > start else { return .unresolved }
-        let name = nsSource.substring(with: NSRange(location: start, length: end - start))
+        let start = token.start
+        let end = token.end
+        let name = token.text
 
-        // Look back for `qualifier.` immediately preceding the name.
+        // Look back for `qualifier.` immediately preceding the name. Skip a
+        // single space — `t .col` happens enough that requiring contiguity
+        // would surprise users.
         var qualifier: String? = nil
-        if start > 0, nsSource.character(at: start - 1) == 0x2E {
-            let qEnd = start - 1
-            var qStart = qEnd
-            while qStart > 0 {
-                let c = nsSource.character(at: qStart - 1)
-                guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
-                qStart -= 1
-            }
-            if qStart < qEnd {
-                qualifier = nsSource.substring(with: NSRange(location: qStart, length: qEnd - qStart))
-            }
+        var qualifierStart: Int? = nil
+        if let q = Self.identifierTokenBeforeDot(in: nsSource, endingAt: start) {
+            qualifier = q.text
+            qualifierStart = q.start
         }
 
         // Look back for an outer schema qualifier `owner.qualifier.name`.
         var owner: String? = nil
-        if let q = qualifier {
-            // Locate the start of the qualifier substring we already pulled.
-            // `qualifier.length + 1` (for the dot) gives us a probe before it.
-            let qLen = q.utf16.count
-            let probe = start - 1 - qLen
-            if probe > 0, nsSource.character(at: probe - 1) == 0x2E {
-                let oEnd = probe - 1
-                var oStart = oEnd
-                while oStart > 0 {
-                    let c = nsSource.character(at: oStart - 1)
-                    guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
-                    oStart -= 1
-                }
-                if oStart < oEnd {
-                    owner = nsSource.substring(with: NSRange(location: oStart, length: oEnd - oStart))
-                }
-            }
+        if let qStart = qualifierStart,
+           let o = Self.identifierTokenBeforeDot(in: nsSource, endingAt: qStart) {
+            owner = o.text
         }
 
         // If a qualifier exists, it could be either an alias (resolve via
@@ -348,21 +320,21 @@ struct ObjectAtCursorResolver {
             if let resolved = aliases[qualifier.uppercased()] ?? nil {
                 return .column(tableOwner: resolved.owner,
                                tableName: resolved.name,
-                               columnName: name.uppercased())
+                               columnName: Self.normalizeIdentifier(name))
             }
             // Not an alias — treat as schema-or-package.
             if let owner {
-                return .packageMember(packageOwner: owner.uppercased(),
-                                      packageName: qualifier.uppercased(),
-                                      memberName: name.uppercased())
+                return .packageMember(packageOwner: Self.normalizeIdentifier(owner),
+                                      packageName: Self.normalizeIdentifier(qualifier),
+                                      memberName: Self.normalizeIdentifier(name))
             }
             return .packageMember(packageOwner: nil,
-                                  packageName: qualifier.uppercased(),
-                                  memberName: name.uppercased())
+                                  packageName: Self.normalizeIdentifier(qualifier),
+                                  memberName: Self.normalizeIdentifier(name))
         }
 
         // No qualifier — return the bare identifier as a schema object lookup.
-        return .schemaObject(owner: nil, name: name.uppercased())
+        return .schemaObject(owner: nil, name: Self.normalizeIdentifier(name))
     }
 
     // MARK: - Helpers
@@ -435,17 +407,19 @@ struct ObjectAtCursorResolver {
     private func referenceFromParts(_ parts: ObjectParts,
                                     source: String,
                                     cursorByte: UInt32) -> ResolvedDBReference {
-        let nameUpper = parts.name.uppercased()
-        guard !nameUpper.isEmpty else { return .unresolved }
+        let normalizedName = Self.normalizeIdentifier(parts.name)
+        guard !normalizedName.isEmpty else { return .unresolved }
 
         if let qualifier = parts.qualifier {
             // 2-part `qualifier.name`: ambiguous between `schema.object` and
             // `package.member`. Default to schema-object; the fetcher tries
             // package-member as a fallback. This keeps the simple table
             // case (`hr.employees`) cheap.
-            return .schemaObject(owner: qualifier.uppercased(), name: nameUpper)
+            return .schemaObject(owner: Self.normalizeIdentifier(qualifier),
+                                 name: normalizedName)
         }
-        return .schemaObject(owner: parts.owner?.uppercased(), name: nameUpper)
+        return .schemaObject(owner: parts.owner.map(Self.normalizeIdentifier),
+                             name: normalizedName)
     }
 
     private func firstNamedChild(of node: SwiftTreeSitter.Node) -> SwiftTreeSitter.Node? {
@@ -472,6 +446,112 @@ struct ObjectAtCursorResolver {
         default:
             return false
         }
+    }
+
+    /// Folds an Oracle identifier to its catalog form. Quoted identifiers
+    /// (`"MixedCase"`) preserve their interior case verbatim — that's what
+    /// Oracle's data dictionary stores. Unquoted identifiers fold to upper.
+    /// Empty strings and the bare `""` pass through unchanged.
+    static func normalizeIdentifier(_ raw: String) -> String {
+        if raw.count >= 2, raw.hasPrefix("\""), raw.hasSuffix("\"") {
+            return String(raw.dropFirst().dropLast())
+        }
+        return raw.uppercased()
+    }
+
+    /// Walks forward and backward from `cursor` (an NSString offset) to find
+    /// the surrounding identifier token, including quoted forms. Returns the
+    /// raw substring with quotes intact when present — `normalizeIdentifier`
+    /// strips them on the way out. Returns nil if `cursor` doesn't sit on an
+    /// identifier-shaped run.
+    private static func identifierToken(
+        in nsSource: NSString,
+        around cursor: Int
+    ) -> (start: Int, end: Int, text: String)? {
+        // Quoted identifier: detect by looking for `"` to the left without a
+        // closing `"` between it and the cursor. The grammar's Oracle quoted
+        // identifier may not contain `"` inside (escaping not supported), so
+        // a single backwards scan suffices.
+        var qLeft = cursor
+        while qLeft > 0 {
+            let c = nsSource.character(at: qLeft - 1)
+            if c == 0x22 {  // '"'
+                qLeft -= 1
+                break
+            }
+            // The cursor's quoted run ends at the first newline or closing
+            // quote — bail out as soon as we see something obviously outside.
+            if c == 0x0A || c == 0x0D { qLeft = -1; break }
+            qLeft -= 1
+            if cursor - qLeft > 256 { qLeft = -1; break }   // safety bound
+        }
+        if qLeft >= 0 && qLeft < cursor && nsSource.character(at: qLeft) == 0x22 {
+            // Find the matching closing quote at or after the cursor.
+            var qRight = cursor
+            while qRight < nsSource.length {
+                let c = nsSource.character(at: qRight)
+                if c == 0x22 {
+                    qRight += 1
+                    let range = NSRange(location: qLeft, length: qRight - qLeft)
+                    return (qLeft, qRight, nsSource.substring(with: range))
+                }
+                if c == 0x0A || c == 0x0D { break }
+                qRight += 1
+            }
+            // No closing quote yet — fall through to the unquoted walk.
+        }
+
+        var start = cursor
+        while start > 0 {
+            let c = nsSource.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            start -= 1
+        }
+        var end = cursor
+        while end < nsSource.length {
+            let c = nsSource.character(at: end)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            end += 1
+        }
+        guard end > start else { return nil }
+        return (start, end, nsSource.substring(with: NSRange(location: start, length: end - start)))
+    }
+
+    /// Probes for an identifier (quoted or unquoted) immediately preceding a
+    /// `.` at NSString offset `nameStart - 1`. Returns nil when there is no
+    /// dot, or the dot isn't followed by an identifier-shaped run.
+    private static func identifierTokenBeforeDot(
+        in nsSource: NSString,
+        endingAt nameStart: Int
+    ) -> (start: Int, end: Int, text: String)? {
+        guard nameStart > 0, nsSource.character(at: nameStart - 1) == 0x2E else {
+            return nil
+        }
+        // Walk backwards from just before the dot. Quoted forms end with `"`;
+        // unquoted forms end with an identifier char.
+        let probe = nameStart - 1
+        if probe > 0, nsSource.character(at: probe - 1) == 0x22 {
+            // Quoted qualifier — find the matching opening quote.
+            var qLeft = probe - 2
+            while qLeft >= 0 {
+                let c = nsSource.character(at: qLeft)
+                if c == 0x22 {
+                    let range = NSRange(location: qLeft, length: probe - qLeft)
+                    return (qLeft, probe, nsSource.substring(with: range))
+                }
+                if c == 0x0A || c == 0x0D { return nil }
+                qLeft -= 1
+            }
+            return nil
+        }
+        var qStart = probe
+        while qStart > 0 {
+            let c = nsSource.character(at: qStart - 1)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            qStart -= 1
+        }
+        guard qStart < probe else { return nil }
+        return (qStart, probe, nsSource.substring(with: NSRange(location: qStart, length: probe - qStart)))
     }
 
     /// Converts a node's UTF-16-LE byte range to a `String` slice. Mirrors

--- a/Macintora/Editor/Completion/SQLContextAnalyzer.swift
+++ b/Macintora/Editor/Completion/SQLContextAnalyzer.swift
@@ -117,7 +117,7 @@ struct SQLContextAnalyzer {
                 i -= 1
             }
             // Capture the word.
-            var end = i
+            let end = i
             while i > 0 {
                 let ch = utf16[utf16.index(utf16.startIndex, offsetBy: i - 1)]
                 guard let scalar = Unicode.Scalar(ch), scalar.properties.isAlphabetic else { break }
@@ -199,7 +199,7 @@ struct SourceScanner {
         //    backward over identifier characters to grab the qualifier.
         var qualifier: String? = nil
         if prefixStart > 0, ns.character(at: prefixStart - 1) == 0x2E /* '.' */ {
-            var qualEnd = prefixStart - 1
+            let qualEnd = prefixStart - 1
             var qualStart = qualEnd
             while qualStart > 0 {
                 let c = ns.character(at: qualStart - 1)

--- a/Macintora/Editor/Completion/SQLParserHelper.swift
+++ b/Macintora/Editor/Completion/SQLParserHelper.swift
@@ -18,7 +18,12 @@ enum SQLParserHelper {
     /// than user input we can recover from.
     static func parse(_ source: String) -> SwiftTreeSitter.Tree {
         let parser = Parser()
-        let language = SwiftTreeSitter.Language(language: TreeSitterLanguage.sqlOrcl.parser)
+        // `SwiftTreeSitter.Language(language:)` consumes a C parser
+        // pointer (`UnsafePointer<TSLanguage>`) — SE-0458 wants the
+        // unsafe acknowledgement at the call site. The pointer comes
+        // from a static linked symbol in the bundled grammar; reading
+        // it is safe.
+        let language = unsafe SwiftTreeSitter.Language(language: TreeSitterLanguage.sqlOrcl.parser)
         try! parser.setLanguage(language)
         // `parse` returns the parser's internal `MutableTree`. The `Tree`
         // wrapper isn't directly accessible, but `copy()` produces one.

--- a/Macintora/Editor/MacintoraEditor+Completion.swift
+++ b/Macintora/Editor/MacintoraEditor+Completion.swift
@@ -15,8 +15,9 @@
 //
 
 import AppKit
-@preconcurrency import STTextView
+import STTextView
 import STPluginNeon  // re-exports SwiftTreeSitter
+import os
 
 extension MacintoraEditorRepresentable.Coordinator {
 

--- a/Macintora/Editor/MacintoraEditor+Coordinator.swift
+++ b/Macintora/Editor/MacintoraEditor+Coordinator.swift
@@ -47,6 +47,15 @@ extension MacintoraEditorRepresentable {
         /// source/formatted) leave this nil for the editor's lifetime.
         var completionCoordinator: CompletionCoordinator?
 
+        /// Quick View orchestrator — owned alongside `completionCoordinator`
+        /// so both share the same `treeStore` and `dataSource`. nil for
+        /// read-only viewers that opt out of completion.
+        var quickViewController: QuickViewController?
+
+        /// Weak reference back to the SwiftUI-owned Quick View box so we can
+        /// detect identity changes (rebind on full document re-init).
+        weak var quickViewBoxRef: EditorQuickViewBox?
+
         /// Last UTF-16 cursor location seen in the selection callback. Used to
         /// detect when the cursor moves outside the in-progress identifier so
         /// auto-trigger can be cancelled.
@@ -59,20 +68,53 @@ extension MacintoraEditorRepresentable {
 
         /// Builds the `CompletionCoordinator` using the previously installed
         /// `treeStore`. Idempotent: subsequent calls are no-ops while a
-        /// coordinator is already in place.
+        /// coordinator is already in place. Returns the coordinator on first
+        /// build so the caller can install dependent plugins.
         @MainActor
-        func installCompletionCoordinator(with config: EditorCompletionConfig) {
-            guard completionCoordinator == nil else { return }
+        @discardableResult
+        func installCompletionCoordinator(with config: EditorCompletionConfig) -> CompletionCoordinator? {
+            if let completionCoordinator { return completionCoordinator }
             guard let treeStore else {
                 editorCompletionLog.error("installCompletionCoordinator called before treeStore was set")
-                return
+                return nil
             }
             let dataSource = CompletionDataSource(persistenceController: config.persistenceController)
-            completionCoordinator = CompletionCoordinator(
+            let coordinator = CompletionCoordinator(
                 treeStore: treeStore,
                 dataSource: dataSource,
                 defaultOwnerProvider: config.defaultOwnerProvider)
+            completionCoordinator = coordinator
             editorCompletionLog.info("installCompletionCoordinator: completion wired for editor")
+            return coordinator
+        }
+
+        /// Builds the Quick View controller once the `completionCoordinator`
+        /// has been installed. Re-uses its `treeStore` and `dataSource`.
+        @MainActor
+        func installQuickViewController(textView: STTextView) {
+            guard quickViewController == nil,
+                  let completionCoordinator else { return }
+            quickViewController = QuickViewController(
+                textView: textView,
+                treeStore: completionCoordinator.treeStore,
+                dataSource: completionCoordinator.dataSource,
+                defaultOwnerProvider: completionCoordinator.defaultOwnerProvider)
+        }
+
+        /// Wires the SwiftUI-owned `EditorQuickViewBox` to this editor's
+        /// Quick View controller. The box's `trigger` closure becomes the
+        /// path the menu command uses to invoke Quick View at the cursor.
+        @MainActor
+        func bindQuickViewBox(_ box: EditorQuickViewBox?, textView: STTextView) {
+            // Drop the previous box's trigger so a stale closure doesn't
+            // keep us alive after a re-mount.
+            quickViewBoxRef?.trigger = nil
+            quickViewBoxRef = box
+            guard let box, let controller = quickViewController else { return }
+            box.trigger = { [weak controller, weak textView] in
+                guard let controller, let textView else { return }
+                controller.triggerAtCursor(textView: textView)
+            }
         }
 
         @MainActor

--- a/Macintora/Editor/MacintoraEditor.swift
+++ b/Macintora/Editor/MacintoraEditor.swift
@@ -133,6 +133,15 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
         textView.setAccessibilityIdentifier(accessibilityIdentifier)
         textView.setAccessibilityRole(.textArea)
 
+        // SQL editor: keep AppKit's spell/grammar/text-replacement machinery
+        // out of the right-click path. NSSpellChecker hops to a default-QoS
+        // thread for NLP and surfaces as a "Hang Risk: priority inversion"
+        // diagnostic when the user-interactive main thread waits on it
+        // (STTextView+Mouse.swift line 231 / super.rightMouseDown at 197).
+        // The two `isAutomatic*` flags otherwise lazily default to the system
+        // NSSpellChecker setting, which is normally on.
+        disableSpellCheckingMachinery(on: textView)
+
         // Always create the SQLTreeStore and install Neon with a tree-update
         // callback, even when the host hasn't (yet) opted in to autocompletion.
         // The CompletionCoordinator is built lazily in `updateNSView` once
@@ -198,6 +207,10 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
             textView.isHorizontallyResizable = !wordWrap
         }
 
+        // SwiftUI re-renders shouldn't be able to flip these back on. Cheap
+        // idempotent writes — see makeNSView for why this is gated off.
+        disableSpellCheckingMachinery(on: textView)
+
         // Only overwrite editor contents when the upstream text diverged from what
         // the editor already shows. Skipping the no-op write prevents the classic
         // re-entrancy loop where a keystroke-driven binding update would stomp on
@@ -220,5 +233,12 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
         if let textView = scrollView.documentView as? STTextView {
             textView.textDelegate = nil
         }
+    }
+
+    private func disableSpellCheckingMachinery(on textView: STTextView) {
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.isGrammarCheckingEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
     }
 }

--- a/Macintora/Editor/MacintoraEditor.swift
+++ b/Macintora/Editor/MacintoraEditor.swift
@@ -46,6 +46,7 @@ struct MacintoraEditor: View {
     let highlightsSelectedLine: Bool
     let accessibilityIdentifier: String
     let completionConfig: EditorCompletionConfig?
+    let quickViewBox: EditorQuickViewBox?
 
     @AppStorage("editorTheme") private var editorThemeRaw: String = EditorTheme.default.rawValue
 
@@ -59,7 +60,8 @@ struct MacintoraEditor: View {
         showsLineNumbers: Bool = true,
         highlightsSelectedLine: Bool = true,
         accessibilityIdentifier: String = "editor.main",
-        completionConfig: EditorCompletionConfig? = nil
+        completionConfig: EditorCompletionConfig? = nil,
+        quickViewBox: EditorQuickViewBox? = nil
     ) {
         self._text = text
         self._selection = selection
@@ -71,6 +73,7 @@ struct MacintoraEditor: View {
         self.highlightsSelectedLine = highlightsSelectedLine
         self.accessibilityIdentifier = accessibilityIdentifier
         self.completionConfig = completionConfig
+        self.quickViewBox = quickViewBox
     }
 
     private var editorTheme: EditorTheme {
@@ -89,7 +92,8 @@ struct MacintoraEditor: View {
             highlightsSelectedLine: highlightsSelectedLine,
             accessibilityIdentifier: accessibilityIdentifier,
             theme: editorTheme,
-            completionConfig: completionConfig
+            completionConfig: completionConfig,
+            quickViewBox: quickViewBox
         )
         .id(editorTheme)
     }
@@ -107,6 +111,7 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
     let accessibilityIdentifier: String
     let theme: EditorTheme
     let completionConfig: EditorCompletionConfig?
+    let quickViewBox: EditorQuickViewBox?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(text: $text, selection: $selection)
@@ -140,6 +145,11 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
         }
         if let config = completionConfig {
             context.coordinator.installCompletionCoordinator(with: config)
+            context.coordinator.installQuickViewController(textView: textView)
+            context.coordinator.bindQuickViewBox(quickViewBox, textView: textView)
+            if let quickViewController = context.coordinator.quickViewController {
+                textView.addPlugin(STDBObjectQuickViewPlugin(controller: quickViewController))
+            }
         }
 
         // Install the Neon syntax-highlighting plugin before the first text
@@ -162,9 +172,20 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
         guard let textView = scrollView.documentView as? STTextView else { return }
 
         // Promote a late-binding completion config (e.g. MainDocumentView's
-        // `.onAppear` runs after `makeNSView`) to a live CompletionCoordinator.
+        // `.onAppear` runs after `makeNSView`) to a live CompletionCoordinator
+        // and Quick View plugin.
         if let config = completionConfig, context.coordinator.completionCoordinator == nil {
             context.coordinator.installCompletionCoordinator(with: config)
+            context.coordinator.installQuickViewController(textView: textView)
+            context.coordinator.bindQuickViewBox(quickViewBox, textView: textView)
+            if let quickViewController = context.coordinator.quickViewController {
+                textView.addPlugin(STDBObjectQuickViewPlugin(controller: quickViewController))
+            }
+        } else if context.coordinator.quickViewBoxRef !== quickViewBox {
+            // Box identity changed (rare but happens on full document
+            // re-init). Rebind so the menu command keeps working against the
+            // freshly-mounted editor.
+            context.coordinator.bindQuickViewBox(quickViewBox, textView: textView)
         }
 
         if textView.isEditable != isEditable { textView.isEditable = isEditable }

--- a/Macintora/Editor/Plugins/QuickView/EditorQuickViewBox.swift
+++ b/Macintora/Editor/Plugins/QuickView/EditorQuickViewBox.swift
@@ -1,0 +1,58 @@
+//
+//  EditorQuickViewBox.swift
+//  Macintora
+//
+//  Bridge object that lets the SwiftUI menu command (in
+//  `MainDocumentMenuCommands`) trigger Quick View on the focused editor
+//  without holding a direct reference to the AppKit text view.
+//
+//  - `MainDocumentView` owns a single instance of this box and publishes it
+//    via `.focusedSceneValue(\.editorQuickViewBox, ...)`.
+//  - The editor's coordinator (`MacintoraEditorRepresentable.Coordinator`)
+//    writes a `[weak self, weak textView]` closure into `trigger` once the
+//    Quick View controller is installed, and clears it when the editor is
+//    dismantled.
+//  - The menu command reads the focused box from anywhere in the responder
+//    hierarchy and invokes `trigger?()`.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+@Observable
+final class EditorQuickViewBox {
+    /// Set by the editor's coordinator after Quick View has been wired.
+    /// Reading nil means no editor is currently capable of Quick View
+    /// (read-only viewer, completion config not yet installed, etc.).
+    var trigger: (() -> Void)?
+}
+
+// MARK: - FocusedValueKey
+
+struct EditorQuickViewBoxKey: FocusedValueKey {
+    typealias Value = EditorQuickViewBox
+}
+
+extension FocusedValues {
+    var editorQuickViewBox: EditorQuickViewBoxKey.Value? {
+        get { self[EditorQuickViewBoxKey.self] }
+        set { self[EditorQuickViewBoxKey.self] = newValue }
+    }
+}
+
+// MARK: - View modifier
+
+extension View {
+    /// Conditionally applies the `.keyboardShortcut(...)` modifier only when
+    /// the hotkey enum carries a key equivalent. When the user has chosen
+    /// "Disabled", no shortcut is bound.
+    @ViewBuilder
+    func quickViewShortcut(_ hotkey: QuickViewHotkey) -> some View {
+        if let key = hotkey.keyEquivalent {
+            self.keyboardShortcut(key, modifiers: hotkey.modifiers)
+        } else {
+            self
+        }
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/EditorQuickViewBox.swift
+++ b/Macintora/Editor/Plugins/QuickView/EditorQuickViewBox.swift
@@ -19,12 +19,27 @@
 import Foundation
 import SwiftUI
 
+/// Plain reference-type holder — intentionally **not** `@Observable`.
+///
+/// The trigger closure is rebound from `updateNSView`'s install path each
+/// time the editor's coordinator wires Quick View. If this class were
+/// observable, every rebind would invalidate `MainDocumentMenuCommands`
+/// (which reads `box.trigger` for `.disabled(...)`), and that invalidation
+/// cascading through the @FocusedSceneValue subscription was enough to
+/// drive `_NSSplitViewItemViewWrapper.updateConstraints` into the
+/// "more Update Constraints passes than views" loop AppKit aborts on —
+/// the same crash signature as `SidebarToggleCrashRegressionTests`.
+///
+/// The menu command instead disables on box identity (nil vs non-nil),
+/// which is settled at focus-publish time and doesn't re-fire on closure
+/// reassignment.
 @MainActor
-@Observable
 final class EditorQuickViewBox {
     /// Set by the editor's coordinator after Quick View has been wired.
-    /// Reading nil means no editor is currently capable of Quick View
-    /// (read-only viewer, completion config not yet installed, etc.).
+    /// nil during the brief window before `installQuickViewController`
+    /// runs — pressing ⌘I in that window is a silent no-op (the closure
+    /// invocation simply does nothing), which is preferable to the menu
+    /// re-render storm that observability would cause.
     var trigger: (() -> Void)?
 }
 

--- a/Macintora/Editor/Plugins/QuickView/QuickViewColumnView.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewColumnView.swift
@@ -1,0 +1,161 @@
+//
+//  QuickViewColumnView.swift
+//  Macintora
+//
+//  Compact mini-popover for a single column reference. Shows name + type +
+//  nullable + default + a chip row for derived (identity / virtual / hidden).
+//  Sized small (~280×170) so it doesn't fight the table popover for space.
+//
+
+import SwiftUI
+
+struct QuickViewColumnView: View {
+    let payload: ColumnDetailPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Image(systemName: "list.bullet")
+                    .foregroundStyle(.tint)
+                Text(payload.column.columnName)
+                    .font(.system(.headline, design: .monospaced))
+                    .textSelection(.enabled)
+                Spacer(minLength: 0)
+                Text(payload.column.dataTypeFormatted)
+                    .font(.system(.subheadline, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            QuickViewColumnFlagsRow(column: payload.column)
+
+            QuickViewColumnDetailsBlock(column: payload.column)
+
+            HStack {
+                Text("\(payload.tableOwner).\(payload.tableName)")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                Spacer()
+                if let openInBrowserAction {
+                    Button("Open Table…", systemImage: "tablecells", action: openInBrowserAction)
+                        .controlSize(.small)
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 320, alignment: .topLeading)
+    }
+}
+
+private struct QuickViewColumnFlagsRow: View {
+    let column: QuickViewColumn
+
+    var body: some View {
+        HStack(spacing: 6) {
+            QuickViewChip(label: column.isNullable ? "NULL" : "NOT NULL",
+                          tone: column.isNullable ? .secondary : .accent)
+            if column.isIdentity {
+                QuickViewChip(label: "Identity", tone: .accent)
+            }
+            if column.isVirtual {
+                QuickViewChip(label: "Virtual", tone: .accent)
+            }
+            if column.isHidden {
+                QuickViewChip(label: "Hidden", tone: .secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+private struct QuickViewColumnDetailsBlock: View {
+    let column: QuickViewColumn
+
+    var body: some View {
+        if let defaultValue = column.defaultValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !defaultValue.isEmpty {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(column.isVirtual ? "Expression" : "Default")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                ScrollView(.vertical) {
+                    Text(defaultValue)
+                        .font(.system(.callout, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 80)
+            }
+        }
+    }
+}
+
+enum QuickViewChipTone {
+    case accent, secondary
+}
+
+struct QuickViewChip: View {
+    let label: String
+    let tone: QuickViewChipTone
+
+    var body: some View {
+        Text(label)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(background, in: .capsule)
+            .foregroundStyle(foreground)
+    }
+
+    private var background: AnyShapeStyle {
+        switch tone {
+        case .accent: AnyShapeStyle(.tint.opacity(0.15))
+        case .secondary: AnyShapeStyle(.quaternary)
+        }
+    }
+
+    private var foreground: AnyShapeStyle {
+        switch tone {
+        case .accent: AnyShapeStyle(.tint)
+        case .secondary: AnyShapeStyle(.secondary)
+        }
+    }
+}
+
+#Preview("Plain column") {
+    QuickViewColumnView(
+        payload: ColumnDetailPayload(
+            tableOwner: "HR",
+            tableName: "EMPLOYEES",
+            column: QuickViewColumn(
+                columnID: 1,
+                columnName: "SALARY",
+                dataType: "NUMBER",
+                dataTypeFormatted: "NUMBER(10,2)",
+                isNullable: false,
+                defaultValue: nil,
+                isIdentity: false,
+                isVirtual: false,
+                isHidden: false)),
+        openInBrowserAction: {})
+}
+
+#Preview("Virtual + identity") {
+    QuickViewColumnView(
+        payload: ColumnDetailPayload(
+            tableOwner: "HR",
+            tableName: "EMPLOYEES",
+            column: QuickViewColumn(
+                columnID: 8,
+                columnName: "TOTAL_COMP",
+                dataType: "NUMBER",
+                dataTypeFormatted: "NUMBER(12,2)",
+                isNullable: true,
+                defaultValue: "salary + nvl(commission,0)",
+                isIdentity: false,
+                isVirtual: true,
+                isHidden: false)),
+        openInBrowserAction: {})
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewContent.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewContent.swift
@@ -1,0 +1,134 @@
+//
+//  QuickViewContent.swift
+//  Macintora
+//
+//  Root SwiftUI view consumed by `QuickViewPresenter`'s NSHostingController.
+//  Switches on the payload kind so the popover always renders one of:
+//    * column mini-popover
+//    * table / view detail
+//    * package / type detail
+//    * standalone procedure / function detail
+//    * "not cached" placeholder when the cache holds no row
+//
+//  Receives a single `openInBrowserAction` closure that the host wires up
+//  for issue #13 (DB Browser pre-fetch). When `nil`, the footer button is
+//  hidden (read-only viewers, previews, etc.).
+//
+
+import SwiftUI
+
+struct QuickViewContent: View {
+    let payload: QuickViewPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        switch payload {
+        case .table(let table):
+            QuickViewTableView(payload: table,
+                               openInBrowserAction: openInBrowserAction)
+        case .packageOrType(let pkg):
+            QuickViewPackageView(payload: pkg,
+                                 openInBrowserAction: openInBrowserAction)
+        case .procedure(let proc):
+            QuickViewProcedureView(payload: proc,
+                                   openInBrowserAction: openInBrowserAction)
+        case .column(let col):
+            QuickViewColumnView(payload: col,
+                                openInBrowserAction: openInBrowserAction)
+        case .unknownObject(let unknown):
+            QuickViewUnknownObjectView(payload: unknown,
+                                       openInBrowserAction: openInBrowserAction)
+        case .notCached(let reference):
+            QuickViewNotCachedView(reference: reference,
+                                   openInBrowserAction: openInBrowserAction)
+        }
+    }
+}
+
+struct QuickViewUnknownObjectView: View {
+    let payload: UnknownObjectPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Image(systemName: "questionmark.square")
+                    .foregroundStyle(.tint)
+                Text("\(payload.owner).\(payload.name)")
+                    .font(.system(.headline, design: .monospaced))
+                    .textSelection(.enabled)
+                QuickViewChip(label: payload.objectType, tone: .accent)
+                if !payload.isValid {
+                    QuickViewChip(label: "Invalid", tone: .secondary)
+                }
+                Spacer()
+            }
+            if let lastDDL = payload.lastDDLDate {
+                Text("Last DDL: \(lastDDL.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Spacer()
+                if let action = openInBrowserAction {
+                    Button("Open in Browser",
+                           systemImage: "rectangle.portrait.and.arrow.right",
+                           action: action)
+                        .controlSize(.small)
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 360, alignment: .topLeading)
+    }
+}
+
+struct QuickViewNotCachedView: View {
+    let reference: ResolvedDBReference
+    let openInBrowserAction: (() -> Void)?
+
+    private var displayName: String {
+        switch reference {
+        case .schemaObject(let owner, let name):
+            return owner.map { "\($0).\(name)" } ?? name
+        case .packageMember(let owner, let pkg, let member):
+            let prefix = owner.map { "\($0)." } ?? ""
+            return "\(prefix)\(pkg).\(member)"
+        case .column(let owner, let table, let column):
+            let prefix = owner.map { "\($0)." } ?? ""
+            return "\(prefix)\(table).\(column)"
+        case .unresolved:
+            return "—"
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Image(systemName: "exclamationmark.circle")
+                    .foregroundStyle(.secondary)
+                Text(displayName)
+                    .font(.system(.headline, design: .monospaced))
+                    .textSelection(.enabled)
+                Spacer()
+            }
+            Text("Not cached for this connection.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Text("Refresh the database cache from the Browser to populate Quick View.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            HStack {
+                Spacer()
+                if let action = openInBrowserAction {
+                    Button("Open in Browser",
+                           systemImage: "rectangle.portrait.and.arrow.right",
+                           action: action)
+                        .controlSize(.small)
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 360, alignment: .topLeading)
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
@@ -1,0 +1,304 @@
+//
+//  QuickViewController.swift
+//  Macintora
+//
+//  Orchestrates the resolve → fetch → present pipeline. Each trigger (right-
+//  click menu item, hotkey, ⌘+click) calls into the same async entry point;
+//  re-entrant calls cancel the in-flight fetch so a quick double-trigger
+//  doesn't leave a stale popover in the queue.
+//
+//  Owned by `MacintoraEditorRepresentable.Coordinator` alongside the
+//  `CompletionCoordinator`. Both share the same `SQLTreeStore` and
+//  `CompletionDataSource` instances.
+//
+
+import AppKit
+import STTextView
+import STPluginNeon  // re-exports SwiftTreeSitter
+import os
+
+@MainActor
+final class QuickViewController {
+
+    private let logger = Logger(subsystem: "com.iliasazonov.macintora",
+                                category: "editor.quickview")
+    private let resolver = ObjectAtCursorResolver()
+    private let treeStore: SQLTreeStore
+    private let dataSource: CompletionDataSource
+    private let presenter: QuickViewPresenter
+    private let defaultOwnerProvider: @MainActor () -> String
+    /// Closure that opens the DB Browser pre-fetched on the resolved object.
+    /// Issue #13 will replace the simple name-only filter with full schema +
+    /// type pre-filter; today this just routes through the existing
+    /// `\.openWindow(value: DBCacheInputValue(...))` plumbing.
+    var openInBrowserHandler: ((ResolvedDBReference) -> Void)?
+    private var inflight: Task<Void, Never>?
+
+    init(textView: STTextView,
+         treeStore: SQLTreeStore,
+         dataSource: CompletionDataSource,
+         defaultOwnerProvider: @escaping @MainActor () -> String) {
+        self.treeStore = treeStore
+        self.dataSource = dataSource
+        self.defaultOwnerProvider = defaultOwnerProvider
+        self.presenter = QuickViewPresenter(textView: textView)
+    }
+
+    // MARK: - Public triggers
+
+    /// Trigger Quick View at the editor's current keyboard cursor.
+    /// `textView` and the selection are read on the main actor inside this
+    /// method; callers don't need to bridge.
+    func triggerAtCursor(textView: STTextView) {
+        let nsRange = textView.selectedRange()
+        // Use the cursor location regardless of selection length — the user's
+        // intent is "at the cursor", not "across the selection".
+        let offset = nsRange.location
+        trigger(textView: textView,
+                utf16Offset: offset,
+                anchor: .range(NSRange(location: offset, length: 0)))
+    }
+
+    /// Trigger Quick View from a content-coordinates click point. Used by
+    /// the ⌘+Click monitor. The presenter anchors the popover at `point`
+    /// instead of the resolved token's bounding rect — clicks land on a
+    /// known location, so re-deriving the range frame is wasted work.
+    func triggerAtClick(textView: STTextView,
+                        point: CGPoint,
+                        utf16Offset: Int) {
+        trigger(textView: textView,
+                utf16Offset: utf16Offset,
+                anchor: .point(point))
+    }
+
+    /// Trigger Quick View at an explicit text offset (right-click menu path —
+    /// the location is provided by STTextView's plugin event).
+    func triggerAtTextLocation(textView: STTextView, utf16Offset: Int) {
+        trigger(textView: textView,
+                utf16Offset: utf16Offset,
+                anchor: .range(NSRange(location: utf16Offset, length: 0)))
+    }
+
+    func dismiss() {
+        inflight?.cancel()
+        inflight = nil
+        presenter.close()
+    }
+
+    // MARK: - Pipeline
+
+    private func trigger(textView: STTextView,
+                         utf16Offset: Int,
+                         anchor: QuickViewPresenter.Anchor) {
+        let source = textView.text ?? ""
+        let tree = treeStore.tree
+        let reference = resolver.resolve(utf16Offset: utf16Offset,
+                                         source: source,
+                                         tree: tree)
+        guard reference != .unresolved else {
+            logger.debug("QuickView: cursor not on a resolvable token")
+            return
+        }
+        logger.info("QuickView trigger: \(String(describing: reference), privacy: .public)")
+
+        // Replace any in-flight fetch.
+        inflight?.cancel()
+        let owner = defaultOwnerProvider()
+        let dataSource = self.dataSource
+        let presenter = self.presenter
+        let openInBrowserHandler = self.openInBrowserHandler
+
+        inflight = Task { [weak self] in
+            let payload = await Self.fetchPayload(for: reference,
+                                                  preferredOwner: owner,
+                                                  dataSource: dataSource)
+            if Task.isCancelled { return }
+            guard let self else { return }
+            // Re-anchor the actual text range now that we know what was
+            // resolved — for `.range(.zero)` cursor-position triggers this
+            // upgrades the anchor to the token's bounding box.
+            let upgraded = Self.upgradeAnchor(anchor,
+                                              reference: reference,
+                                              source: source,
+                                              utf16Offset: utf16Offset)
+            let action: (() -> Void)? = openInBrowserHandler.map { handler in
+                { handler(reference) }
+            }
+            self.presenter.present(payload: payload,
+                                   anchor: upgraded,
+                                   openInBrowserAction: action)
+            _ = presenter // keep ARC honest about capture
+        }
+    }
+
+    /// Routes a `ResolvedDBReference` to the right `CompletionDataSource`
+    /// fetcher and packages the result as a `QuickViewPayload`. Returns
+    /// `.notCached(reference:)` when no cache row matches — the popover's
+    /// "not cached" state is the source of user feedback.
+    @concurrent
+    nonisolated private static func fetchPayload(
+        for reference: ResolvedDBReference,
+        preferredOwner: String,
+        dataSource: CompletionDataSource
+    ) async -> QuickViewPayload {
+        switch reference {
+        case .schemaObject(let owner, let name):
+            return await fetchSchemaObject(owner: owner,
+                                           name: name,
+                                           preferredOwner: preferredOwner,
+                                           reference: reference,
+                                           dataSource: dataSource)
+        case .packageMember(let pkgOwner, let pkgName, let memberName):
+            return await fetchPackageMember(packageOwner: pkgOwner,
+                                            packageName: pkgName,
+                                            memberName: memberName,
+                                            preferredOwner: preferredOwner,
+                                            reference: reference,
+                                            dataSource: dataSource)
+        case .column(let tableOwner, let tableName, let columnName):
+            // Try column popover first; fall back to the parent table when
+            // no column row exists in the cache (e.g. the column reference
+            // is to a synonym or expression).
+            if let payload = await dataSource.columnDetail(tableOwner: tableOwner,
+                                                           tableName: tableName,
+                                                           columnName: columnName) {
+                return .column(payload)
+            }
+            if let table = await dataSource.tableDetail(owner: tableOwner ?? preferredOwner,
+                                                        name: tableName,
+                                                        highlightedColumn: columnName) {
+                return .table(table)
+            }
+            return .notCached(reference: reference)
+        case .unresolved:
+            return .notCached(reference: reference)
+        }
+    }
+
+    @concurrent
+    nonisolated private static func fetchSchemaObject(
+        owner: String?,
+        name: String,
+        preferredOwner: String,
+        reference: ResolvedDBReference,
+        dataSource: CompletionDataSource
+    ) async -> QuickViewPayload {
+        guard let resolved = await dataSource.resolveSchemaObject(owner: owner,
+                                                                  name: name,
+                                                                  preferredOwner: preferredOwner) else {
+            // 2-part schema-object that didn't match — try the package-member
+            // interpretation before giving up. Common case: user clicks on
+            // `pkg.proc` outside an invocation context.
+            if let owner {
+                if let proc = await dataSource.procedureDetail(owner: preferredOwner,
+                                                               packageName: owner,
+                                                               procedureName: name,
+                                                               overload: nil) {
+                    return .procedure(proc)
+                }
+            }
+            return .notCached(reference: reference)
+        }
+
+        switch resolved.objectType {
+        case "TABLE", "VIEW", "MATERIALIZED VIEW":
+            if let table = await dataSource.tableDetail(owner: resolved.owner,
+                                                        name: resolved.name,
+                                                        highlightedColumn: nil) {
+                return .table(table)
+            }
+            return .notCached(reference: reference)
+        case "PACKAGE", "PACKAGE BODY", "TYPE", "TYPE BODY":
+            if let pkg = await dataSource.packageDetail(owner: resolved.owner,
+                                                        name: resolved.name) {
+                return .packageOrType(pkg)
+            }
+            return .notCached(reference: reference)
+        case "PROCEDURE", "FUNCTION":
+            if let proc = await dataSource.procedureDetail(owner: resolved.owner,
+                                                           packageName: nil,
+                                                           procedureName: resolved.name,
+                                                           overload: nil) {
+                return .procedure(proc)
+            }
+            // Procedure metadata sometimes isn't refreshed; show object-only.
+            if let unknown = await dataSource.unknownObjectDetail(owner: resolved.owner,
+                                                                  name: resolved.name) {
+                return .unknownObject(unknown)
+            }
+            return .notCached(reference: reference)
+        case "SYNONYM":
+            // v1: don't chase synonyms; show the synonym as an unknown object
+            // so the user can see it exists.
+            if let unknown = await dataSource.unknownObjectDetail(owner: resolved.owner,
+                                                                  name: resolved.name) {
+                return .unknownObject(unknown)
+            }
+            return .notCached(reference: reference)
+        default:
+            if let unknown = await dataSource.unknownObjectDetail(owner: resolved.owner,
+                                                                  name: resolved.name) {
+                return .unknownObject(unknown)
+            }
+            return .notCached(reference: reference)
+        }
+    }
+
+    @concurrent
+    nonisolated private static func fetchPackageMember(
+        packageOwner: String?,
+        packageName: String,
+        memberName: String,
+        preferredOwner: String,
+        reference: ResolvedDBReference,
+        dataSource: CompletionDataSource
+    ) async -> QuickViewPayload {
+        // 1) Try the package-member interpretation.
+        if let proc = await dataSource.procedureDetail(owner: packageOwner ?? preferredOwner,
+                                                      packageName: packageName,
+                                                      procedureName: memberName,
+                                                      overload: nil) {
+            return .procedure(proc)
+        }
+        // 2) Fall back to schema-qualified standalone object: treat the
+        // qualifier as a schema and the member as the standalone object.
+        if let resolved = await dataSource.resolveSchemaObject(owner: packageOwner ?? packageName,
+                                                               name: memberName,
+                                                               preferredOwner: preferredOwner) {
+            return await fetchSchemaObject(owner: resolved.owner,
+                                           name: resolved.name,
+                                           preferredOwner: preferredOwner,
+                                           reference: reference,
+                                           dataSource: dataSource)
+        }
+        return .notCached(reference: reference)
+    }
+
+    /// Recovers a meaningful anchor rect when the original anchor was a
+    /// zero-length range (cursor-only trigger). Walks the source around the
+    /// cursor to find the identifier's bounds and re-anchors there.
+    private static func upgradeAnchor(_ anchor: QuickViewPresenter.Anchor,
+                                      reference: ResolvedDBReference,
+                                      source: String,
+                                      utf16Offset: Int) -> QuickViewPresenter.Anchor {
+        if case .range(let r) = anchor, r.length > 0 { return anchor }
+        if case .point = anchor { return anchor }
+
+        let nsSource = source as NSString
+        let safe = max(0, min(utf16Offset, nsSource.length))
+        var start = safe
+        while start > 0 {
+            let c = nsSource.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            start -= 1
+        }
+        var end = safe
+        while end < nsSource.length {
+            let c = nsSource.character(at: end)
+            guard let scalar = Unicode.Scalar(c), SourceScanner.isIdentifierChar(scalar) else { break }
+            end += 1
+        }
+        guard end > start else { return anchor }
+        return .range(NSRange(location: start, length: end - start))
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
@@ -135,8 +135,12 @@ final class QuickViewController {
     /// fetcher and packages the result as a `QuickViewPayload`. Returns
     /// `.notCached(reference:)` when no cache row matches — the popover's
     /// "not cached" state is the source of user feedback.
+    ///
+    /// `internal` so the test target can exercise the orchestration logic
+    /// directly without instantiating an STTextView; the production caller
+    /// is `trigger(textView:utf16Offset:anchor:)` above.
     @concurrent
-    nonisolated private static func fetchPayload(
+    nonisolated static func fetchPayload(
         for reference: ResolvedDBReference,
         preferredOwner: String,
         dataSource: CompletionDataSource
@@ -164,9 +168,16 @@ final class QuickViewController {
                                                            columnName: columnName) {
                 return .column(payload)
             }
+            // For the parent-table fallback we require *some* concrete
+            // evidence the table exists — at minimum one cached column.
+            // Otherwise `tableDetail` returns an empty-containers payload
+            // for a totally-uncached table and we'd render a misleading
+            // "0 columns / 0 indexes" popover instead of the honest
+            // "not cached" placeholder.
             if let table = await dataSource.tableDetail(owner: tableOwner ?? preferredOwner,
                                                         name: tableName,
-                                                        highlightedColumn: columnName) {
+                                                        highlightedColumn: columnName),
+               !table.columns.isEmpty {
                 return .table(table)
             }
             return .notCached(reference: reference)

--- a/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
@@ -105,7 +105,6 @@ final class QuickViewController {
         inflight?.cancel()
         let owner = defaultOwnerProvider()
         let dataSource = self.dataSource
-        let presenter = self.presenter
         let openInBrowserHandler = self.openInBrowserHandler
 
         inflight = Task { [weak self] in
@@ -127,7 +126,6 @@ final class QuickViewController {
             self.presenter.present(payload: payload,
                                    anchor: upgraded,
                                    openInBrowserAction: action)
-            _ = presenter // keep ARC honest about capture
         }
     }
 

--- a/Macintora/Editor/Plugins/QuickView/QuickViewHotkey.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewHotkey.swift
@@ -1,0 +1,50 @@
+//
+//  QuickViewHotkey.swift
+//  Macintora
+//
+//  AppStorage-backed enum of user-selectable hotkeys for the Quick View
+//  feature. v1 ships a small preset list; a free-form key recorder is a
+//  follow-up.
+//
+
+import SwiftUI
+
+enum QuickViewHotkey: String, CaseIterable, Identifiable, Sendable {
+    case cmdI = "cmdI"
+    case cmdF4 = "cmdF4"
+    case cmdShiftI = "cmdShiftI"
+    case disabled = "disabled"
+
+    static let storageKey = "editor.quickViewHotkey"
+    static let `default`: QuickViewHotkey = .cmdI
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .cmdI:      return "⌘I"
+        case .cmdF4:     return "⌘F4"
+        case .cmdShiftI: return "⌘⇧I"
+        case .disabled:  return "Disabled"
+        }
+    }
+
+    /// `KeyEquivalent` for SwiftUI `.keyboardShortcut(...)`. Returns nil for
+    /// the disabled state so the menu item can be omitted entirely.
+    var keyEquivalent: KeyEquivalent? {
+        switch self {
+        case .cmdI, .cmdShiftI: return "i"
+        case .cmdF4:            return KeyEquivalent(Character(UnicodeScalar(NSF4FunctionKey)!))
+        case .disabled:         return nil
+        }
+    }
+
+    var modifiers: EventModifiers {
+        switch self {
+        case .cmdI:      return [.command]
+        case .cmdF4:     return [.command]
+        case .cmdShiftI: return [.command, .shift]
+        case .disabled:  return []
+        }
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewPackageView.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewPackageView.swift
@@ -1,0 +1,153 @@
+//
+//  QuickViewPackageView.swift
+//  Macintora
+//
+//  Quick View popover content for a package or user-defined type. Lists
+//  member procedures with collapsible argument signatures. The full source
+//  body is intentionally not shown here — too long for a popover; the "Open
+//  in Browser" button is the path to that.
+//
+
+import SwiftUI
+
+struct QuickViewPackageView: View {
+    let payload: PackageDetailPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            QuickViewPackageHeader(payload: payload,
+                                   openInBrowserAction: openInBrowserAction)
+            if payload.procedures.isEmpty {
+                QuickViewPackageEmptyState(objectType: payload.objectType,
+                                           specSource: payload.specSource)
+            } else {
+                QuickViewPackageProceduresList(procedures: payload.procedures)
+            }
+        }
+        .padding(12)
+        .frame(width: 520, alignment: .topLeading)
+    }
+}
+
+private struct QuickViewPackageHeader: View {
+    let payload: PackageDetailPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Image(systemName: payload.objectType == "TYPE"
+                  ? "t.square"
+                  : "ellipsis.curlybraces")
+                .foregroundStyle(.tint)
+            Text("\(payload.owner).\(payload.name)")
+                .font(.system(.headline, design: .monospaced))
+                .textSelection(.enabled)
+            QuickViewChip(label: payload.objectType, tone: .accent)
+            if !payload.isValid {
+                QuickViewChip(label: "Invalid", tone: .secondary)
+            }
+            Spacer(minLength: 0)
+            if let action = openInBrowserAction {
+                Button("Open in Browser",
+                       systemImage: "rectangle.portrait.and.arrow.right",
+                       action: action)
+                    .controlSize(.small)
+            }
+        }
+    }
+}
+
+private struct QuickViewPackageEmptyState: View {
+    let objectType: String
+    let specSource: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("No procedures or functions cached.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            if let spec = specSource, !spec.isEmpty {
+                QuickViewSQLBlock(text: spec)
+            }
+        }
+    }
+}
+
+private struct QuickViewPackageProceduresList: View {
+    let procedures: [QuickViewPackageProcedure]
+
+    var body: some View {
+        ScrollView(.vertical) {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(procedures) { proc in
+                    QuickViewPackageProcedureRow(procedure: proc)
+                    Divider().opacity(0.4)
+                }
+            }
+        }
+        .frame(maxHeight: 320)
+    }
+}
+
+private struct QuickViewPackageProcedureRow: View {
+    let procedure: QuickViewPackageProcedure
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.12)) { isExpanded.toggle() }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: procedure.kind == "FUNCTION"
+                          ? "f.cursive"
+                          : "curlybraces")
+                        .foregroundStyle(.tint)
+                    Text(procedure.name)
+                        .font(.system(.callout, design: .monospaced))
+                    if let overload = procedure.overload, !overload.isEmpty {
+                        Text("(#\(overload))")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                    if let returnType = procedure.returnType {
+                        Text("→ \(returnType)")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    Spacer()
+                    Text("\(procedure.parameters.count) param\(procedure.parameters.count == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .contentShape(.rect)
+                .padding(.vertical, 4)
+                .padding(.horizontal, 6)
+            }
+            .buttonStyle(.plain)
+            if isExpanded {
+                if procedure.parameters.isEmpty {
+                    Text("(no parameters)")
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .padding(.leading, 30)
+                        .padding(.bottom, 4)
+                } else {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(procedure.parameters) { arg in
+                            QuickViewArgumentRow(argument: arg)
+                                .padding(.leading, 24)
+                        }
+                    }
+                    .padding(.bottom, 4)
+                }
+            }
+        }
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewPayload.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewPayload.swift
@@ -1,0 +1,139 @@
+//
+//  QuickViewPayload.swift
+//  Macintora
+//
+//  Sendable view-models returned by the cache-side fetchers and consumed by
+//  the `QuickViewContent` SwiftUI tree. Plain structs (never `NSManagedObject`)
+//  so results can cross the `CompletionDataSource` actor boundary safely.
+//
+
+import Foundation
+
+/// What `QuickViewController` hands to `QuickViewContent` after a successful
+/// cache fetch. Drives which detail subview renders.
+enum QuickViewPayload: Sendable, Equatable {
+    case table(TableDetailPayload)
+    case packageOrType(PackageDetailPayload)
+    case procedure(ProcedureDetailPayload)
+    case column(ColumnDetailPayload)
+    case unknownObject(UnknownObjectPayload)
+    case notCached(reference: ResolvedDBReference)
+}
+
+// MARK: - Table / view
+
+struct TableDetailPayload: Sendable, Equatable {
+    let owner: String
+    let name: String
+    let isView: Bool
+    let isEditioning: Bool
+    let isReadOnly: Bool
+    let isPartitioned: Bool
+    let numRows: Int64?
+    let lastAnalyzed: Date?
+    let sqlText: String?       // populated for views
+    let columns: [QuickViewColumn]
+    let indexes: [QuickViewIndex]
+    let triggers: [QuickViewTrigger]
+    /// When the user invoked Quick View from a column reference, this carries
+    /// the column name to scroll/highlight in the columns list. nil otherwise.
+    let highlightedColumn: String?
+}
+
+struct QuickViewColumn: Sendable, Equatable, Identifiable {
+    var id: String { columnName }
+    let columnID: Int32
+    let columnName: String
+    let dataType: String
+    /// Pre-formatted Oracle-style type string e.g. `VARCHAR2(120)` or `NUMBER(10,2)`.
+    let dataTypeFormatted: String
+    let isNullable: Bool
+    let defaultValue: String?
+    let isIdentity: Bool
+    let isVirtual: Bool
+    let isHidden: Bool
+}
+
+struct QuickViewIndex: Sendable, Equatable, Identifiable {
+    var id: String { "\(owner).\(name)" }
+    let owner: String
+    let name: String
+    let type: String?
+    let isUnique: Bool
+    let isValid: Bool
+}
+
+struct QuickViewTrigger: Sendable, Equatable, Identifiable {
+    var id: String { "\(owner).\(name)" }
+    let owner: String
+    let name: String
+    let event: String?
+    let isEnabled: Bool
+}
+
+// MARK: - Package / type
+
+struct PackageDetailPayload: Sendable, Equatable {
+    let owner: String
+    let name: String
+    /// `"PACKAGE"`, `"TYPE"`, etc. — drives the header label.
+    let objectType: String
+    let isValid: Bool
+    /// Spec source. Body is intentionally omitted from Quick View — too long
+    /// for a popover. The "Open in Browser" button is the path to full source.
+    let specSource: String?
+    let procedures: [QuickViewPackageProcedure]
+}
+
+struct QuickViewPackageProcedure: Sendable, Equatable, Identifiable {
+    var id: String { "\(name)#\(overload ?? "")" }
+    let name: String
+    let kind: String   // "PROCEDURE" | "FUNCTION"
+    let overload: String?
+    let returnType: String?
+    let parameters: [QuickViewProcedureArgument]
+}
+
+struct QuickViewProcedureArgument: Sendable, Equatable, Identifiable {
+    var id: Int { sequence }
+    let sequence: Int
+    let position: Int
+    let name: String?
+    let dataType: String
+    let inOut: String        // "IN" | "OUT" | "IN/OUT"
+    let defaulted: Bool
+    let defaultValue: String?
+}
+
+// MARK: - Standalone procedure / function
+
+struct ProcedureDetailPayload: Sendable, Equatable {
+    let owner: String
+    /// Either the standalone proc/function name, or the package member name.
+    let name: String
+    /// Non-nil and equal to the package name when the procedure is a member.
+    let packageName: String?
+    let kind: String   // "PROCEDURE" | "FUNCTION"
+    let overload: String?
+    let returnType: String?
+    let parameters: [QuickViewProcedureArgument]
+    let isValid: Bool
+}
+
+// MARK: - Column
+
+struct ColumnDetailPayload: Sendable, Equatable {
+    let tableOwner: String
+    let tableName: String
+    let column: QuickViewColumn
+}
+
+// MARK: - Catch-all (TYPE, INDEX, TRIGGER without further detail)
+
+struct UnknownObjectPayload: Sendable, Equatable {
+    let owner: String
+    let name: String
+    let objectType: String
+    let isValid: Bool
+    let lastDDLDate: Date?
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
@@ -7,8 +7,9 @@
 //  range) or at a click point. Idempotent: presenting a new payload while a
 //  popover is already showing closes the previous one and re-anchors.
 //
-//  Anchor-rect math is in `QuickViewAnchor.swift` rather than the presenter
-//  so the conversion can be unit-tested independently.
+//  Anchor-rect math lives in the `QuickViewAnchor` enum below, kept in this
+//  same file so the rect-resolution logic stays close to the call site that
+//  consumes it. Both types are small enough to share a file.
 //
 
 import AppKit

--- a/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
@@ -78,7 +78,10 @@ final class QuickViewPresenter: NSObject {
         // "not cached" placeholder before issue #13 wires the Open in
         // Browser button) leaves no responder for AppKit to deliver Esc
         // to, and the only way to dismiss is click-outside.
-        hosting.view.window?.makeFirstResponder(hosting)
+        // `unsafe` acknowledges SE-0458 — `NSWindow.makeFirstResponder`
+        // is annotated `@unsafe` in the AppKit overlay; we're already
+        // on the main actor, so the call is safe in practice.
+        unsafe hosting.view.window?.makeFirstResponder(hosting)
     }
 
     func close() {

--- a/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
@@ -48,13 +48,12 @@ final class QuickViewPresenter: NSObject {
         let content = QuickViewContent(payload: payload,
                                        openInBrowserAction: openInBrowserAction)
 
-        // Reuse the existing popover when one is up — re-show is cheaper than
-        // tearing down and re-creating. Still re-anchors for the new rect.
-        if let popover, let hosting = hostingController, popover.isShown {
-            hosting.rootView = content
-            popover.contentSize = hosting.view.intrinsicContentSize
-            close()
-        }
+        // Always rebuild on present. Re-using the popover would mean keeping
+        // the previous anchor rect in sync with the new payload's range, and
+        // tearing down a transient `NSPopover` is cheap. Tear down any
+        // currently-visible popover so only one Quick View is on screen at a
+        // time.
+        if popover != nil { close() }
 
         let hosting = QuickViewHostingController(rootView: content)
         hosting.sizingOptions = [.preferredContentSize]

--- a/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
@@ -1,0 +1,138 @@
+//
+//  QuickViewPresenter.swift
+//  Macintora
+//
+//  Owns the `NSPopover` + `NSHostingController` lifecycle for Quick View.
+//  Anchors the popover at a token's bounding rect (computed from a UTF-16
+//  range) or at a click point. Idempotent: presenting a new payload while a
+//  popover is already showing closes the previous one and re-anchors.
+//
+//  Anchor-rect math is in `QuickViewAnchor.swift` rather than the presenter
+//  so the conversion can be unit-tested independently.
+//
+
+import AppKit
+import SwiftUI
+import STTextView
+import STTextKitPlus
+
+@MainActor
+final class QuickViewPresenter: NSObject {
+
+    /// Hostable shape of the rect we want the popover to point at.
+    enum Anchor: Equatable {
+        /// A UTF-16 range in the editor's content. The presenter resolves it
+        /// to a screen-space rect via `STTextView.textLayoutManager`.
+        case range(NSRange)
+
+        /// A point in the text view's content-view coordinates (typically
+        /// from a Cmd+Click). The popover anchors at a 1×1 rect there.
+        case point(CGPoint)
+    }
+
+    private weak var textView: STTextView?
+    private var popover: NSPopover?
+    private var hostingController: NSHostingController<QuickViewContent>?
+
+    init(textView: STTextView) {
+        self.textView = textView
+    }
+
+    /// Replaces any visible popover with one rendering `payload`. Caller is
+    /// expected to invoke this on the main actor.
+    func present(payload: QuickViewPayload,
+                 anchor: Anchor,
+                 openInBrowserAction: (() -> Void)?) {
+        guard let textView else { return }
+
+        let content = QuickViewContent(payload: payload,
+                                       openInBrowserAction: openInBrowserAction)
+
+        // Reuse the existing popover when one is up — re-show is cheaper than
+        // tearing down and re-creating. Still re-anchors for the new rect.
+        if let popover, let hosting = hostingController, popover.isShown {
+            hosting.rootView = content
+            popover.contentSize = hosting.view.intrinsicContentSize
+            close()
+        }
+
+        let hosting = NSHostingController(rootView: content)
+        hosting.sizingOptions = [.preferredContentSize]
+        let popover = NSPopover()
+        popover.contentViewController = hosting
+        popover.behavior = .transient   // dismiss on click-outside / Esc
+        popover.animates = true
+        self.popover = popover
+        self.hostingController = hosting
+
+        let rect = QuickViewAnchor.rect(for: anchor, in: textView)
+        // STTextView's content view is the documentView of an NSScrollView;
+        // we anchor relative to the textView itself so the popover follows
+        // scrolling correctly until it's dismissed.
+        popover.show(relativeTo: rect, of: textView, preferredEdge: .maxY)
+    }
+
+    func close() {
+        popover?.close()
+        popover = nil
+        hostingController = nil
+    }
+
+    var isVisible: Bool {
+        popover?.isShown ?? false
+    }
+}
+
+// MARK: - Anchor rect math
+
+@MainActor
+enum QuickViewAnchor {
+    /// Resolves a presenter `Anchor` into a rect in `textView`'s coordinate
+    /// space, suitable for `NSPopover.show(relativeTo:of:preferredEdge:)`.
+    /// Falls back to a small rect at the cursor when the requested range
+    /// can't be located (e.g. it's been clipped out of view).
+    static func rect(for anchor: QuickViewPresenter.Anchor,
+                     in textView: STTextView) -> NSRect {
+        switch anchor {
+        case .range(let nsRange):
+            return rectForRange(nsRange, in: textView) ?? fallbackRect(in: textView)
+        case .point(let point):
+            // Convert from the click's content-view coordinates to the text
+            // view's coordinate system. The hit-test point we receive is
+            // already in the text view's coordinates, so just inflate to a
+            // 1×1 rect at that point.
+            return NSRect(x: point.x, y: point.y, width: 1, height: 1)
+        }
+    }
+
+    private static func rectForRange(_ nsRange: NSRange, in textView: STTextView) -> NSRect? {
+        guard nsRange.length > 0 else { return nil }
+        let layoutManager = textView.textLayoutManager
+        guard let textContentManager = layoutManager.textContentManager else { return nil }
+        let docStart = textContentManager.documentRange.location
+        guard let start = textContentManager.location(docStart, offsetBy: nsRange.location),
+              let end = textContentManager.location(docStart,
+                                                    offsetBy: nsRange.location + nsRange.length),
+              let textRange = NSTextRange(location: start, end: end) else { return nil }
+        var union: NSRect = .null
+        layoutManager.enumerateTextSegments(in: textRange,
+                                            type: .standard,
+                                            options: .middleFragmentsExcluded) { _, rect, _, _ in
+            if union.isNull { union = rect } else { union = union.union(rect) }
+            return true
+        }
+        if union.isNull { return nil }
+        return union
+    }
+
+    private static func fallbackRect(in textView: STTextView) -> NSRect {
+        // Cursor selection rect, or the visible top-left as a last resort.
+        let layoutManager = textView.textLayoutManager
+        if let selection = layoutManager.textSelections.first?.textRanges.first,
+           let frame = layoutManager.textSegmentFrame(in: selection, type: .standard) {
+            return frame
+        }
+        let visible = textView.visibleRect
+        return NSRect(x: visible.minX + 8, y: visible.minY + 8, width: 1, height: 1)
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewPresenter.swift
@@ -32,7 +32,7 @@ final class QuickViewPresenter: NSObject {
 
     private weak var textView: STTextView?
     private var popover: NSPopover?
-    private var hostingController: NSHostingController<QuickViewContent>?
+    private var hostingController: QuickViewHostingController?
 
     init(textView: STTextView) {
         self.textView = textView
@@ -56,12 +56,13 @@ final class QuickViewPresenter: NSObject {
             close()
         }
 
-        let hosting = NSHostingController(rootView: content)
+        let hosting = QuickViewHostingController(rootView: content)
         hosting.sizingOptions = [.preferredContentSize]
         let popover = NSPopover()
         popover.contentViewController = hosting
         popover.behavior = .transient   // dismiss on click-outside / Esc
         popover.animates = true
+        hosting.popover = popover
         self.popover = popover
         self.hostingController = hosting
 
@@ -70,6 +71,14 @@ final class QuickViewPresenter: NSObject {
         // we anchor relative to the textView itself so the popover follows
         // scrolling correctly until it's dismissed.
         popover.show(relativeTo: rect, of: textView, preferredEdge: .maxY)
+
+        // Make the hosting view the popover window's first responder so
+        // Esc reaches our `cancelOperation` override below — without this,
+        // a popover whose SwiftUI tree has no interactive elements (the
+        // "not cached" placeholder before issue #13 wires the Open in
+        // Browser button) leaves no responder for AppKit to deliver Esc
+        // to, and the only way to dismiss is click-outside.
+        hosting.view.window?.makeFirstResponder(hosting)
     }
 
     func close() {
@@ -80,6 +89,27 @@ final class QuickViewPresenter: NSObject {
 
     var isVisible: Bool {
         popover?.isShown ?? false
+    }
+}
+
+/// `NSHostingController` subclass that closes its popover on Esc.
+///
+/// `NSPopover.behavior == .transient` already dismisses on click-outside,
+/// but Esc handling depends on the popover window having a first responder
+/// in the responder chain that responds to `cancelOperation(_:)`. SwiftUI's
+/// hosting view chains responder through interactive subviews (Lists,
+/// Buttons), so payloads with rich content dismiss correctly. The "not
+/// cached" / "unknown object" placeholders have no interactive elements
+/// today; without this subclass they trapped Esc and required a mouse
+/// click to dismiss.
+@MainActor
+final class QuickViewHostingController: NSHostingController<QuickViewContent> {
+    weak var popover: NSPopover?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func cancelOperation(_ sender: Any?) {
+        popover?.close()
     }
 }
 

--- a/Macintora/Editor/Plugins/QuickView/QuickViewProcedureView.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewProcedureView.swift
@@ -1,0 +1,132 @@
+//
+//  QuickViewProcedureView.swift
+//  Macintora
+//
+//  Single-procedure / single-function popover content. Renders the call
+//  signature, parameters, and (for functions) the return type.
+//
+
+import SwiftUI
+
+struct QuickViewProcedureView: View {
+    let payload: ProcedureDetailPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            QuickViewProcedureHeader(payload: payload,
+                                     openInBrowserAction: openInBrowserAction)
+            QuickViewProcedureSignature(payload: payload)
+        }
+        .padding(12)
+        .frame(width: 480, alignment: .topLeading)
+    }
+}
+
+private struct QuickViewProcedureHeader: View {
+    let payload: ProcedureDetailPayload
+    let openInBrowserAction: (() -> Void)?
+
+    private var qualifiedName: String {
+        var parts: [String] = [payload.owner]
+        if let pkg = payload.packageName, !pkg.isEmpty {
+            parts.append(pkg)
+        }
+        parts.append(payload.name)
+        return parts.joined(separator: ".")
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Image(systemName: payload.kind == "FUNCTION" ? "f.cursive" : "curlybraces")
+                .foregroundStyle(.tint)
+            Text(qualifiedName)
+                .font(.system(.headline, design: .monospaced))
+                .textSelection(.enabled)
+            if let overload = payload.overload, !overload.isEmpty {
+                QuickViewChip(label: "Overload \(overload)", tone: .secondary)
+            }
+            if !payload.isValid {
+                QuickViewChip(label: "Invalid", tone: .secondary)
+            }
+            Spacer(minLength: 0)
+            if let action = openInBrowserAction {
+                Button("Open in Browser",
+                       systemImage: "rectangle.portrait.and.arrow.right",
+                       action: action)
+                    .controlSize(.small)
+            }
+        }
+    }
+}
+
+struct QuickViewProcedureSignature: View {
+    let payload: ProcedureDetailPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if payload.parameters.isEmpty {
+                Text("(no parameters)")
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView(.vertical) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(payload.parameters) { arg in
+                            QuickViewArgumentRow(argument: arg)
+                            Divider().opacity(0.4)
+                        }
+                    }
+                }
+                .frame(maxHeight: 240)
+            }
+            if let returnType = payload.returnType {
+                Divider()
+                HStack {
+                    Image(systemName: "return")
+                        .foregroundStyle(.secondary)
+                    Text("RETURN")
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    Text(returnType)
+                        .font(.system(.callout, design: .monospaced))
+                        .textSelection(.enabled)
+                    Spacer()
+                }
+                .padding(.top, 2)
+            }
+        }
+    }
+}
+
+struct QuickViewArgumentRow: View {
+    let argument: QuickViewProcedureArgument
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(argument.inOut)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 36, alignment: .leading)
+            Text(argument.name ?? "")
+                .font(.system(.callout, design: .monospaced))
+                .frame(minWidth: 140, alignment: .leading)
+                .textSelection(.enabled)
+            Text(argument.dataType)
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 140, alignment: .leading)
+                .textSelection(.enabled)
+            if argument.defaulted {
+                Text("DEFAULT \(argument.defaultValue ?? "")")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewTableView.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewTableView.swift
@@ -161,7 +161,7 @@ private struct QuickViewIndexList: View {
         VStack(alignment: .leading, spacing: 2) {
             ForEach(indexes) { idx in
                 HStack(spacing: 8) {
-                    Image(systemName: "ecrease.indent")
+                    Image(systemName: "decrease.indent")
                         .foregroundStyle(.tint)
                     Text(idx.name)
                         .font(.system(.callout, design: .monospaced))

--- a/Macintora/Editor/Plugins/QuickView/QuickViewTableView.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewTableView.swift
@@ -1,0 +1,250 @@
+//
+//  QuickViewTableView.swift
+//  Macintora
+//
+//  Quick View popover content for a table or view: header strip, columns
+//  list, expandable Indexes / Triggers sections, and (for views) a "View
+//  SQL" disclosure with the underlying SELECT text.
+//
+
+import SwiftUI
+
+struct QuickViewTableView: View {
+    let payload: TableDetailPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            QuickViewTableHeader(payload: payload,
+                                 openInBrowserAction: openInBrowserAction)
+            QuickViewTableColumnsList(columns: payload.columns,
+                                      highlightedColumn: payload.highlightedColumn)
+            if !payload.indexes.isEmpty {
+                QuickViewTableSection(title: "Indexes (\(payload.indexes.count))") {
+                    QuickViewIndexList(indexes: payload.indexes)
+                }
+            }
+            if !payload.triggers.isEmpty {
+                QuickViewTableSection(title: "Triggers (\(payload.triggers.count))") {
+                    QuickViewTriggerList(triggers: payload.triggers)
+                }
+            }
+            if payload.isView, let sql = payload.sqlText, !sql.isEmpty {
+                QuickViewTableSection(title: "View SQL") {
+                    QuickViewSQLBlock(text: sql)
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 520, alignment: .topLeading)
+    }
+}
+
+private struct QuickViewTableHeader: View {
+    let payload: TableDetailPayload
+    let openInBrowserAction: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Image(systemName: payload.isView ? "tablecells.badge.ellipsis" : "tablecells")
+                .foregroundStyle(.tint)
+            Text("\(payload.owner).\(payload.name)")
+                .font(.system(.headline, design: .monospaced))
+                .textSelection(.enabled)
+            if payload.isView {
+                QuickViewChip(label: "View", tone: .accent)
+            }
+            if payload.isPartitioned {
+                QuickViewChip(label: "Partitioned", tone: .secondary)
+            }
+            if payload.isReadOnly {
+                QuickViewChip(label: "Read-Only", tone: .secondary)
+            }
+            Spacer(minLength: 0)
+            if let action = openInBrowserAction {
+                Button("Open in Browser", systemImage: "rectangle.portrait.and.arrow.right",
+                       action: action)
+                    .controlSize(.small)
+            }
+        }
+    }
+}
+
+private struct QuickViewTableColumnsList: View {
+    let columns: [QuickViewColumn]
+    let highlightedColumn: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Columns")
+                    .font(.subheadline.bold())
+                Spacer()
+                Text(columns.count.formatted())
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.bottom, 4)
+
+            if columns.isEmpty {
+                Text("No columns cached for this object.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView(.vertical) {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(columns) { column in
+                                QuickViewColumnRow(column: column,
+                                                   isHighlighted: column.columnName == highlightedColumn)
+                                    .id(column.columnName)
+                                Divider()
+                                    .opacity(0.5)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 220)
+                    .task(id: highlightedColumn) {
+                        if let target = highlightedColumn {
+                            withAnimation(.easeOut(duration: 0.15)) {
+                                proxy.scrollTo(target, anchor: .center)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct QuickViewColumnRow: View {
+    let column: QuickViewColumn
+    let isHighlighted: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(column.columnName)
+                .font(.system(.callout, design: .monospaced))
+                .frame(minWidth: 120, alignment: .leading)
+                .textSelection(.enabled)
+            Text(column.dataTypeFormatted)
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 120, alignment: .leading)
+                .textSelection(.enabled)
+            Group {
+                if !column.isNullable {
+                    QuickViewChip(label: "NOT NULL", tone: .accent)
+                }
+                if column.isIdentity {
+                    QuickViewChip(label: "Identity", tone: .accent)
+                }
+                if column.isVirtual {
+                    QuickViewChip(label: "Virtual", tone: .accent)
+                }
+                if column.isHidden {
+                    QuickViewChip(label: "Hidden", tone: .secondary)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(isHighlighted ? AnyShapeStyle(.tint.opacity(0.18)) : AnyShapeStyle(.clear),
+                    in: .rect(cornerRadius: 4))
+    }
+}
+
+private struct QuickViewIndexList: View {
+    let indexes: [QuickViewIndex]
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(indexes) { idx in
+                HStack(spacing: 8) {
+                    Image(systemName: "ecrease.indent")
+                        .foregroundStyle(.tint)
+                    Text(idx.name)
+                        .font(.system(.callout, design: .monospaced))
+                        .textSelection(.enabled)
+                    if idx.isUnique { QuickViewChip(label: "Unique", tone: .accent) }
+                    if !idx.isValid { QuickViewChip(label: "Invalid", tone: .secondary) }
+                    Spacer()
+                    if let type = idx.type {
+                        Text(type)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct QuickViewTriggerList: View {
+    let triggers: [QuickViewTrigger]
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(triggers) { trg in
+                HStack(spacing: 8) {
+                    Image(systemName: "bolt")
+                        .foregroundStyle(.tint)
+                    Text(trg.name)
+                        .font(.system(.callout, design: .monospaced))
+                        .textSelection(.enabled)
+                    if !trg.isEnabled {
+                        QuickViewChip(label: "Disabled", tone: .secondary)
+                    }
+                    Spacer()
+                    if let event = trg.event {
+                        Text(event)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct QuickViewSQLBlock: View {
+    let text: String
+    var body: some View {
+        ScrollView(.vertical) {
+            Text(text)
+                .font(.system(.callout, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+        }
+        .frame(maxHeight: 220)
+        .background(.quaternary.opacity(0.4), in: .rect(cornerRadius: 6))
+    }
+}
+
+struct QuickViewTableSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+    @State private var isExpanded = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) { isExpanded.toggle() }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                    Text(title)
+                        .font(.subheadline.bold())
+                    Spacer()
+                }
+                .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            if isExpanded {
+                content
+                    .padding(.leading, 4)
+            }
+        }
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewTableView.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewTableView.swift
@@ -45,27 +45,64 @@ private struct QuickViewTableHeader: View {
     let openInBrowserAction: (() -> Void)?
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline) {
-            Image(systemName: payload.isView ? "tablecells.badge.ellipsis" : "tablecells")
-                .foregroundStyle(.tint)
-            Text("\(payload.owner).\(payload.name)")
-                .font(.system(.headline, design: .monospaced))
-                .textSelection(.enabled)
-            if payload.isView {
-                QuickViewChip(label: "View", tone: .accent)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline) {
+                Image(systemName: payload.isView ? "tablecells.badge.ellipsis" : "tablecells")
+                    .foregroundStyle(.tint)
+                Text("\(payload.owner).\(payload.name)")
+                    .font(.system(.headline, design: .monospaced))
+                    .textSelection(.enabled)
+                if payload.isView {
+                    QuickViewChip(label: "View", tone: .accent)
+                }
+                if payload.isPartitioned {
+                    QuickViewChip(label: "Partitioned", tone: .secondary)
+                }
+                if payload.isReadOnly {
+                    QuickViewChip(label: "Read-Only", tone: .secondary)
+                }
+                if payload.isEditioning {
+                    QuickViewChip(label: "Editioning", tone: .secondary)
+                }
+                Spacer(minLength: 0)
+                if let action = openInBrowserAction {
+                    Button("Open in Browser", systemImage: "rectangle.portrait.and.arrow.right",
+                           action: action)
+                        .controlSize(.small)
+                }
             }
-            if payload.isPartitioned {
-                QuickViewChip(label: "Partitioned", tone: .secondary)
+            QuickViewTableStatsLine(numRows: payload.numRows,
+                                    lastAnalyzed: payload.lastAnalyzed)
+        }
+    }
+}
+
+/// Compact stats subline under the table title — row count and a relative
+/// "analyzed" timestamp. Renders `EmptyView` when neither field is populated
+/// so a fully-uncached table doesn't grow a blank line.
+private struct QuickViewTableStatsLine: View {
+    let numRows: Int64?
+    let lastAnalyzed: Date?
+
+    var body: some View {
+        if numRows == nil && lastAnalyzed == nil {
+            EmptyView()
+        } else {
+            HStack(spacing: 6) {
+                if let numRows {
+                    Text("\(numRows, format: .number.notation(.compactName)) rows")
+                }
+                if numRows != nil && lastAnalyzed != nil {
+                    Text(verbatim: "·")
+                        .foregroundStyle(.tertiary)
+                }
+                if let lastAnalyzed {
+                    Text("analyzed \(lastAnalyzed, format: .relative(presentation: .named))")
+                }
+                Spacer(minLength: 0)
             }
-            if payload.isReadOnly {
-                QuickViewChip(label: "Read-Only", tone: .secondary)
-            }
-            Spacer(minLength: 0)
-            if let action = openInBrowserAction {
-                Button("Open in Browser", systemImage: "rectangle.portrait.and.arrow.right",
-                       action: action)
-                    .controlSize(.small)
-            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
     }
 }

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -162,30 +162,6 @@ struct STDBObjectQuickViewPlugin: STPlugin {
             removeMonitor()
         }
 
-        /// Hit-tests `point` (in `textView` coordinates) against the layout
-        /// manager and returns the UTF-16 offset of the resulting text
-        /// location. Returns nil for clicks outside any text run.
-        @MainActor
-        static func utf16Offset(at point: CGPoint, in textView: STTextView) -> Int? {
-            let layoutManager = textView.textLayoutManager
-            guard let textContentManager = layoutManager.textContentManager else { return nil }
-            let docStart = layoutManager.documentRange.location
-            // `lineFragmentRange(for:inContainerAt:)` returns the visible line
-            // range; its `textSelectionNavigation.textSelections(...)` lookup
-            // produces the click-resolved text location.
-            guard let fragmentRange = layoutManager.lineFragmentRange(for: point,
-                                                                       inContainerAt: docStart),
-                  let location = layoutManager.textSelectionNavigation
-                    .textSelections(interactingAt: point,
-                                    inContainerAt: fragmentRange.location,
-                                    anchors: [],
-                                    modifiers: [],
-                                    selecting: false,
-                                    bounds: layoutManager.usageBoundsForTextContainer)
-                    .first?.textRanges.first?.location
-            else { return nil }
-            return textContentManager.offset(from: docStart, to: location)
-        }
     }
 
     func tearDown() {
@@ -198,7 +174,7 @@ struct STDBObjectQuickViewPlugin: STPlugin {
 /// Tiny target object owning the closure invoked when the user picks the
 /// "Quick View" context menu item.
 @MainActor
-final class QuickViewMenuTarget: NSObject {
+private final class QuickViewMenuTarget: NSObject {
     private let action: () -> Void
     init(action: @escaping () -> Void) {
         self.action = action

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -110,7 +110,7 @@ struct STDBObjectQuickViewPlugin: STPlugin {
                     // `unsafe` acknowledges SE-0458 — `NSEvent.window` and
                     // `NSResponder.window` are marked `@unsafe` in the
                     // AppKit overlay; we're already main-actor isolated.
-                    let eventWindow = unsafe event.window
+                    let eventWindow = event.window
                     guard Coordinator.shouldTrigger(eventWindow: eventWindow,
                                                     locationInWindow: event.locationInWindow,
                                                     textView: textView) else { return }

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -83,27 +83,40 @@ struct STDBObjectQuickViewPlugin: STPlugin {
                                     controller: QuickViewController) {
             // Only one monitor per coordinator instance; tearDown removes it.
             removeMonitor()
-            // The NSEvent local-monitor closure is declared nonisolated by
-            // AppKit but fires on the main thread. The strategy:
+            // ⌘+Click hit-testing strategy:
             //
-            //   1. Pre-filter on `event.modifierFlags` (Sendable) for ⌘.
-            //   2. Return `event` so AppKit dispatches the click normally —
-            //      the cursor moves to the click point through STTextView's
-            //      own hit-testing path, which already knows about content-
-            //      view coordinate offsets, line gutters, etc.
-            //   3. Schedule a main-actor Task to fire Quick View at the
-            //      *new* cursor location, which by definition is the click
-            //      target. This avoids re-implementing STTextView's point-
-            //      to-offset conversion (an earlier attempt got the
-            //      coordinate space wrong because `textView.convert(_:from:)`
-            //      is bounds-relative, while `lineFragmentRange(for:inContainerAt:)`
-            //      is content-view-relative).
+            //   * Reading the cursor *after* the click doesn't work —
+            //     NSTextView/STTextView don't move the cursor on ⌘+click,
+            //     so `selectedRange()` reports the *old* location.
+            //   * Doing my own point-to-offset conversion via
+            //     `textView.convert(_:from:)` and `lineFragmentRange(for:)`
+            //     gives the wrong coordinate space (textView bounds vs.
+            //     content-view interior — see commit history).
+            //
+            // Use STTextView's public `characterIndex(for screenPoint:)`,
+            // which is the official NSTextInputClient hit-tester. It
+            // converts screen → window → contentView for us, runs through
+            // `textLayoutManager.caretLocation(interactingAt:)`, and
+            // returns the document-relative UTF-16 offset (or NSNotFound).
+            //
+            // Body wrapped in `MainActor.assumeIsolated` because AppKit's
+            // Swift overlay marks `NSEvent.window` and the responder
+            // hierarchy `@MainActor`. Local monitors fire on the main
+            // thread, so the assumption is the documented contract.
             monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak textView, weak controller] event in
                 guard event.modifierFlags.contains(.command) else { return event }
-                guard let textView, let controller else { return event }
-
-                Task { @MainActor in
-                    controller.triggerAtCursor(textView: textView)
+                MainActor.assumeIsolated {
+                    guard let textView, let controller else { return }
+                    // `unsafe` acknowledges SE-0458 — `NSEvent.window` and
+                    // `NSResponder.window` are marked `@unsafe` in the
+                    // AppKit overlay; we're already main-actor isolated.
+                    guard let window = unsafe textView.window else { return }
+                    let eventWindow = unsafe event.window
+                    guard eventWindow === window else { return }
+                    let screenPoint = window.convertPoint(toScreen: event.locationInWindow)
+                    let offset = textView.characterIndex(for: screenPoint)
+                    guard offset != NSNotFound else { return }
+                    controller.triggerAtTextLocation(textView: textView, utf16Offset: offset)
                 }
                 return event
             }

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -56,13 +56,13 @@ struct STDBObjectQuickViewPlugin: STPlugin {
             }
             item.target = target
             item.action = #selector(QuickViewMenuTarget.invoke(_:))
-            // `NSMenu.addItem(_:)` doesn't retain the target; stash it on the
-            // menu item via objc associated objects so it lives until the
-            // menu is dismissed.
-            objc_setAssociatedObject(item,
-                                     &QuickViewMenuTargetAssocKey,
-                                     target,
-                                     .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            // `NSMenuItem.target` is a weak reference, so we need a strong
+            // ref to keep the closure alive until the menu is dismissed.
+            // `representedObject` is the canonical strong-ref slot on
+            // NSMenuItem — using it avoids an `objc_setAssociatedObject`
+            // call that Swift 6's strict-memory-safety mode now flags as
+            // unsafe.
+            item.representedObject = target
             menu.addItem(item)
             return menu
         }
@@ -74,39 +74,43 @@ struct STDBObjectQuickViewPlugin: STPlugin {
 
     @MainActor
     final class Coordinator {
-        /// `nonisolated(unsafe)` — the monitor token is read on the main
-        /// actor (`installCmdClickMonitor` / `removeMonitor`) but `deinit`
-        /// runs in the runtime's chosen isolation, which the type checker
-        /// can't statically prove is main. `NSEvent.removeMonitor(_:)` is
-        /// thread-safe per AppKit, so calling it from any thread is fine.
-        nonisolated(unsafe) private var monitor: Any?
+        /// Token returned by `NSEvent.addLocalMonitorForEvents`. Read and
+        /// written only on the main actor; the matching `removeMonitor`
+        /// call also runs on main — see `isolated deinit` below.
+        private var monitor: Any?
 
         func installCmdClickMonitor(textView: STTextView,
                                     controller: QuickViewController) {
             // Only one monitor per coordinator instance; tearDown removes it.
             removeMonitor()
+            // The NSEvent local-monitor closure is declared nonisolated by
+            // AppKit but always invoked on the main thread. AppKit's Swift
+            // overlay marks `NSEvent.window` and the AppKit responder
+            // hierarchy as `@MainActor`, so we hop the body through
+            // `MainActor.assumeIsolated` to read those without per-call
+            // `unsafe` annotations. We deliberately return Void from the
+            // assumed block (NSEvent is non-Sendable, and the closure
+            // result type would otherwise force a Sendable bound) and let
+            // the outer closure return `event` unconditionally — Quick
+            // View is non-destructive and never consumes the click.
             monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak textView, weak controller] event in
-                guard let textView, let controller else { return event }
+                // Modifier flags are Sendable; cheap pre-filter avoids
+                // hopping the actor for the hot non-⌘ path.
                 guard event.modifierFlags.contains(.command) else { return event }
-                guard event.window === textView.window else { return event }
-
-                // Hit-test the click against the text view's content bounds.
-                let pointInText = textView.convert(event.locationInWindow, from: nil)
-                guard textView.bounds.contains(pointInText) else { return event }
-
-                // Map the text-view-coordinate point to a content-text offset.
-                guard let offset = MainActor.assumeIsolated({
-                    Self.utf16Offset(at: pointInText, in: textView)
-                }) else { return event }
+                guard let textView, let controller else { return event }
 
                 MainActor.assumeIsolated {
+                    // Unsafe-marked AppKit window identity check; SE-0458
+                    // requires acknowledgement at the call site. Reading
+                    // is safe under main-actor isolation.
+                    guard unsafe event.window === textView.window else { return }
+                    let pointInText = textView.convert(event.locationInWindow, from: nil)
+                    guard textView.bounds.contains(pointInText) else { return }
+                    guard let offset = Self.utf16Offset(at: pointInText, in: textView) else { return }
                     controller.triggerAtClick(textView: textView,
                                               point: pointInText,
                                               utf16Offset: offset)
                 }
-
-                // Return the event so cursor placement still happens — Quick
-                // View is non-destructive and doesn't consume the click.
                 return event
             }
         }
@@ -118,11 +122,12 @@ struct STDBObjectQuickViewPlugin: STPlugin {
             monitor = nil
         }
 
-        deinit {
-            // `NSEvent.removeMonitor` is safe from any thread per AppKit docs.
-            if let monitor = monitor {
-                NSEvent.removeMonitor(monitor)
-            }
+        /// `isolated deinit` (SE-0371) keeps the cleanup main-actor-bound
+        /// so we can read the `monitor` property without `nonisolated(unsafe)`
+        /// hatches. The Swift runtime hops to the main executor for the
+        /// deinit body if invoked from another isolation domain.
+        isolated deinit {
+            removeMonitor()
         }
 
         /// Hit-tests `point` (in `textView` coordinates) against the layout
@@ -157,9 +162,6 @@ struct STDBObjectQuickViewPlugin: STPlugin {
         // owns monitor cleanup. Nothing to do here.
     }
 }
-
-/// Associated-object key for `NSMenuItem` → `QuickViewMenuTarget` retention.
-nonisolated(unsafe) private var QuickViewMenuTargetAssocKey: UInt8 = 0
 
 /// Tiny target object owning the closure invoked when the user picks the
 /// "Quick View" context menu item.

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -1,0 +1,175 @@
+//
+//  STDBObjectQuickViewPlugin.swift
+//  Macintora
+//
+//  STTextView plugin that wires three trigger paths into a single
+//  `QuickViewController`:
+//
+//    1. Right-click — adds a "Quick View" item to the standard context menu
+//       via `STPluginEvents.onContextMenu`. STTextView appends single-item
+//       plugin menus to its own menu (with a separator) — see
+//       `STTextViewDelegateProxy.swift` upstream — so we don't replace the
+//       built-in actions.
+//
+//    2. ⌘+Click — installed as an `NSEvent.addLocalMonitorForEvents` monitor
+//       scoped to the text view's window. Returns the original event so the
+//       click still moves the cursor; no text selection is consumed.
+//
+//    3. Hotkey — handled outside the plugin (focused-value action published
+//       by `MainDocumentView` and consumed by the SwiftUI menu command).
+//       Routed back here through the controller exposed on the editor's
+//       coordinator.
+//
+
+import AppKit
+import STTextView
+
+@MainActor
+struct STDBObjectQuickViewPlugin: STPlugin {
+    let controller: QuickViewController
+
+    init(controller: QuickViewController) {
+        self.controller = controller
+    }
+
+    func setUp(context: any Context) {
+        let textView = context.textView
+        let controller = self.controller
+        let coordinator = context.coordinator
+        coordinator.installCmdClickMonitor(textView: textView, controller: controller)
+
+        context.events.onContextMenu { location, contentManager in
+            let menu = NSMenu()
+            let item = NSMenuItem(
+                title: "Quick View",
+                action: nil,
+                keyEquivalent: "")
+            // Use a local target object so we don't rely on the responder
+            // chain finding our action on STTextView.
+            let target = QuickViewMenuTarget { [weak controller, weak textView] in
+                guard let controller, let textView else { return }
+                let utf16Offset = contentManager.offset(
+                    from: contentManager.documentRange.location,
+                    to: location)
+                controller.triggerAtTextLocation(textView: textView,
+                                                 utf16Offset: utf16Offset)
+            }
+            item.target = target
+            item.action = #selector(QuickViewMenuTarget.invoke(_:))
+            // `NSMenu.addItem(_:)` doesn't retain the target; stash it on the
+            // menu item via objc associated objects so it lives until the
+            // menu is dismissed.
+            objc_setAssociatedObject(item,
+                                     &QuickViewMenuTargetAssocKey,
+                                     target,
+                                     .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            menu.addItem(item)
+            return menu
+        }
+    }
+
+    func makeCoordinator(context: CoordinatorContext) -> Coordinator {
+        Coordinator()
+    }
+
+    @MainActor
+    final class Coordinator {
+        /// `nonisolated(unsafe)` — the monitor token is read on the main
+        /// actor (`installCmdClickMonitor` / `removeMonitor`) but `deinit`
+        /// runs in the runtime's chosen isolation, which the type checker
+        /// can't statically prove is main. `NSEvent.removeMonitor(_:)` is
+        /// thread-safe per AppKit, so calling it from any thread is fine.
+        nonisolated(unsafe) private var monitor: Any?
+
+        func installCmdClickMonitor(textView: STTextView,
+                                    controller: QuickViewController) {
+            // Only one monitor per coordinator instance; tearDown removes it.
+            removeMonitor()
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak textView, weak controller] event in
+                guard let textView, let controller else { return event }
+                guard event.modifierFlags.contains(.command) else { return event }
+                guard event.window === textView.window else { return event }
+
+                // Hit-test the click against the text view's content bounds.
+                let pointInText = textView.convert(event.locationInWindow, from: nil)
+                guard textView.bounds.contains(pointInText) else { return event }
+
+                // Map the text-view-coordinate point to a content-text offset.
+                guard let offset = MainActor.assumeIsolated({
+                    Self.utf16Offset(at: pointInText, in: textView)
+                }) else { return event }
+
+                MainActor.assumeIsolated {
+                    controller.triggerAtClick(textView: textView,
+                                              point: pointInText,
+                                              utf16Offset: offset)
+                }
+
+                // Return the event so cursor placement still happens — Quick
+                // View is non-destructive and doesn't consume the click.
+                return event
+            }
+        }
+
+        func removeMonitor() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            monitor = nil
+        }
+
+        deinit {
+            // `NSEvent.removeMonitor` is safe from any thread per AppKit docs.
+            if let monitor = monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+        }
+
+        /// Hit-tests `point` (in `textView` coordinates) against the layout
+        /// manager and returns the UTF-16 offset of the resulting text
+        /// location. Returns nil for clicks outside any text run.
+        @MainActor
+        static func utf16Offset(at point: CGPoint, in textView: STTextView) -> Int? {
+            let layoutManager = textView.textLayoutManager
+            guard let textContentManager = layoutManager.textContentManager else { return nil }
+            let docStart = layoutManager.documentRange.location
+            // `lineFragmentRange(for:inContainerAt:)` returns the visible line
+            // range; its `textSelectionNavigation.textSelections(...)` lookup
+            // produces the click-resolved text location.
+            guard let fragmentRange = layoutManager.lineFragmentRange(for: point,
+                                                                       inContainerAt: docStart),
+                  let location = layoutManager.textSelectionNavigation
+                    .textSelections(interactingAt: point,
+                                    inContainerAt: fragmentRange.location,
+                                    anchors: [],
+                                    modifiers: [],
+                                    selecting: false,
+                                    bounds: layoutManager.usageBoundsForTextContainer)
+                    .first?.textRanges.first?.location
+            else { return nil }
+            return textContentManager.offset(from: docStart, to: location)
+        }
+    }
+
+    func tearDown() {
+        // STPlugin teardown happens on a different STPlugin instance copy
+        // than makeCoordinator, so the coordinator's deinit is what really
+        // owns monitor cleanup. Nothing to do here.
+    }
+}
+
+/// Associated-object key for `NSMenuItem` → `QuickViewMenuTarget` retention.
+nonisolated(unsafe) private var QuickViewMenuTargetAssocKey: UInt8 = 0
+
+/// Tiny target object owning the closure invoked when the user picks the
+/// "Quick View" context menu item.
+@MainActor
+final class QuickViewMenuTarget: NSObject {
+    private let action: () -> Void
+    init(action: @escaping () -> Void) {
+        self.action = action
+    }
+    @objc func invoke(_ sender: Any?) {
+        action()
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -110,9 +110,11 @@ struct STDBObjectQuickViewPlugin: STPlugin {
                     // `unsafe` acknowledges SE-0458 — `NSEvent.window` and
                     // `NSResponder.window` are marked `@unsafe` in the
                     // AppKit overlay; we're already main-actor isolated.
-                    guard let window = unsafe textView.window else { return }
                     let eventWindow = unsafe event.window
-                    guard eventWindow === window else { return }
+                    guard Coordinator.shouldTrigger(eventWindow: eventWindow,
+                                                    locationInWindow: event.locationInWindow,
+                                                    textView: textView) else { return }
+                    guard let window = unsafe textView.window else { return }
                     let screenPoint = window.convertPoint(toScreen: event.locationInWindow)
                     let offset = textView.characterIndex(for: screenPoint)
                     guard offset != NSNotFound else { return }
@@ -120,6 +122,29 @@ struct STDBObjectQuickViewPlugin: STPlugin {
                 }
                 return event
             }
+        }
+
+        /// Click-gate predicate. Returns true only when `eventWindow` is the
+        /// text view's window AND the click hit-tests onto the text view (or
+        /// a descendant of it) — `NSEvent.addLocalMonitorForEvents` is
+        /// process-global, so without these gates a ⌘-click in the sidebar,
+        /// toolbar, or another worksheet's editor would also pop. Extracted
+        /// as a static so it's exercised by `QuickViewClickGateTests`
+        /// without synthesizing an `NSEvent`.
+        static func shouldTrigger(eventWindow: NSWindow?,
+                                  locationInWindow: NSPoint,
+                                  textView: NSView) -> Bool {
+            // `unsafe` acknowledges the AppKit overlay's `@unsafe` marker on
+            // `window` accessors. The caller is main-actor isolated.
+            guard let textViewWindow = unsafe textView.window,
+                  let eventWindow,
+                  eventWindow === textViewWindow else {
+                return false
+            }
+            guard let hit = textViewWindow.contentView?.hitTest(locationInWindow) else {
+                return false
+            }
+            return hit === textView || hit.isDescendant(of: textView)
         }
 
         func removeMonitor() {

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -84,32 +84,26 @@ struct STDBObjectQuickViewPlugin: STPlugin {
             // Only one monitor per coordinator instance; tearDown removes it.
             removeMonitor()
             // The NSEvent local-monitor closure is declared nonisolated by
-            // AppKit but always invoked on the main thread. AppKit's Swift
-            // overlay marks `NSEvent.window` and the AppKit responder
-            // hierarchy as `@MainActor`, so we hop the body through
-            // `MainActor.assumeIsolated` to read those without per-call
-            // `unsafe` annotations. We deliberately return Void from the
-            // assumed block (NSEvent is non-Sendable, and the closure
-            // result type would otherwise force a Sendable bound) and let
-            // the outer closure return `event` unconditionally — Quick
-            // View is non-destructive and never consumes the click.
+            // AppKit but fires on the main thread. The strategy:
+            //
+            //   1. Pre-filter on `event.modifierFlags` (Sendable) for ⌘.
+            //   2. Return `event` so AppKit dispatches the click normally —
+            //      the cursor moves to the click point through STTextView's
+            //      own hit-testing path, which already knows about content-
+            //      view coordinate offsets, line gutters, etc.
+            //   3. Schedule a main-actor Task to fire Quick View at the
+            //      *new* cursor location, which by definition is the click
+            //      target. This avoids re-implementing STTextView's point-
+            //      to-offset conversion (an earlier attempt got the
+            //      coordinate space wrong because `textView.convert(_:from:)`
+            //      is bounds-relative, while `lineFragmentRange(for:inContainerAt:)`
+            //      is content-view-relative).
             monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak textView, weak controller] event in
-                // Modifier flags are Sendable; cheap pre-filter avoids
-                // hopping the actor for the hot non-⌘ path.
                 guard event.modifierFlags.contains(.command) else { return event }
                 guard let textView, let controller else { return event }
 
-                MainActor.assumeIsolated {
-                    // Unsafe-marked AppKit window identity check; SE-0458
-                    // requires acknowledgement at the call site. Reading
-                    // is safe under main-actor isolation.
-                    guard unsafe event.window === textView.window else { return }
-                    let pointInText = textView.convert(event.locationInWindow, from: nil)
-                    guard textView.bounds.contains(pointInText) else { return }
-                    guard let offset = Self.utf16Offset(at: pointInText, in: textView) else { return }
-                    controller.triggerAtClick(textView: textView,
-                                              point: pointInText,
-                                              utf16Offset: offset)
+                Task { @MainActor in
+                    controller.triggerAtCursor(textView: textView)
                 }
                 return event
             }

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -267,10 +267,14 @@ struct MainDocumentMenuCommands: Commands {
 
             Divider()
 
+            // Disabled gating reads the box's identity (nil = no focused
+            // editor capable of Quick View) rather than `box.trigger` —
+            // see the long comment in `EditorQuickViewBox` for the
+            // constraint-loop crash that observable trigger reads caused.
             Button("Quick View") {
                 quickViewBox?.trigger?()
             }
-            .disabled(quickViewBox?.trigger == nil)
+            .disabled(quickViewBox == nil)
             .quickViewShortcut(quickViewHotkey)
         }
     }

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -57,6 +57,21 @@ extension MacintoraAppDelegate: nonisolated NSApplicationDelegate {
         UserDefaults.standard.register(defaults: [
             "NSShowAppCentricOpenPanelInsteadOfUntitledFile": false
         ])
+
+        // Validate the persisted window frame BEFORE any window opens. If
+        // the saved frame lives on a now-disconnected display (or otherwise
+        // doesn't meaningfully intersect any current screen) AppKit's
+        // `setFrameAutosaveName` replays the bad frame, the window appears
+        // off-screen, and SwiftUI's NavigationSplitView immediately drives
+        // `_NSSplitViewItemViewWrapper.updateConstraints` past AppKit's
+        // "more passes than views" safety net and crashes. The post-window
+        // sanity check in `WindowLayoutPersister.ensureFrameIsOnScreen`
+        // can't help — by the time `viewDidMoveToWindow` fires, the bad
+        // layout has already aborted the app.
+        WindowFrameSanitiser.sanitisePersistedFrames(
+            autosaveNames: ["Macintora.MainDocument"],
+            in: .standard,
+            screens: NSScreen.screens)
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -231,9 +231,15 @@ struct MainDocumentMenuCommands: Commands {
 //    @FocusedValue(\.cacheConnectionDetails) var cacheConnectionDetails: ConnectionDetails?
     @FocusedValue(\.selectedObjectName) var selectedObjectName: String?
     @FocusedValue(\.mainConnection) var mainConnection
+    @FocusedValue(\.editorQuickViewBox) var quickViewBox
     @Environment(\.openWindow) var openWindow
 
     @Environment(\.openSettings) private var openSettings
+
+    @AppStorage(QuickViewHotkey.storageKey) private var quickViewHotkeyRaw: String = QuickViewHotkey.default.rawValue
+    private var quickViewHotkey: QuickViewHotkey {
+        QuickViewHotkey(rawValue: quickViewHotkeyRaw) ?? .default
+    }
 
     var body: some Commands {
         CommandMenu("Database") {
@@ -258,6 +264,14 @@ struct MainDocumentMenuCommands: Commands {
                 .disabled(mainConnection?.mainConnDetails == nil)
                 .presentedWindowStyle(TitleBarWindowStyle())
                 .keyboardShortcut("s", modifiers: [.command, .control, .shift])
+
+            Divider()
+
+            Button("Quick View") {
+                quickViewBox?.trigger?()
+            }
+            .disabled(quickViewBox?.trigger == nil)
+            .quickViewShortcut(quickViewHotkey)
         }
     }
 }

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -36,6 +36,10 @@ struct MainDocumentView: View {
     /// expensive CoreData load only happens at view construction. Reconnects
     /// keep the same store (per-TNS); switching TNS requires a new worksheet.
     @State private var completionConfig: EditorCompletionConfig?
+    /// Bridge that lets the SwiftUI menu command trigger Quick View on this
+    /// editor without holding a direct reference to the AppKit text view.
+    /// Populated by the editor's coordinator after Quick View is wired.
+    @State private var quickViewBox = EditorQuickViewBox()
 
     var selectedObject: String {
         if editorSelection.isEmpty { return "" }
@@ -86,7 +90,8 @@ struct MainDocumentView: View {
                         wordWrap: $wordWrapping,
                         showsLineNumbers: true,
                         highlightsSelectedLine: true,
-                        completionConfig: completionConfig
+                        completionConfig: completionConfig,
+                        quickViewBox: quickViewBox
                     )
                         .frame(maxWidth: .infinity, minHeight: 120, idealHeight: 320, maxHeight: .infinity)
                         .focused($focusedView, equals: .codeEditor)
@@ -116,6 +121,7 @@ struct MainDocumentView: View {
         )
         .focusedSceneValue(\.mainConnection, document.mainConnection)
         .focusedSceneValue(\.selectedObjectName, selectedObject)
+        .focusedSceneValue(\.editorQuickViewBox, quickViewBox)
         .tnsImportPromptOnFirstLaunch()
         .onAppear {
             document.prepareOnAppear(store: injectedStore, keychain: keychain)

--- a/Macintora/MainApp/SettingsView.swift
+++ b/Macintora/MainApp/SettingsView.swift
@@ -55,6 +55,14 @@ struct EditorSettings: View {
     @AppStorage(ScriptRunnerDefaults.dbmsOutputInline) private var scriptDbmsOutputInline: Bool = true
     @AppStorage(ScriptRunnerDefaults.miniGridRowCap) private var scriptMiniGridRowCap: Int = 200
     @AppStorage(ScriptRunnerDefaults.alwaysStopOnError) private var scriptAlwaysStopOnError: Bool = false
+    @AppStorage(QuickViewHotkey.storageKey) private var quickViewHotkeyRaw: String = QuickViewHotkey.default.rawValue
+
+    private var quickViewHotkeyBinding: Binding<QuickViewHotkey> {
+        Binding(
+            get: { QuickViewHotkey(rawValue: quickViewHotkeyRaw) ?? .default },
+            set: { quickViewHotkeyRaw = $0.rawValue }
+        )
+    }
 
     private var editorThemeBinding: Binding<EditorTheme> {
         Binding(
@@ -104,6 +112,13 @@ struct EditorSettings: View {
                         Text(mode.displayName).tag(mode)
                     }
                 }
+
+                Picker("Quick View Hotkey", selection: quickViewHotkeyBinding) {
+                    ForEach(QuickViewHotkey.allCases) { hotkey in
+                        Text(hotkey.displayName).tag(hotkey)
+                    }
+                }
+                .help("Shortcut to open the DB Object Quick View popover at the cursor.")
 
                 Section("Script Runner") {
                     Toggle("Show DBMS_OUTPUT inline", isOn: $scriptDbmsOutputInline)

--- a/Macintora/MainApp/WindowFrameSanitiser.swift
+++ b/Macintora/MainApp/WindowFrameSanitiser.swift
@@ -1,0 +1,101 @@
+//
+//  WindowFrameSanitiser.swift
+//  Macintora
+//
+//  Pre-launch validator for `NSWindow setFrameAutosaveName` entries
+//  stored in `UserDefaults`. Exists because AppKit replays a saved
+//  frame *before* SwiftUI's view tree wires up — if that frame doesn't
+//  intersect any currently-connected screen, NavigationSplitView's
+//  layout immediately drives `_NSSplitViewItemViewWrapper.updateConstraints`
+//  past the "more passes than there are views" safety net and aborts
+//  the app. The post-window check in `WindowLayoutPersister.ensureFrameIsOnScreen`
+//  runs on `viewDidMoveToWindow`, which is too late for that case.
+//
+//  The sanitiser runs in `applicationWillFinishLaunching` before any
+//  document window is created, so the bad UserDefaults entry never
+//  gets a chance to drive layout.
+//
+//  Format note: `NSWindow.saveFrame(usingName:)` writes the value as
+//  a single string of eight space-separated numbers —
+//  "wx wy ww wh sx sy sw sh", the first four being the window frame
+//  and the last four the visible screen frame at save time. We only
+//  need the window frame to validate against current screens.
+//
+
+import AppKit
+import Foundation
+
+enum WindowFrameSanitiser {
+
+    /// Reads `NSWindow Frame {autosaveName}` for each name in
+    /// `autosaveNames`, verifies the window frame intersects at least one
+    /// of the supplied `screens` by a meaningful amount, and deletes the
+    /// defaults entry when it doesn't. Deleting is safer than rewriting
+    /// the value: the next window launch falls back to AppKit's default
+    /// placement (centered on the main screen), which is always valid.
+    ///
+    /// Exposed as a static helper so unit tests can drive it with a
+    /// scratch `UserDefaults` and synthesised `NSScreen` substitutes.
+    static func sanitisePersistedFrames(autosaveNames: [String],
+                                        in defaults: UserDefaults,
+                                        screens: [NSScreen]) {
+        let visibleFrames = screens.map(\.visibleFrame)
+        for name in autosaveNames {
+            sanitise(autosaveName: name, defaults: defaults, screens: visibleFrames)
+        }
+    }
+
+    /// Test-friendly overload that accepts plain `CGRect` screens — lets
+    /// tests run without instantiating `NSScreen`.
+    static func sanitisePersistedFrames(autosaveNames: [String],
+                                        in defaults: UserDefaults,
+                                        screenFrames: [CGRect]) {
+        for name in autosaveNames {
+            sanitise(autosaveName: name, defaults: defaults, screens: screenFrames)
+        }
+    }
+
+    /// `true` when `frame` intersects at least one of `screens` by the
+    /// minimum visible area threshold. Centralised so production and tests
+    /// agree on the rule.
+    static func frameIsOnScreen(_ frame: CGRect, screens: [CGRect]) -> Bool {
+        let minVisibleArea: CGFloat = 100 * 100
+        return screens.contains { screen in
+            let intersection = frame.intersection(screen)
+            guard !intersection.isNull, !intersection.isEmpty else { return false }
+            return intersection.width * intersection.height >= minVisibleArea
+        }
+    }
+
+    /// Parses an `NSWindow.saveFrame(usingName:)`-style 8-number string
+    /// and returns the window frame portion (first four numbers). Returns
+    /// `nil` for any malformed input so callers can decide whether to
+    /// keep or drop the defaults entry.
+    static func parseWindowFrame(from value: String) -> CGRect? {
+        let components = value.split(whereSeparator: { $0.isWhitespace })
+        guard components.count >= 4 else { return nil }
+        guard let x = Double(components[0]),
+              let y = Double(components[1]),
+              let w = Double(components[2]),
+              let h = Double(components[3]),
+              w > 0, h > 0 else { return nil }
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+
+    // MARK: - Internals
+
+    private static func sanitise(autosaveName: String,
+                                 defaults: UserDefaults,
+                                 screens: [CGRect]) {
+        let key = "NSWindow Frame \(autosaveName)"
+        guard let raw = defaults.string(forKey: key) else { return }
+        guard let frame = parseWindowFrame(from: raw) else {
+            // Garbage value — drop it.
+            defaults.removeObject(forKey: key)
+            return
+        }
+        if !frameIsOnScreen(frame, screens: screens) {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}

--- a/Macintora/Results/ResultsController.swift
+++ b/Macintora/Results/ResultsController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import OracleNIO
 import Logging
 

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -337,6 +337,56 @@ final class CompletionDataSourceTests: XCTestCase {
         XCTAssertNil(proc)
     }
 
+    func test_procedureDetail_packageMember_propagatesParentInvalidity() async {
+        seedAccountsPackage()
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "HR", name: "ACCOUNTS_PKG", type: "PACKAGE")
+        // Last-seeded object wins under our addObject helper — flip isValid
+        // by editing the row we just created.
+        let request = DBCacheObject.fetchRequest()
+        request.predicate = NSPredicate(format: "owner_ = %@ AND name_ = %@",
+                                        "HR", "ACCOUNTS_PKG")
+        let row = try! ctx.fetch(request).first
+        row?.isValid = false
+        try! ctx.save()
+
+        let proc = await dataSource.procedureDetail(
+            owner: "HR", packageName: "ACCOUNTS_PKG",
+            procedureName: "DEBIT", overload: nil)
+        XCTAssertNotNil(proc)
+        XCTAssertFalse(proc?.isValid ?? true)
+    }
+
+    func test_procedureDetail_standalone_propagatesObjectInvalidity() async {
+        let ctx = persistence.container.viewContext
+        // Standalone PROCEDURE — parent object is keyed by the procedure name.
+        addProcedure(in: ctx, owner: "HR", pkg: "PURGE_OLD", name: "PURGE_OLD",
+                     subprogramId: 1, overload: nil, parentType: "PROCEDURE")
+        addObject(in: ctx, owner: "HR", name: "PURGE_OLD", type: "PROCEDURE")
+        let request = DBCacheObject.fetchRequest()
+        request.predicate = NSPredicate(format: "owner_ = %@ AND name_ = %@",
+                                        "HR", "PURGE_OLD")
+        let row = try! ctx.fetch(request).first
+        row?.isValid = false
+        try! ctx.save()
+
+        let proc = await dataSource.procedureDetail(
+            owner: "HR", packageName: nil,
+            procedureName: "PURGE_OLD", overload: nil)
+        XCTAssertNotNil(proc)
+        XCTAssertFalse(proc?.isValid ?? true)
+    }
+
+    func test_procedureDetail_defaultsToValidWhenParentObjectMissing() async {
+        // Existing fixture has no DBCacheObject for ACCOUNTS_PKG — the
+        // fallback should keep isValid = true so we don't false-positive.
+        seedAccountsPackage()
+        let proc = await dataSource.procedureDetail(
+            owner: "HR", packageName: "ACCOUNTS_PKG",
+            procedureName: "DEBIT", overload: nil)
+        XCTAssertTrue(proc?.isValid ?? false)
+    }
+
     // MARK: - Quick View: unknownObjectDetail
 
     func test_unknownObjectDetail_carriesObjectMetadata() async {

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -149,6 +149,212 @@ final class CompletionDataSourceTests: XCTestCase {
         XCTAssertTrue(args.allSatisfy { $0.position > 0 })
     }
 
+    // MARK: - Quick View: resolveSchemaObject
+
+    func test_resolveSchemaObject_explicitOwner_findsExactRow() async {
+        let resolved = await dataSource.resolveSchemaObject(
+            owner: "HR", name: "EMPLOYEES", preferredOwner: "")
+        XCTAssertEqual(resolved?.owner, "HR")
+        XCTAssertEqual(resolved?.name, "EMPLOYEES")
+        XCTAssertEqual(resolved?.objectType, "TABLE")
+    }
+
+    func test_resolveSchemaObject_caseInsensitive() async {
+        // Lowercase input — the cache stores upper-case names, the resolver
+        // must normalise.
+        let resolved = await dataSource.resolveSchemaObject(
+            owner: "hr", name: "employees", preferredOwner: "")
+        XCTAssertEqual(resolved?.owner, "HR")
+        XCTAssertEqual(resolved?.name, "EMPLOYEES")
+    }
+
+    func test_resolveSchemaObject_noOwner_prefersConnectedSchema() async {
+        // EMP_BILLS exists only in BILLING; EMPLOYEES exists only in HR.
+        // When the cursor lacked a schema qualifier, the connected schema
+        // (preferredOwner) wins ties.
+        addObject(in: persistence.container.viewContext,
+                  owner: "BILLING", name: "EMPLOYEES", type: "VIEW")
+        try! persistence.container.viewContext.save()
+
+        let resolved = await dataSource.resolveSchemaObject(
+            owner: nil, name: "EMPLOYEES", preferredOwner: "HR")
+        XCTAssertEqual(resolved?.owner, "HR",
+                       "Tie between HR.EMPLOYEES and BILLING.EMPLOYEES must resolve to the connected schema")
+    }
+
+    func test_resolveSchemaObject_returnsNilForUnknown() async {
+        let resolved = await dataSource.resolveSchemaObject(
+            owner: "HR", name: "DOES_NOT_EXIST", preferredOwner: "")
+        XCTAssertNil(resolved)
+    }
+
+    // MARK: - Quick View: tableDetail
+
+    func test_tableDetail_assemblesColumnsIndexesTriggers() async {
+        seedEmployeesTableExtras()
+        guard let detail = await dataSource.tableDetail(
+            owner: "HR", name: "EMPLOYEES", highlightedColumn: nil)
+        else { return XCTFail("tableDetail returned nil for seeded HR.EMPLOYEES") }
+
+        XCTAssertFalse(detail.isView)
+        XCTAssertEqual(detail.columns.map(\.columnName).sorted(),
+                       ["EMPLOYEE_ID", "FIRST_NAME", "SALARY"])
+        XCTAssertEqual(detail.indexes.map(\.name), ["EMP_PK"])
+        XCTAssertEqual(detail.triggers.map(\.name), ["EMP_AUDIT_TRG"])
+        XCTAssertNil(detail.highlightedColumn)
+    }
+
+    func test_tableDetail_passesThroughHighlightedColumn() async {
+        seedEmployeesTableExtras()
+        let detail = await dataSource.tableDetail(
+            owner: "HR", name: "EMPLOYEES", highlightedColumn: "salary")
+        // Highlighted column is upper-cased so the SwiftUI `id` lookup matches.
+        XCTAssertEqual(detail?.highlightedColumn, "SALARY")
+    }
+
+    func test_tableDetail_typeFormatting_oracleStyle() async {
+        seedEmployeesTableExtras()
+        let detail = await dataSource.tableDetail(
+            owner: "HR", name: "EMPLOYEES", highlightedColumn: nil)
+        let firstName = detail?.columns.first { $0.columnName == "FIRST_NAME" }
+        // Seeded with length=120 → VARCHAR2(120).
+        XCTAssertEqual(firstName?.dataTypeFormatted, "VARCHAR2(120)")
+        let salary = detail?.columns.first { $0.columnName == "SALARY" }
+        // Seeded with precision=10, scale=2 → NUMBER(10,2).
+        XCTAssertEqual(salary?.dataTypeFormatted, "NUMBER(10,2)")
+    }
+
+    func test_tableDetail_view_carriesSqlText() async {
+        seedActiveEmployeesView()
+        let detail = await dataSource.tableDetail(
+            owner: "HR", name: "ACTIVE_EMPLOYEES", highlightedColumn: nil)
+        XCTAssertTrue(detail?.isView ?? false)
+        XCTAssertEqual(detail?.sqlText, "SELECT * FROM employees WHERE active = 1")
+    }
+
+    func test_tableDetail_returnsEmptyContainersForCacheMiss() async {
+        // Object exists but no DBCacheTable / column / index / trigger rows.
+        addObject(in: persistence.container.viewContext,
+                  owner: "HR", name: "BARE_OBJECT", type: "TABLE")
+        try! persistence.container.viewContext.save()
+
+        let detail = await dataSource.tableDetail(
+            owner: "HR", name: "BARE_OBJECT", highlightedColumn: nil)
+        XCTAssertNotNil(detail, "tableDetail returns a payload even when the row is metadata-only")
+        XCTAssertTrue(detail?.columns.isEmpty ?? false)
+        XCTAssertTrue(detail?.indexes.isEmpty ?? false)
+        XCTAssertTrue(detail?.triggers.isEmpty ?? false)
+    }
+
+    // MARK: - Quick View: columnDetail
+
+    func test_columnDetail_findsAndPopulatesFlags() async {
+        seedEmployeesTableExtras()
+        guard let column = await dataSource.columnDetail(
+            tableOwner: "HR", tableName: "EMPLOYEES", columnName: "SALARY")
+        else { return XCTFail("columnDetail returned nil") }
+        XCTAssertEqual(column.column.columnName, "SALARY")
+        XCTAssertEqual(column.column.dataTypeFormatted, "NUMBER(10,2)")
+        XCTAssertFalse(column.column.isNullable)
+    }
+
+    func test_columnDetail_returnsNilForMissingColumn() async {
+        seedEmployeesTableExtras()
+        let column = await dataSource.columnDetail(
+            tableOwner: "HR", tableName: "EMPLOYEES", columnName: "NOPE")
+        XCTAssertNil(column)
+    }
+
+    // MARK: - Quick View: packageDetail
+
+    func test_packageDetail_assemblesProceduresWithReturnTypes() async {
+        seedAccountsPackage()
+        guard let pkg = await dataSource.packageDetail(
+            owner: "HR", name: "ACCOUNTS_PKG")
+        else { return XCTFail("packageDetail returned nil") }
+
+        XCTAssertEqual(pkg.objectType, "PACKAGE")
+        let names = pkg.procedures.map(\.name)
+        XCTAssertEqual(names.sorted(), ["DEBIT", "DEBIT", "GET_BALANCE"],
+                       "Both DEBIT overloads must appear as separate entries")
+
+        let getBalance = pkg.procedures.first { $0.name == "GET_BALANCE" }
+        XCTAssertEqual(getBalance?.kind, "FUNCTION")
+        XCTAssertEqual(getBalance?.returnType, "NUMBER")
+        XCTAssertEqual(getBalance?.parameters.map(\.name) ?? [], ["ACCT_ID"])
+
+        let debitOverload2 = pkg.procedures.first {
+            $0.name == "DEBIT" && $0.overload == "2"
+        }
+        XCTAssertEqual(debitOverload2?.parameters.map(\.name) ?? [], ["AMOUNT", "CURRENCY"])
+    }
+
+    func test_packageDetail_skipsPackageSelfRow() async {
+        seedAccountsPackage()
+        let pkg = await dataSource.packageDetail(owner: "HR", name: "ACCOUNTS_PKG")
+        // The SUBPROGRAM_ID = 0 self-row has procedureName_ = nil and must
+        // never appear in the rendered list.
+        XCTAssertFalse(pkg?.procedures.contains { $0.name.isEmpty } ?? true)
+    }
+
+    // MARK: - Quick View: procedureDetail
+
+    func test_procedureDetail_packageMember_pickFirstOverload() async {
+        seedAccountsPackage()
+        // Both DEBIT overloads exist; passing nil should pick the lowest
+        // subprogram_id, matching ALL_PROCEDURES order.
+        let proc = await dataSource.procedureDetail(
+            owner: "HR", packageName: "ACCOUNTS_PKG",
+            procedureName: "DEBIT", overload: nil)
+        XCTAssertEqual(proc?.kind, "PROCEDURE")
+        XCTAssertEqual(proc?.packageName, "ACCOUNTS_PKG")
+        // overload "1" has one parameter; "2" has two.
+        XCTAssertEqual(proc?.parameters.count, 1)
+    }
+
+    func test_procedureDetail_packageMember_specificOverload() async {
+        seedAccountsPackage()
+        let proc = await dataSource.procedureDetail(
+            owner: "HR", packageName: "ACCOUNTS_PKG",
+            procedureName: "DEBIT", overload: "2")
+        XCTAssertEqual(proc?.parameters.map(\.name), ["AMOUNT", "CURRENCY"])
+    }
+
+    func test_procedureDetail_function_carriesReturnType() async {
+        seedAccountsPackage()
+        let proc = await dataSource.procedureDetail(
+            owner: "HR", packageName: "ACCOUNTS_PKG",
+            procedureName: "GET_BALANCE", overload: nil)
+        XCTAssertEqual(proc?.kind, "FUNCTION")
+        XCTAssertEqual(proc?.returnType, "NUMBER")
+    }
+
+    func test_procedureDetail_returnsNilForUnknownMember() async {
+        seedAccountsPackage()
+        let proc = await dataSource.procedureDetail(
+            owner: "HR", packageName: "ACCOUNTS_PKG",
+            procedureName: "NOPE", overload: nil)
+        XCTAssertNil(proc)
+    }
+
+    // MARK: - Quick View: unknownObjectDetail
+
+    func test_unknownObjectDetail_carriesObjectMetadata() async {
+        let ctx = persistence.container.viewContext
+        let row = DBCacheObject(context: ctx)
+        row.owner_ = "HR"
+        row.name_ = "EMP_PK"
+        row.type_ = "INDEX"
+        row.isValid = true
+        row.lastDDLDate = Date(timeIntervalSince1970: 1_700_000_000)
+        try! ctx.save()
+
+        let payload = await dataSource.unknownObjectDetail(owner: "HR", name: "EMP_PK")
+        XCTAssertEqual(payload?.objectType, "INDEX")
+        XCTAssertEqual(payload?.lastDDLDate, Date(timeIntervalSince1970: 1_700_000_000))
+        XCTAssertTrue(payload?.isValid ?? false)
+    }
+
     // MARK: - Seed helpers
 
     private func seed() {
@@ -261,5 +467,90 @@ final class CompletionDataSourceTests: XCTestCase {
         row.argumentName_ = name
         row.dataType_ = dataType
         row.inOut_ = inOut
+    }
+
+    /// Seeds the rows the Quick View `tableDetail` fetcher consumes:
+    /// a `DBCacheTable` for HR.EMPLOYEES (so isView/sqltext are populated),
+    /// fully-typed columns, one index, and one trigger.
+    private func seedEmployeesTableExtras() {
+        let ctx = persistence.container.viewContext
+
+        let table = DBCacheTable(context: ctx)
+        table.owner_ = "HR"
+        table.name_ = "EMPLOYEES"
+        table.isView = false
+        table.isPartitioned = false
+
+        // Replace the bare-bones columns from `seed()` with typed copies so
+        // formatDataType has dimensions to render. Delete-then-recreate keeps
+        // the test independent of the seed's exact field set.
+        let existing = (try? ctx.fetch(DBCacheTableColumn.fetchRequest()))?
+            .filter { $0.owner_ == "HR" && $0.tableName_ == "EMPLOYEES" } ?? []
+        for column in existing { ctx.delete(column) }
+
+        addTypedColumn(in: ctx, owner: "HR", table: "EMPLOYEES",
+                       column: "EMPLOYEE_ID", type: "NUMBER",
+                       length: 0, precision: 6, scale: 0,
+                       isNullable: false, columnID: 1)
+        addTypedColumn(in: ctx, owner: "HR", table: "EMPLOYEES",
+                       column: "FIRST_NAME", type: "VARCHAR2",
+                       length: 120, precision: 0, scale: 0,
+                       isNullable: true, columnID: 2)
+        addTypedColumn(in: ctx, owner: "HR", table: "EMPLOYEES",
+                       column: "SALARY", type: "NUMBER",
+                       length: 0, precision: 10, scale: 2,
+                       isNullable: false, columnID: 3)
+
+        let index = DBCacheIndex(context: ctx)
+        index.owner_ = "HR"
+        index.name_ = "EMP_PK"
+        index.tableOwner_ = "HR"
+        index.tableName_ = "EMPLOYEES"
+        index.isUnique = true
+        index.isValid = true
+        index.type_ = "NORMAL"
+
+        let trigger = DBCacheTrigger(context: ctx)
+        trigger.owner_ = "HR"
+        trigger.name_ = "EMP_AUDIT_TRG"
+        trigger.objectOwner = "HR"
+        trigger.objectName = "EMPLOYEES"
+        trigger.event_ = "UPDATE"
+        trigger.isEnabled = true
+
+        try! ctx.save()
+    }
+
+    /// Seeds an HR.ACTIVE_EMPLOYEES view so `tableDetail` has a row whose
+    /// `isView == true` and `sqltext` is populated.
+    private func seedActiveEmployeesView() {
+        let ctx = persistence.container.viewContext
+
+        addObject(in: ctx, owner: "HR", name: "ACTIVE_EMPLOYEES", type: "VIEW")
+        let view = DBCacheTable(context: ctx)
+        view.owner_ = "HR"
+        view.name_ = "ACTIVE_EMPLOYEES"
+        view.isView = true
+        view.sqltext = "SELECT * FROM employees WHERE active = 1"
+
+        try! ctx.save()
+    }
+
+    private func addTypedColumn(in ctx: NSManagedObjectContext,
+                                owner: String, table: String, column: String,
+                                type: String, length: Int32,
+                                precision: Int32, scale: Int32,
+                                isNullable: Bool, columnID: Int) {
+        let row = DBCacheTableColumn(context: ctx)
+        row.owner_ = owner
+        row.tableName_ = table
+        row.columnName_ = column
+        row.dataType_ = type
+        row.length = length
+        row.precision = precision == 0 ? nil : NSNumber(value: precision)
+        row.scale = scale == 0 ? nil : NSNumber(value: scale)
+        row.isNullable = isNullable
+        row.columnID = NSNumber(value: columnID)
+        row.internalColumnID = Int16(columnID)
     }
 }

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -408,11 +408,15 @@ final class CompletionDataSourceTests: XCTestCase {
         addProcedure(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG",
                      name: "GET_BALANCE", subprogramId: 1, overload: nil,
                      parentType: "PACKAGE")
+        // Distinct subprogram_id per overload — Oracle gives each overload
+        // a unique value in ALL_PROCEDURES, and our sort-by-subprogramId
+        // picker breaks ties non-deterministically when they collide,
+        // which made `pickFirstOverload` flaky on cold full-suite runs.
         addProcedure(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG",
                      name: "DEBIT", subprogramId: 2, overload: "1",
                      parentType: "PACKAGE")
         addProcedure(in: ctx, owner: "HR", pkg: "ACCOUNTS_PKG",
-                     name: "DEBIT", subprogramId: 2, overload: "2",
+                     name: "DEBIT", subprogramId: 3, overload: "2",
                      parentType: "PACKAGE")
 
         // GET_BALANCE return row + IN parameter.

--- a/MacintoraTests/Editor/Completion/ObjectAtCursorResolverTests.swift
+++ b/MacintoraTests/Editor/Completion/ObjectAtCursorResolverTests.swift
@@ -1,0 +1,181 @@
+//
+//  ObjectAtCursorResolverTests.swift
+//  MacintoraTests
+//
+//  Verifies the cursor → `ResolvedDBReference` mapping for the Quick View
+//  feature. Uses the production `parseAndResolve(_:utf16Offset:)` facade so
+//  the test target doesn't need direct tree-sitter linkage.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class ObjectAtCursorResolverTests: XCTestCase {
+
+    // MARK: - Schema-object resolution
+
+    func test_bareTable_resolvesAsSchemaObject() {
+        let source = "SELECT * FROM employees"
+        let cursor = (source as NSString).range(of: "employees").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result, .schemaObject(owner: nil, name: "EMPLOYEES"))
+    }
+
+    func test_schemaQualifiedTable_resolvesWithOwner() {
+        let source = "SELECT * FROM hr.employees"
+        let cursor = (source as NSString).range(of: "employees").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result, .schemaObject(owner: "HR", name: "EMPLOYEES"))
+    }
+
+    func test_cursorOnSchemaSegment_returnsSchemaQualified() {
+        let source = "SELECT * FROM hr.employees"
+        let cursor = (source as NSString).range(of: "hr").location + 1
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        // Whether the resolver lands on "hr" alone or the full reference, the
+        // schemaObject should carry HR/EMPLOYEES — the popover's fetcher
+        // disambiguates.
+        if case let .schemaObject(_, name) = result {
+            XCTAssertTrue(["HR", "EMPLOYEES"].contains(name),
+                          "Expected schemaObject pointing at HR or EMPLOYEES, got \(result)")
+        } else {
+            XCTFail("Expected schemaObject case, got \(result)")
+        }
+    }
+
+    // MARK: - Column references via alias
+
+    func test_aliasQualifiedColumn_resolvesToTable() {
+        let source = "SELECT e.salary FROM employees e"
+        let cursor = (source as NSString).range(of: "salary").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .column(tableOwner: nil,
+                               tableName: "EMPLOYEES",
+                               columnName: "SALARY"))
+    }
+
+    func test_aliasQualifiedColumn_acrossSchemaQualifiedTable() {
+        let source = "SELECT e.salary FROM hr.employees e"
+        let cursor = (source as NSString).range(of: "salary").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .column(tableOwner: "HR",
+                               tableName: "EMPLOYEES",
+                               columnName: "SALARY"))
+    }
+
+    func test_unknownAlias_doesNotProduceColumn() {
+        let source = "SELECT x.salary FROM employees e"
+        let cursor = (source as NSString).range(of: "salary").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        // x isn't an alias bound by the FROM — fall back to schemaObject so
+        // the popover can attempt a schema lookup. Don't fabricate a column.
+        if case .column = result {
+            XCTFail("Unknown qualifier `x` must not yield a column resolution; got \(result)")
+        }
+    }
+
+    // MARK: - Package members
+
+    func test_packageMemberCall_resolvesAsPackageMember() {
+        let source = "BEGIN dbms_output.put_line('hello'); END;"
+        let cursor = (source as NSString).range(of: "put_line").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .packageMember(packageOwner: nil,
+                                      packageName: "DBMS_OUTPUT",
+                                      memberName: "PUT_LINE"))
+    }
+
+    func test_ownerQualifiedPackageMemberCall_resolvesAsPackageMember() {
+        let source = "BEGIN sys.dbms_output.put_line('hello'); END;"
+        let cursor = (source as NSString).range(of: "put_line").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .packageMember(packageOwner: "SYS",
+                                      packageName: "DBMS_OUTPUT",
+                                      memberName: "PUT_LINE"))
+    }
+
+    func test_standaloneFunctionCall_resolvesAsSchemaObject() {
+        let source = "SELECT my_func(1) FROM dual"
+        let cursor = (source as NSString).range(of: "my_func").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        if case let .schemaObject(_, name) = result {
+            XCTAssertEqual(name, "MY_FUNC")
+        } else {
+            XCTFail("Expected schemaObject case, got \(result)")
+        }
+    }
+
+    // MARK: - Multi-statement scoping
+
+    func test_multiStatement_resolvesAliasFromOwningStatement() {
+        // Cursor sits inside stmt2 — the resolver must reach into stmt2's FROM,
+        // not stmt1's FROM dual.
+        let stmt1 = "SELECT 42 FROM dual;\n"
+        let stmt2 = "SELECT a.amount FROM bills a"
+        let source = stmt1 + stmt2
+        let cursor = (source as NSString).range(of: "amount").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .column(tableOwner: nil,
+                               tableName: "BILLS",
+                               columnName: "AMOUNT"))
+    }
+
+    // MARK: - Negative cases
+
+    func test_cursorInStringLiteral_returnsUnresolved() {
+        let source = "SELECT 'employees' FROM dual"
+        // Cursor inside the string literal.
+        let cursor = (source as NSString).range(of: "employees").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result, .unresolved,
+                       "Cursor inside a string must not produce a DB reference")
+    }
+
+    func test_cursorInLineComment_returnsUnresolved() {
+        let source = "-- employees\nSELECT * FROM dual"
+        let cursor = (source as NSString).range(of: "employees").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result, .unresolved,
+                       "Cursor in a -- comment must not produce a DB reference")
+    }
+
+    func test_cursorOnWhitespace_returnsUnresolved() {
+        let source = "SELECT  *  FROM employees"
+        let firstSpace = (source as NSString).range(of: "  ").location + 1
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: firstSpace)
+        if case .schemaObject = result { return /* tolerated when grammar absorbs the cursor into surrounding token */ }
+        XCTAssertEqual(result, .unresolved,
+                       "Cursor on whitespace should resolve to unresolved or fall through to a known token")
+    }
+
+    // MARK: - Mid-typing fallback
+
+    /// Reproduces the typing pattern `SELECT b.| FROM bills b` — the parser
+    /// often produces an ERROR node around the partial statement, so the
+    /// resolver must still pick up the alias map via the source-text path.
+    func test_partialTyping_aliasResolvesViaFallback() {
+        let source = "SELECT b. FROM bills b"
+        let cursor = (source as NSString).range(of: "b.").location + 2
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        // The cursor sits on the empty member position. We expect either
+        // `.unresolved` (no member name to extract) or a column-shaped
+        // resolution where `tableName == "BILLS"`. Both are acceptable for v1
+        // — what matters is we don't fabricate a wrong table.
+        if case .column(_, let tableName, _) = result {
+            XCTAssertEqual(tableName, "BILLS")
+        }
+    }
+
+    func test_endOfBuffer_resolvesTrailingIdentifier() {
+        let source = "SELECT * FROM hr.employees"
+        let cursor = source.utf16.count
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result, .schemaObject(owner: "HR", name: "EMPLOYEES"))
+    }
+}

--- a/MacintoraTests/Editor/Completion/ObjectAtCursorResolverTests.swift
+++ b/MacintoraTests/Editor/Completion/ObjectAtCursorResolverTests.swift
@@ -178,4 +178,76 @@ final class ObjectAtCursorResolverTests: XCTestCase {
         let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
         XCTAssertEqual(result, .schemaObject(owner: "HR", name: "EMPLOYEES"))
     }
+
+    // MARK: - Quoted identifiers
+
+    /// `"MixedCase"` preserves interior case verbatim — Oracle stores quoted
+    /// identifiers exactly as written, so cache lookups must match the same
+    /// way.
+    func test_quotedTable_preservesInteriorCase() {
+        let source = "SELECT * FROM \"MixedCase\""
+        let cursor = (source as NSString).range(of: "MixedCase").location + 3
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result, .schemaObject(owner: nil, name: "MixedCase"))
+    }
+
+    /// Two-part `"Schema"."Table"` — both segments preserve case independently.
+    func test_quotedSchemaAndTable_preserveCase() {
+        let source = "SELECT * FROM \"Schema\".\"Tab\""
+        let cursor = (source as NSString).range(of: "Tab").location + 1
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result, .schemaObject(owner: "Schema", name: "Tab"))
+    }
+
+    /// Mixed: quoted column on an unquoted alias. The alias map lookup folds
+    /// the alias to upper, but the column name is held verbatim.
+    func test_quotedColumnOnUnquotedAlias_preservesColumnCase() {
+        let source = "SELECT a.\"ColumnX\" FROM employees a"
+        let cursor = (source as NSString).range(of: "ColumnX").location + 2
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .column(tableOwner: nil,
+                               tableName: "EMPLOYEES",
+                               columnName: "ColumnX"))
+    }
+
+    /// Mixed-case quoted package member: `"Pkg".proc(…)` should preserve the
+    /// quoted package name, fold the unquoted member name.
+    func test_quotedPackageWithUnquotedMember_preservesCase() {
+        let source = "BEGIN \"Pkg\".do_work(); END;"
+        let cursor = (source as NSString).range(of: "do_work").location + 2
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .packageMember(packageOwner: nil,
+                                      packageName: "Pkg",
+                                      memberName: "DO_WORK"))
+    }
+
+    /// And the inverse: unquoted package, quoted mixed-case member.
+    func test_unquotedPackageWithQuotedMember_preservesCase() {
+        let source = "BEGIN pkg.\"DoWork\"(); END;"
+        let cursor = (source as NSString).range(of: "DoWork").location + 2
+        let result = ObjectAtCursorResolver.parseAndResolve(source, utf16Offset: cursor)
+        XCTAssertEqual(result,
+                       .packageMember(packageOwner: nil,
+                                      packageName: "PKG",
+                                      memberName: "DoWork"))
+    }
+
+    // MARK: - normalizeIdentifier helper
+
+    func test_normalizeIdentifier_unquotedFoldsToUpper() {
+        XCTAssertEqual(ObjectAtCursorResolver.normalizeIdentifier("emp"), "EMP")
+    }
+
+    func test_normalizeIdentifier_quotedPreservesCase() {
+        XCTAssertEqual(ObjectAtCursorResolver.normalizeIdentifier("\"MixedCase\""),
+                       "MixedCase")
+    }
+
+    func test_normalizeIdentifier_emptyAndBareQuotesPassThrough() {
+        XCTAssertEqual(ObjectAtCursorResolver.normalizeIdentifier(""), "")
+        // `""` is the empty quoted identifier — drop the two quotes.
+        XCTAssertEqual(ObjectAtCursorResolver.normalizeIdentifier("\"\""), "")
+    }
 }

--- a/MacintoraTests/Editor/Plugins/QuickView/EditorQuickViewBoxTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/EditorQuickViewBoxTests.swift
@@ -1,0 +1,57 @@
+//
+//  EditorQuickViewBoxTests.swift
+//  MacintoraTests
+//
+//  Verifies the SwiftUI ↔ AppKit bridge object that lets the menu command
+//  trigger Quick View on the focused editor. The contract is small but
+//  critical: a nil trigger means the menu disables the Quick View item;
+//  a non-nil trigger fires the editor's "trigger at cursor" closure once
+//  per menu invocation.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class EditorQuickViewBoxTests: XCTestCase {
+
+    func test_freshBox_hasNilTrigger() {
+        let box = EditorQuickViewBox()
+        XCTAssertNil(box.trigger,
+                     "A box with no editor wired must report nil so the menu Button can disable")
+    }
+
+    func test_setTrigger_invokesClosureWhenCalled() {
+        let box = EditorQuickViewBox()
+        var calls = 0
+        box.trigger = { calls += 1 }
+        box.trigger?()
+        XCTAssertEqual(calls, 1)
+        box.trigger?()
+        XCTAssertEqual(calls, 2,
+                       "Menu invocation should fire the closure each time the user picks it")
+    }
+
+    func test_overwriteTrigger_replacesPreviousClosure() {
+        // Mirrors what `Coordinator.bindQuickViewBox` does on document
+        // re-mount: the previous closure must be dropped so a stale,
+        // dismantled editor isn't called into.
+        let box = EditorQuickViewBox()
+        var firstCalls = 0
+        var secondCalls = 0
+        box.trigger = { firstCalls += 1 }
+        box.trigger = { secondCalls += 1 }
+        box.trigger?()
+        XCTAssertEqual(firstCalls, 0)
+        XCTAssertEqual(secondCalls, 1)
+    }
+
+    func test_clearTrigger_disablesInvocation() {
+        let box = EditorQuickViewBox()
+        var calls = 0
+        box.trigger = { calls += 1 }
+        box.trigger = nil
+        box.trigger?()
+        XCTAssertEqual(calls, 0)
+    }
+}

--- a/MacintoraTests/Editor/Plugins/QuickView/QuickViewClickGateTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/QuickViewClickGateTests.swift
@@ -1,0 +1,94 @@
+//
+//  QuickViewClickGateTests.swift
+//  MacintoraTests
+//
+//  Exercises `STDBObjectQuickViewPlugin.Coordinator.shouldTrigger(...)` —
+//  the predicate that decides whether a process-global ⌘+leftMouseDown
+//  event should pop a Quick View on a given text view. Covers the four
+//  important cases:
+//    * click in the text view's own window, hit-tests the text view → true
+//    * click in the text view's own window, hit-tests a sibling view → false
+//    * click in a different window → false
+//    * text view detached (no window) → false
+//
+//  Synthesizing real `NSEvent` mouse events is awkward, so the predicate
+//  takes the pieces the monitor reads (`eventWindow`, `locationInWindow`)
+//  directly; we drive it with plain views instead. NSWindow instances are
+//  released to ARC at scope exit — calling `close()` from a teardown block
+//  occasionally double-frees through the autorelease pool, so we let the
+//  default cleanup happen.
+//
+
+import AppKit
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class QuickViewClickGateTests: XCTestCase {
+
+    func test_clickInsideTextView_inSameWindow_passes() {
+        let (window, textView) = makeWindowWithTextView()
+        let inside = NSPoint(x: 50, y: 50)   // squarely inside textView
+        XCTAssertTrue(STDBObjectQuickViewPlugin.Coordinator.shouldTrigger(
+            eventWindow: window,
+            locationInWindow: inside,
+            textView: textView))
+    }
+
+    func test_clickOnSiblingView_inSameWindow_isRejected() {
+        let (window, textView) = makeWindowWithTextView()
+        // Sibling pane below the text view in the same content view.
+        let sibling = NSView(frame: NSRect(x: 0, y: 200, width: 400, height: 100))
+        window.contentView?.addSubview(sibling)
+
+        let onSibling = NSPoint(x: 50, y: 250)
+        XCTAssertFalse(STDBObjectQuickViewPlugin.Coordinator.shouldTrigger(
+            eventWindow: window,
+            locationInWindow: onSibling,
+            textView: textView))
+    }
+
+    func test_clickInDifferentWindow_isRejected() {
+        let (_, textView) = makeWindowWithTextView()
+        let otherWindow = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   styleMask: [],
+                                   backing: .buffered,
+                                   defer: true)
+
+        XCTAssertFalse(STDBObjectQuickViewPlugin.Coordinator.shouldTrigger(
+            eventWindow: otherWindow,
+            locationInWindow: NSPoint(x: 50, y: 50),
+            textView: textView))
+    }
+
+    func test_textViewWithoutWindow_isRejected() {
+        let detached = NSView(frame: NSRect(x: 0, y: 0, width: 100, height: 100))
+        XCTAssertFalse(STDBObjectQuickViewPlugin.Coordinator.shouldTrigger(
+            eventWindow: nil,
+            locationInWindow: .zero,
+            textView: detached))
+    }
+
+    func test_nilEventWindow_isRejected() {
+        let (_, textView) = makeWindowWithTextView()
+        XCTAssertFalse(STDBObjectQuickViewPlugin.Coordinator.shouldTrigger(
+            eventWindow: nil,
+            locationInWindow: NSPoint(x: 50, y: 50),
+            textView: textView))
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a window with a single text-view-like NSView occupying the
+    /// upper half of its content view. The text view is the only descendant
+    /// the gate should accept.
+    private func makeWindowWithTextView() -> (NSWindow, NSView) {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+                              styleMask: [],
+                              backing: .buffered,
+                              defer: true)
+        let textView = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
+        window.contentView?.addSubview(textView)
+        return (window, textView)
+    }
+}

--- a/MacintoraTests/Editor/Plugins/QuickView/QuickViewContentRenderTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/QuickViewContentRenderTests.swift
@@ -108,6 +108,62 @@ final class QuickViewContentRenderTests: XCTestCase {
         XCTAssertNoThrow(try renderAndForceLayout(payload: payload))
     }
 
+    // MARK: - Table header stats line
+
+    func test_render_table_withRowCountAndAnalyzed() {
+        let table = TableDetailPayload(
+            owner: "HR", name: "EMPLOYEES",
+            isView: false, isEditioning: false, isReadOnly: false,
+            isPartitioned: false,
+            numRows: 12_345_678,
+            lastAnalyzed: Date(timeIntervalSince1970: 1_700_000_000),
+            sqlText: nil,
+            columns: TableDetailPayload.fixtureColumns,
+            indexes: [], triggers: [],
+            highlightedColumn: nil)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .table(table)))
+    }
+
+    func test_render_table_withEditioningChip() {
+        let table = TableDetailPayload(
+            owner: "HR", name: "EMPLOYEES",
+            isView: false, isEditioning: true, isReadOnly: false,
+            isPartitioned: false,
+            numRows: nil, lastAnalyzed: nil,
+            sqlText: nil,
+            columns: TableDetailPayload.fixtureColumns,
+            indexes: [], triggers: [],
+            highlightedColumn: nil)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .table(table)))
+    }
+
+    func test_render_table_withNoStats_subLineHidden() {
+        // Both `numRows` and `lastAnalyzed` nil — the stats subline must
+        // collapse to `EmptyView` so the header doesn't grow a blank row.
+        let table = TableDetailPayload(
+            owner: "HR", name: "BLANK_TABLE",
+            isView: false, isEditioning: false, isReadOnly: false,
+            isPartitioned: false,
+            numRows: nil, lastAnalyzed: nil,
+            sqlText: nil,
+            columns: [], indexes: [], triggers: [],
+            highlightedColumn: nil)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .table(table)))
+    }
+
+    func test_render_table_withRowCountOnly_omitsAnalyzed() {
+        let table = TableDetailPayload(
+            owner: "HR", name: "EMPLOYEES",
+            isView: false, isEditioning: false, isReadOnly: false,
+            isPartitioned: false,
+            numRows: 42, lastAnalyzed: nil,
+            sqlText: nil,
+            columns: TableDetailPayload.fixtureColumns,
+            indexes: [], triggers: [],
+            highlightedColumn: nil)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .table(table)))
+    }
+
     func test_render_notCached_eachReferenceShape() {
         // The "not cached" placeholder formats the reference name; cover
         // each enum case so we don't regress the formatter accidentally.

--- a/MacintoraTests/Editor/Plugins/QuickView/QuickViewContentRenderTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/QuickViewContentRenderTests.swift
@@ -1,0 +1,279 @@
+//
+//  QuickViewContentRenderTests.swift
+//  MacintoraTests
+//
+//  Smoke tests that each `QuickViewPayload` variant renders without
+//  trapping. Hosts the SwiftUI view inside `NSHostingView` and forces
+//  layout so the body actually evaluates — catches missing types,
+//  force-unwraps, or accidental nil dereferences in the view tree.
+//
+//  Doesn't assert on visual output (that's UI-test territory). The win is
+//  guarding against compile-time-only regressions that don't show up
+//  until a user triggers a particular payload kind in production.
+//
+
+import XCTest
+import AppKit
+import SwiftUI
+@testable import Macintora
+
+@MainActor
+final class QuickViewContentRenderTests: XCTestCase {
+
+    // MARK: - Per-payload smoke tests
+
+    func test_render_table() {
+        let payload = QuickViewPayload.table(.fixture(isView: false))
+        XCTAssertNoThrow(try renderAndForceLayout(payload: payload))
+    }
+
+    func test_render_view_withSqlText() {
+        var table = TableDetailPayload.fixture(isView: true)
+        table = TableDetailPayload(
+            owner: table.owner, name: table.name,
+            isView: true, isEditioning: false, isReadOnly: false,
+            isPartitioned: false, numRows: nil, lastAnalyzed: nil,
+            sqlText: "SELECT * FROM employees WHERE active = 1",
+            columns: table.columns, indexes: [], triggers: [],
+            highlightedColumn: nil)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .table(table)))
+    }
+
+    func test_render_table_withHighlightedColumn() {
+        let highlighted = TableDetailPayload(
+            owner: "HR", name: "EMPLOYEES",
+            isView: false, isEditioning: false, isReadOnly: false,
+            isPartitioned: false, numRows: 10_000,
+            lastAnalyzed: Date(timeIntervalSince1970: 1_700_000_000),
+            sqlText: nil,
+            columns: TableDetailPayload.fixtureColumns,
+            indexes: [QuickViewIndex.fixture],
+            triggers: [QuickViewTrigger.fixture],
+            highlightedColumn: "SALARY")
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .table(highlighted)))
+    }
+
+    func test_render_packageOrType() {
+        let payload = QuickViewPayload.packageOrType(.fixture)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: payload))
+    }
+
+    func test_render_packageOrType_emptyProcedures_showsSpec() {
+        let bare = PackageDetailPayload(
+            owner: "HR", name: "BARE_PKG",
+            objectType: "PACKAGE", isValid: true,
+            specSource: "PACKAGE bare_pkg AS\n  -- no public members\nEND;",
+            procedures: [])
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .packageOrType(bare)))
+    }
+
+    func test_render_procedure_function() {
+        let payload = QuickViewPayload.procedure(.functionFixture)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: payload))
+    }
+
+    func test_render_procedure_procedure_noParams() {
+        let payload = QuickViewPayload.procedure(.procedureNoParamsFixture)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: payload))
+    }
+
+    func test_render_column() {
+        let payload = QuickViewPayload.column(.fixture(virtual: false))
+        XCTAssertNoThrow(try renderAndForceLayout(payload: payload))
+    }
+
+    func test_render_column_virtual_withLongDefault() {
+        // Virtual columns render the expression in a scroll view. Stress
+        // the view with a multi-line expression so the disclosure path runs.
+        var col = ColumnDetailPayload.fixture(virtual: true)
+        col = ColumnDetailPayload(
+            tableOwner: col.tableOwner,
+            tableName: col.tableName,
+            column: QuickViewColumn(
+                columnID: 1, columnName: "TOTAL_COMP",
+                dataType: "NUMBER", dataTypeFormatted: "NUMBER(12,2)",
+                isNullable: true,
+                defaultValue: """
+                CASE
+                  WHEN dept = 'SALES' THEN salary + nvl(bonus,0) * 1.10
+                  ELSE salary + nvl(bonus,0)
+                END
+                """,
+                isIdentity: false, isVirtual: true, isHidden: false))
+        XCTAssertNoThrow(try renderAndForceLayout(payload: .column(col)))
+    }
+
+    func test_render_unknownObject() {
+        let payload = QuickViewPayload.unknownObject(.fixture)
+        XCTAssertNoThrow(try renderAndForceLayout(payload: payload))
+    }
+
+    func test_render_notCached_eachReferenceShape() {
+        // The "not cached" placeholder formats the reference name; cover
+        // each enum case so we don't regress the formatter accidentally.
+        let cases: [ResolvedDBReference] = [
+            .schemaObject(owner: "HR", name: "EMPLOYEES"),
+            .schemaObject(owner: nil, name: "DUAL"),
+            .packageMember(packageOwner: "SYS",
+                           packageName: "DBMS_OUTPUT",
+                           memberName: "PUT_LINE"),
+            .packageMember(packageOwner: nil,
+                           packageName: "DBMS_OUTPUT",
+                           memberName: "PUT_LINE"),
+            .column(tableOwner: "HR", tableName: "EMPLOYEES", columnName: "SALARY"),
+            .column(tableOwner: nil, tableName: "EMPLOYEES", columnName: "SALARY"),
+            .unresolved
+        ]
+        for reference in cases {
+            XCTAssertNoThrow(try renderAndForceLayout(
+                payload: .notCached(reference: reference)),
+                             "notCached must render for \(reference)")
+        }
+    }
+
+    // MARK: - "Open in Browser" closure variants
+
+    func test_render_withOpenInBrowserClosure() {
+        // Footer button is conditionally shown when the closure is non-nil;
+        // exercise the branch.
+        XCTAssertNoThrow(try renderAndForceLayout(
+            payload: .table(.fixture(isView: false)),
+            openInBrowserAction: { /* no-op */ }))
+    }
+
+    func test_render_withoutOpenInBrowserClosure() {
+        XCTAssertNoThrow(try renderAndForceLayout(
+            payload: .table(.fixture(isView: false)),
+            openInBrowserAction: nil))
+    }
+
+    // MARK: - Helpers
+
+    private func renderAndForceLayout(payload: QuickViewPayload,
+                                      openInBrowserAction: (() -> Void)? = {}) throws {
+        let view = QuickViewContent(payload: payload,
+                                    openInBrowserAction: openInBrowserAction)
+        let host = NSHostingView(rootView: view)
+        // Pin to a realistic popover frame so layout has a finite container
+        // to resolve scroll views and lazy stacks against.
+        host.frame = NSRect(x: 0, y: 0, width: 520, height: 600)
+        host.layoutSubtreeIfNeeded()
+        // `fittingSize` triggers body evaluation independently of the frame
+        // we set above — belt-and-braces.
+        _ = host.fittingSize
+    }
+}
+
+// MARK: - Fixtures
+
+extension TableDetailPayload {
+    static let fixtureColumns: [QuickViewColumn] = [
+        QuickViewColumn(columnID: 1, columnName: "EMPLOYEE_ID",
+                        dataType: "NUMBER", dataTypeFormatted: "NUMBER(6)",
+                        isNullable: false, defaultValue: nil,
+                        isIdentity: true, isVirtual: false, isHidden: false),
+        QuickViewColumn(columnID: 2, columnName: "FIRST_NAME",
+                        dataType: "VARCHAR2", dataTypeFormatted: "VARCHAR2(120)",
+                        isNullable: true, defaultValue: nil,
+                        isIdentity: false, isVirtual: false, isHidden: false),
+        QuickViewColumn(columnID: 3, columnName: "SALARY",
+                        dataType: "NUMBER", dataTypeFormatted: "NUMBER(10,2)",
+                        isNullable: false, defaultValue: "0",
+                        isIdentity: false, isVirtual: false, isHidden: false)
+    ]
+
+    static func fixture(isView: Bool) -> TableDetailPayload {
+        TableDetailPayload(
+            owner: "HR", name: isView ? "ACTIVE_EMPLOYEES" : "EMPLOYEES",
+            isView: isView, isEditioning: false, isReadOnly: false,
+            isPartitioned: false, numRows: 12, lastAnalyzed: nil,
+            sqlText: isView ? "SELECT * FROM employees" : nil,
+            columns: fixtureColumns, indexes: [QuickViewIndex.fixture],
+            triggers: [QuickViewTrigger.fixture],
+            highlightedColumn: nil)
+    }
+}
+
+extension QuickViewIndex {
+    static let fixture = QuickViewIndex(
+        owner: "HR", name: "EMP_PK",
+        type: "NORMAL", isUnique: true, isValid: true)
+}
+
+extension QuickViewTrigger {
+    static let fixture = QuickViewTrigger(
+        owner: "HR", name: "EMP_AUDIT_TRG",
+        event: "UPDATE", isEnabled: true)
+}
+
+extension PackageDetailPayload {
+    static let fixture = PackageDetailPayload(
+        owner: "HR", name: "ACCOUNTS_PKG",
+        objectType: "PACKAGE", isValid: true,
+        specSource: "PACKAGE accounts_pkg AS\n  FUNCTION get_balance(...) RETURN NUMBER;\nEND;",
+        procedures: [
+            QuickViewPackageProcedure(
+                name: "GET_BALANCE", kind: "FUNCTION",
+                overload: nil, returnType: "NUMBER",
+                parameters: [
+                    QuickViewProcedureArgument(
+                        sequence: 1, position: 1,
+                        name: "ACCT_ID", dataType: "NUMBER",
+                        inOut: "IN", defaulted: false, defaultValue: nil)
+                ]),
+            QuickViewPackageProcedure(
+                name: "DEBIT", kind: "PROCEDURE",
+                overload: "1", returnType: nil,
+                parameters: [
+                    QuickViewProcedureArgument(
+                        sequence: 1, position: 1,
+                        name: "AMOUNT", dataType: "NUMBER",
+                        inOut: "IN", defaulted: false, defaultValue: nil)
+                ])
+        ])
+}
+
+extension ProcedureDetailPayload {
+    static let functionFixture = ProcedureDetailPayload(
+        owner: "HR", name: "GET_BALANCE",
+        packageName: "ACCOUNTS_PKG", kind: "FUNCTION",
+        overload: nil, returnType: "NUMBER",
+        parameters: [
+            QuickViewProcedureArgument(
+                sequence: 1, position: 1,
+                name: "ACCT_ID", dataType: "NUMBER",
+                inOut: "IN", defaulted: true, defaultValue: "0")
+        ],
+        isValid: true)
+
+    static let procedureNoParamsFixture = ProcedureDetailPayload(
+        owner: "HR", name: "DAILY_RESET",
+        packageName: nil, kind: "PROCEDURE",
+        overload: nil, returnType: nil,
+        parameters: [],
+        isValid: true)
+}
+
+extension ColumnDetailPayload {
+    static func fixture(virtual: Bool) -> ColumnDetailPayload {
+        ColumnDetailPayload(
+            tableOwner: "HR", tableName: "EMPLOYEES",
+            column: QuickViewColumn(
+                columnID: 1,
+                columnName: virtual ? "TOTAL_COMP" : "SALARY",
+                dataType: "NUMBER",
+                dataTypeFormatted: "NUMBER(10,2)",
+                isNullable: virtual,
+                defaultValue: virtual ? "salary + nvl(commission,0)" : nil,
+                isIdentity: false,
+                isVirtual: virtual,
+                isHidden: false))
+    }
+}
+
+extension UnknownObjectPayload {
+    static let fixture = UnknownObjectPayload(
+        owner: "HR", name: "EMP_PK",
+        objectType: "INDEX", isValid: true,
+        lastDDLDate: Date(timeIntervalSince1970: 1_700_000_000))
+}

--- a/MacintoraTests/Editor/Plugins/QuickView/QuickViewControllerTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/QuickViewControllerTests.swift
@@ -1,0 +1,468 @@
+//
+//  QuickViewControllerTests.swift
+//  MacintoraTests
+//
+//  Exercises `QuickViewController.fetchPayload(for:preferredOwner:dataSource:)`
+//  — the routing brain that turns a `ResolvedDBReference` into the right
+//  cached `QuickViewPayload` variant. Drives an in-memory CoreData store via
+//  `CompletionDataSource` so we cover the full data path that production
+//  takes after a trigger fires, minus the AppKit popover layer.
+//
+
+import XCTest
+import CoreData
+@testable import Macintora
+
+@MainActor
+final class QuickViewControllerTests: XCTestCase {
+
+    private var persistence: PersistenceController!
+    private var dataSource: CompletionDataSource!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistence = PersistenceController(inMemory: true)
+        dataSource = CompletionDataSource(persistenceController: persistence)
+    }
+
+    override func tearDown() async throws {
+        dataSource = nil
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - schemaObject → table
+
+    func test_schemaObject_table_returnsTablePayload() async {
+        seedTable(owner: "HR", name: "EMPLOYEES")
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "EMPLOYEES"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .table(let table) = payload else {
+            return XCTFail("expected .table, got \(payload)")
+        }
+        XCTAssertEqual(table.owner, "HR")
+        XCTAssertEqual(table.name, "EMPLOYEES")
+        XCTAssertFalse(table.isView)
+    }
+
+    func test_schemaObject_view_returnsTablePayloadWithIsView() async {
+        seedView(owner: "HR", name: "ACTIVE_EMPLOYEES",
+                 sql: "SELECT * FROM employees WHERE active = 1")
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "ACTIVE_EMPLOYEES"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .table(let table) = payload else {
+            return XCTFail("expected .table for view payload, got \(payload)")
+        }
+        XCTAssertTrue(table.isView)
+        XCTAssertEqual(table.sqlText, "SELECT * FROM employees WHERE active = 1")
+    }
+
+    func test_schemaObject_unqualified_prefersConnectedSchema() async {
+        // Two schemas have an EMPLOYEES table; with no owner provided, the
+        // controller must defer to the user's connected schema.
+        seedTable(owner: "HR", name: "EMPLOYEES")
+        seedTable(owner: "BILLING", name: "EMPLOYEES")
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: nil, name: "EMPLOYEES"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .table(let table) = payload else {
+            return XCTFail("expected .table, got \(payload)")
+        }
+        XCTAssertEqual(table.owner, "HR")
+    }
+
+    // MARK: - schemaObject → package / type
+
+    func test_schemaObject_package_returnsPackagePayload() async {
+        seedAccountsPackage()
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "ACCOUNTS_PKG"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .packageOrType(let pkg) = payload else {
+            return XCTFail("expected .packageOrType, got \(payload)")
+        }
+        XCTAssertEqual(pkg.objectType, "PACKAGE")
+        XCTAssertFalse(pkg.procedures.isEmpty,
+                       "package payload must include cached procedures")
+    }
+
+    func test_schemaObject_userDefinedType_returnsPackagePayload() async {
+        addObject(owner: "HR", name: "ADDRESS_T", type: "TYPE")
+        try! persistence.container.viewContext.save()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "ADDRESS_T"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .packageOrType(let pkg) = payload else {
+            return XCTFail("expected .packageOrType for TYPE, got \(payload)")
+        }
+        XCTAssertEqual(pkg.objectType, "TYPE")
+    }
+
+    // MARK: - schemaObject → standalone procedure / function
+
+    func test_schemaObject_standaloneFunction_returnsProcedurePayload() async {
+        seedStandaloneFunction(owner: "HR", name: "SALARY_GRADE",
+                               returnType: "VARCHAR2",
+                               argument: ("AMOUNT", "NUMBER"))
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "SALARY_GRADE"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .procedure(let proc) = payload else {
+            return XCTFail("expected .procedure, got \(payload)")
+        }
+        XCTAssertEqual(proc.kind, "FUNCTION")
+        XCTAssertNil(proc.packageName)
+        XCTAssertEqual(proc.returnType, "VARCHAR2")
+        XCTAssertEqual(proc.parameters.map(\.name), ["AMOUNT"])
+    }
+
+    func test_schemaObject_unknownObjectType_returnsUnknownPayload() async {
+        addObject(owner: "HR", name: "EMP_PK", type: "INDEX")
+        try! persistence.container.viewContext.save()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "EMP_PK"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .unknownObject(let unknown) = payload else {
+            return XCTFail("expected .unknownObject for INDEX, got \(payload)")
+        }
+        XCTAssertEqual(unknown.objectType, "INDEX")
+    }
+
+    func test_schemaObject_synonym_returnsUnknownPayload() async {
+        // Synonyms aren't chased in v1 — the popover shows the synonym row
+        // itself with an "Open in Browser" affordance.
+        addObject(owner: "PUBLIC", name: "EMP", type: "SYNONYM")
+        try! persistence.container.viewContext.save()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "PUBLIC", name: "EMP"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .unknownObject(let unknown) = payload else {
+            return XCTFail("expected .unknownObject for SYNONYM, got \(payload)")
+        }
+        XCTAssertEqual(unknown.objectType, "SYNONYM")
+    }
+
+    // MARK: - schemaObject → not cached
+
+    func test_schemaObject_missing_returnsNotCached() async {
+        let reference = ResolvedDBReference.schemaObject(owner: "HR", name: "GHOST")
+        let payload = await QuickViewController.fetchPayload(
+            for: reference, preferredOwner: "HR", dataSource: dataSource)
+        guard case .notCached(let echoed) = payload else {
+            return XCTFail("expected .notCached, got \(payload)")
+        }
+        XCTAssertEqual(echoed, reference,
+                       "notCached must echo the original reference so the UI can render its name")
+    }
+
+    func test_schemaObject_qualified_fallsBackToPackageMember() async {
+        // `schema.proc` interpretation didn't match — a 2-part schemaObject
+        // looking like `pkg.proc` must fall through to the package-member
+        // probe before declaring the cache empty. Seed a package member
+        // matching the second leg.
+        seedAccountsPackage()
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "ACCOUNTS_PKG", name: "GET_BALANCE"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .procedure(let proc) = payload else {
+            return XCTFail("expected .procedure via package-member fallback, got \(payload)")
+        }
+        XCTAssertEqual(proc.packageName, "ACCOUNTS_PKG")
+        XCTAssertEqual(proc.name, "GET_BALANCE")
+    }
+
+    // MARK: - packageMember
+
+    func test_packageMember_explicit_returnsProcedurePayload() async {
+        seedAccountsPackage()
+        let payload = await QuickViewController.fetchPayload(
+            for: .packageMember(packageOwner: "HR",
+                                packageName: "ACCOUNTS_PKG",
+                                memberName: "GET_BALANCE"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .procedure(let proc) = payload else {
+            return XCTFail("expected .procedure for packageMember, got \(payload)")
+        }
+        XCTAssertEqual(proc.packageName, "ACCOUNTS_PKG")
+        XCTAssertEqual(proc.kind, "FUNCTION")
+    }
+
+    func test_packageMember_unqualified_usesPreferredOwner() async {
+        seedAccountsPackage()
+        let payload = await QuickViewController.fetchPayload(
+            for: .packageMember(packageOwner: nil,
+                                packageName: "ACCOUNTS_PKG",
+                                memberName: "GET_BALANCE"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        if case .procedure = payload { return /* OK */ }
+        XCTFail("nil packageOwner with preferredOwner=HR should still resolve, got \(payload)")
+    }
+
+    func test_packageMember_fallsBackToSchemaWhenNoSuchMember() async {
+        // No DBCacheProcedure rows exist; the qualifier was actually a schema
+        // and the member is a standalone object. Controller must try the
+        // schema-object path before giving up.
+        addObject(owner: "BILLING", name: "RUN_REPORT", type: "PROCEDURE")
+        seedStandaloneProcedure(owner: "BILLING", name: "RUN_REPORT",
+                                argument: ("DATE_ARG", "DATE"))
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .packageMember(packageOwner: nil,
+                                packageName: "BILLING",
+                                memberName: "RUN_REPORT"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .procedure(let proc) = payload else {
+            return XCTFail("expected .procedure via schema fallback, got \(payload)")
+        }
+        XCTAssertEqual(proc.owner, "BILLING")
+        XCTAssertNil(proc.packageName)
+    }
+
+    func test_packageMember_unresolvable_returnsNotCached() async {
+        let reference = ResolvedDBReference.packageMember(
+            packageOwner: nil,
+            packageName: "GHOST_PKG",
+            memberName: "NOPE")
+        let payload = await QuickViewController.fetchPayload(
+            for: reference, preferredOwner: "HR", dataSource: dataSource)
+        guard case .notCached(let echoed) = payload else {
+            return XCTFail("expected .notCached, got \(payload)")
+        }
+        XCTAssertEqual(echoed, reference)
+    }
+
+    // MARK: - column
+
+    func test_column_returnsColumnPayload() async {
+        seedTable(owner: "HR", name: "EMPLOYEES")
+        let payload = await QuickViewController.fetchPayload(
+            for: .column(tableOwner: "HR", tableName: "EMPLOYEES", columnName: "SALARY"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .column(let col) = payload else {
+            return XCTFail("expected .column, got \(payload)")
+        }
+        XCTAssertEqual(col.column.columnName, "SALARY")
+        XCTAssertEqual(col.tableName, "EMPLOYEES")
+    }
+
+    func test_column_unknownColumn_fallsBackToParentTable() async {
+        // Table is cached but the specific column row is missing — controller
+        // upgrades to a table popover with the missing column "highlighted".
+        seedTable(owner: "HR", name: "EMPLOYEES")
+        let payload = await QuickViewController.fetchPayload(
+            for: .column(tableOwner: "HR", tableName: "EMPLOYEES", columnName: "GHOST"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        guard case .table(let table) = payload else {
+            return XCTFail("expected .table fallback, got \(payload)")
+        }
+        XCTAssertEqual(table.highlightedColumn, "GHOST")
+    }
+
+    func test_column_unknownTable_returnsNotCached() async {
+        let reference = ResolvedDBReference.column(
+            tableOwner: "HR",
+            tableName: "GHOST",
+            columnName: "ANYTHING")
+        let payload = await QuickViewController.fetchPayload(
+            for: reference, preferredOwner: "HR", dataSource: dataSource)
+        guard case .notCached(let echoed) = payload else {
+            return XCTFail("expected .notCached, got \(payload)")
+        }
+        XCTAssertEqual(echoed, reference)
+    }
+
+    func test_column_nilOwner_fallsBackToPreferredOwnerForTable() async {
+        // The resolver couldn't determine the table owner via alias map, but
+        // the column does belong to a cached HR.EMPLOYEES.SALARY. Controller
+        // must still succeed.
+        seedTable(owner: "HR", name: "EMPLOYEES")
+        let payload = await QuickViewController.fetchPayload(
+            for: .column(tableOwner: nil, tableName: "EMPLOYEES", columnName: "SALARY"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        if case .column = payload { return /* OK */ }
+        XCTFail("nil tableOwner with cached HR.EMPLOYEES should resolve, got \(payload)")
+    }
+
+    // MARK: - unresolved
+
+    func test_unresolved_returnsNotCached() async {
+        let payload = await QuickViewController.fetchPayload(
+            for: .unresolved,
+            preferredOwner: "HR",
+            dataSource: dataSource)
+        if case .notCached(.unresolved) = payload { return /* OK */ }
+        XCTFail("unresolved must produce .notCached(.unresolved), got \(payload)")
+    }
+
+    // MARK: - Seed helpers
+
+    private func seedTable(owner: String, name: String) {
+        let ctx = persistence.container.viewContext
+        addObject(owner: owner, name: name, type: "TABLE")
+        let table = DBCacheTable(context: ctx)
+        table.owner_ = owner
+        table.name_ = name
+        table.isView = false
+
+        addColumn(owner: owner, table: name, column: "EMPLOYEE_ID",
+                  type: "NUMBER", precision: 6, scale: 0,
+                  isNullable: false, columnID: 1)
+        addColumn(owner: owner, table: name, column: "FIRST_NAME",
+                  type: "VARCHAR2", precision: 0, scale: 0,
+                  isNullable: true, columnID: 2, length: 120)
+        addColumn(owner: owner, table: name, column: "SALARY",
+                  type: "NUMBER", precision: 10, scale: 2,
+                  isNullable: false, columnID: 3)
+
+        try! ctx.save()
+    }
+
+    private func seedView(owner: String, name: String, sql: String) {
+        let ctx = persistence.container.viewContext
+        addObject(owner: owner, name: name, type: "VIEW")
+        let view = DBCacheTable(context: ctx)
+        view.owner_ = owner
+        view.name_ = name
+        view.isView = true
+        view.sqltext = sql
+
+        addColumn(owner: owner, table: name, column: "EMPLOYEE_ID",
+                  type: "NUMBER", precision: 6, scale: 0,
+                  isNullable: false, columnID: 1)
+        try! ctx.save()
+    }
+
+    private func seedAccountsPackage() {
+        let ctx = persistence.container.viewContext
+        addObject(owner: "HR", name: "ACCOUNTS_PKG", type: "PACKAGE")
+
+        addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: nil,
+                     subprogramId: 0, overload: nil, parentType: "PACKAGE")
+        addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "GET_BALANCE",
+                     subprogramId: 1, overload: nil, parentType: "PACKAGE")
+        addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "DEBIT",
+                     subprogramId: 2, overload: "1", parentType: "PACKAGE")
+
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 0, sequence: 1, name: nil,
+                    dataType: "NUMBER", inOut: "OUT")
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 1, sequence: 2, name: "ACCT_ID",
+                    dataType: "NUMBER", inOut: "IN")
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "1", position: 1, sequence: 1, name: "AMOUNT",
+                    dataType: "NUMBER", inOut: "IN")
+
+        try! ctx.save()
+    }
+
+    /// Seeds a standalone function — `objectName_` and `procedureName_`
+    /// match (the latter is required by the cache schema even for
+    /// standalone subprograms; the data fetcher's
+    /// `procedureDetail(packageName: nil, …)` falls back to using the
+    /// procedure's own name as the `objectName_`).
+    private func seedStandaloneFunction(owner: String, name: String,
+                                        returnType: String,
+                                        argument: (String, String)) {
+        let ctx = persistence.container.viewContext
+        addObject(owner: owner, name: name, type: "FUNCTION")
+
+        addProcedure(owner: owner, pkg: name, name: name,
+                     subprogramId: 1, overload: nil, parentType: "FUNCTION")
+        addArgument(owner: owner, pkg: name, proc: name,
+                    overload: nil, position: 0, sequence: 1,
+                    name: nil, dataType: returnType, inOut: "OUT")
+        addArgument(owner: owner, pkg: name, proc: name,
+                    overload: nil, position: 1, sequence: 2,
+                    name: argument.0, dataType: argument.1, inOut: "IN")
+
+        try! ctx.save()
+    }
+
+    private func seedStandaloneProcedure(owner: String, name: String,
+                                         argument: (String, String)) {
+        let ctx = persistence.container.viewContext
+        addProcedure(owner: owner, pkg: name, name: name,
+                     subprogramId: 1, overload: nil, parentType: "PROCEDURE")
+        addArgument(owner: owner, pkg: name, proc: name,
+                    overload: nil, position: 1, sequence: 1,
+                    name: argument.0, dataType: argument.1, inOut: "IN")
+        try! persistence.container.viewContext.save()
+    }
+
+    // MARK: - Low-level seed helpers (mirror `CompletionDataSourceTests`)
+
+    private func addObject(owner: String, name: String, type: String) {
+        let row = DBCacheObject(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.name_ = name
+        row.type_ = type
+        row.isValid = true
+    }
+
+    private func addColumn(owner: String, table: String, column: String,
+                           type: String, precision: Int32, scale: Int32,
+                           isNullable: Bool, columnID: Int,
+                           length: Int32 = 0) {
+        let row = DBCacheTableColumn(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.tableName_ = table
+        row.columnName_ = column
+        row.dataType_ = type
+        row.precision = precision == 0 ? nil : NSNumber(value: precision)
+        row.scale = scale == 0 ? nil : NSNumber(value: scale)
+        row.isNullable = isNullable
+        row.columnID = NSNumber(value: columnID)
+        row.internalColumnID = Int16(columnID)
+        row.length = length
+    }
+
+    private func addProcedure(owner: String, pkg: String, name: String?,
+                              subprogramId: Int32, overload: String?,
+                              parentType: String) {
+        let row = DBCacheProcedure(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = name
+        row.objectType_ = parentType
+        row.subprogramId = subprogramId
+        row.overload_ = overload
+    }
+
+    private func addArgument(owner: String, pkg: String, proc: String,
+                             overload: String?, position: Int16, sequence: Int16,
+                             name: String?, dataType: String, inOut: String) {
+        let row = DBCacheProcedureArgument(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = proc
+        row.overload_ = overload
+        row.position = position
+        row.sequence = sequence
+        row.dataLevel = 0
+        row.argumentName_ = name
+        row.dataType_ = dataType
+        row.inOut_ = inOut
+    }
+}

--- a/MacintoraTests/Editor/Plugins/QuickView/QuickViewEndToEndTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/QuickViewEndToEndTests.swift
@@ -1,0 +1,499 @@
+//
+//  QuickViewEndToEndTests.swift
+//  MacintoraTests
+//
+//  Wires the full Quick View pipeline against an in-memory DB cache for
+//  every supported object type. For each type we:
+//    1. Seed `DBCacheObject` plus the type-specific child entities.
+//    2. Run `QuickViewController.fetchPayload(for:preferredOwner:dataSource:)`
+//       — the production routing brain.
+//    3. Assert the payload's user-facing fields match the seeded data.
+//    4. Force-render `QuickViewContent` so the SwiftUI tree actually
+//       evaluates with that payload (catches missing types or trapping
+//       unwraps that synthetic-fixture render tests would miss).
+//
+//  Where `QuickViewControllerTests` covers branch logic and
+//  `QuickViewContentRenderTests` covers rendering with synthesized data,
+//  this suite proves cache → payload → SwiftUI works for real seeded
+//  rows of each supported `OracleObjectType`.
+//
+
+import XCTest
+import AppKit
+import SwiftUI
+import CoreData
+@testable import Macintora
+
+@MainActor
+final class QuickViewEndToEndTests: XCTestCase {
+
+    private var persistence: PersistenceController!
+    private var dataSource: CompletionDataSource!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistence = PersistenceController(inMemory: true)
+        dataSource = CompletionDataSource(persistenceController: persistence)
+    }
+
+    override func tearDown() async throws {
+        dataSource = nil
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - TABLE
+
+    func test_endToEnd_table_rendersColumnsIndexesTriggers() async {
+        seedTable(owner: "HR", name: "EMPLOYEES")
+        seedIndex(owner: "HR", table: "EMPLOYEES", name: "EMP_PK", isUnique: true)
+        seedTrigger(tableOwner: "HR", tableName: "EMPLOYEES",
+                    name: "EMP_AUDIT_TRG", event: "UPDATE", enabled: true)
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "EMPLOYEES"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .table(let table) = payload else {
+            return XCTFail("expected .table for a seeded TABLE row, got \(payload)")
+        }
+        XCTAssertFalse(table.isView)
+        XCTAssertEqual(table.columns.map(\.columnName).sorted(),
+                       ["EMPLOYEE_ID", "FIRST_NAME", "SALARY"])
+        XCTAssertEqual(table.indexes.map(\.name), ["EMP_PK"])
+        XCTAssertEqual(table.triggers.map(\.name), ["EMP_AUDIT_TRG"])
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - VIEW
+
+    func test_endToEnd_view_rendersSqlAndColumns() async {
+        seedView(owner: "HR", name: "ACTIVE_EMPLOYEES",
+                 sql: "SELECT * FROM employees WHERE active = 1")
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "ACTIVE_EMPLOYEES"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .table(let view) = payload else {
+            return XCTFail("expected .table (view shape) for VIEW, got \(payload)")
+        }
+        XCTAssertTrue(view.isView)
+        XCTAssertEqual(view.sqlText, "SELECT * FROM employees WHERE active = 1")
+        XCTAssertFalse(view.columns.isEmpty,
+                       "View payload must include cached column metadata")
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - PACKAGE
+
+    func test_endToEnd_package_rendersMembersAndOverloads() async {
+        seedAccountsPackage()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "ACCOUNTS_PKG"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .packageOrType(let pkg) = payload else {
+            return XCTFail("expected .packageOrType for PACKAGE, got \(payload)")
+        }
+        XCTAssertEqual(pkg.objectType, "PACKAGE")
+        // GET_BALANCE function + DEBIT overload "1" + DEBIT overload "2".
+        XCTAssertEqual(pkg.procedures.count, 3)
+        let getBalance = pkg.procedures.first { $0.name == "GET_BALANCE" }
+        XCTAssertEqual(getBalance?.kind, "FUNCTION")
+        XCTAssertEqual(getBalance?.returnType, "NUMBER")
+        let debit2 = pkg.procedures.first {
+            $0.name == "DEBIT" && $0.overload == "2"
+        }
+        XCTAssertEqual(debit2?.parameters.count, 2)
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - TYPE
+
+    func test_endToEnd_userDefinedType_rendersAsPackage() async {
+        addObject(owner: "HR", name: "ADDRESS_T", type: "TYPE")
+        try! persistence.container.viewContext.save()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "ADDRESS_T"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .packageOrType(let pkg) = payload else {
+            return XCTFail("expected .packageOrType for TYPE, got \(payload)")
+        }
+        XCTAssertEqual(pkg.objectType, "TYPE")
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - Standalone PROCEDURE
+
+    func test_endToEnd_standaloneProcedure_rendersSignature() async {
+        addObject(owner: "BILLING", name: "RUN_REPORT", type: "PROCEDURE")
+        seedStandaloneProcedure(owner: "BILLING", name: "RUN_REPORT",
+                                arguments: [("DATE_ARG", "DATE"), ("DETAILED", "BOOLEAN")])
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "BILLING", name: "RUN_REPORT"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .procedure(let proc) = payload else {
+            return XCTFail("expected .procedure for PROCEDURE, got \(payload)")
+        }
+        XCTAssertEqual(proc.kind, "PROCEDURE")
+        XCTAssertNil(proc.packageName,
+                     "Standalone procedure has no parent package")
+        XCTAssertEqual(proc.parameters.map(\.name), ["DATE_ARG", "DETAILED"])
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - Standalone FUNCTION
+
+    func test_endToEnd_standaloneFunction_rendersReturnType() async {
+        addObject(owner: "HR", name: "SALARY_GRADE", type: "FUNCTION")
+        seedStandaloneFunction(owner: "HR", name: "SALARY_GRADE",
+                               returnType: "VARCHAR2",
+                               arguments: [("AMOUNT", "NUMBER")])
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "SALARY_GRADE"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .procedure(let proc) = payload else {
+            return XCTFail("expected .procedure for FUNCTION, got \(payload)")
+        }
+        XCTAssertEqual(proc.kind, "FUNCTION")
+        XCTAssertEqual(proc.returnType, "VARCHAR2")
+        XCTAssertEqual(proc.parameters.map(\.name), ["AMOUNT"])
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - INDEX (catch-all)
+
+    func test_endToEnd_index_rendersAsUnknownObject() async {
+        let ctx = persistence.container.viewContext
+        let row = DBCacheObject(context: ctx)
+        row.owner_ = "HR"
+        row.name_ = "EMP_PK"
+        row.type_ = "INDEX"
+        row.isValid = true
+        row.lastDDLDate = Date(timeIntervalSince1970: 1_700_000_000)
+        try! ctx.save()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "EMP_PK"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .unknownObject(let unknown) = payload else {
+            return XCTFail("expected .unknownObject for INDEX, got \(payload)")
+        }
+        XCTAssertEqual(unknown.objectType, "INDEX")
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - SYNONYM (no-chase, v1)
+
+    func test_endToEnd_synonym_rendersAsUnknownObject() async {
+        addObject(owner: "PUBLIC", name: "EMP", type: "SYNONYM")
+        try! persistence.container.viewContext.save()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "PUBLIC", name: "EMP"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .unknownObject(let unknown) = payload else {
+            return XCTFail("expected .unknownObject for SYNONYM, got \(payload)")
+        }
+        XCTAssertEqual(unknown.objectType, "SYNONYM")
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - TRIGGER (catch-all)
+
+    func test_endToEnd_trigger_rendersAsUnknownObject() async {
+        addObject(owner: "HR", name: "EMP_AUDIT_TRG", type: "TRIGGER")
+        try! persistence.container.viewContext.save()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .schemaObject(owner: "HR", name: "EMP_AUDIT_TRG"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .unknownObject(let unknown) = payload else {
+            return XCTFail("expected .unknownObject for TRIGGER, got \(payload)")
+        }
+        XCTAssertEqual(unknown.objectType, "TRIGGER")
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - COLUMN reference (the alias-resolved path)
+
+    func test_endToEnd_column_rendersColumnPopover() async {
+        seedTable(owner: "HR", name: "EMPLOYEES")
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .column(tableOwner: "HR",
+                         tableName: "EMPLOYEES",
+                         columnName: "SALARY"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .column(let col) = payload else {
+            return XCTFail("expected .column for column reference, got \(payload)")
+        }
+        XCTAssertEqual(col.column.columnName, "SALARY")
+        XCTAssertEqual(col.column.dataTypeFormatted, "NUMBER(10,2)")
+        XCTAssertFalse(col.column.isNullable)
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - PACKAGE MEMBER call (e.g. dbms_output.put_line)
+
+    func test_endToEnd_packageMember_rendersProcedurePopover() async {
+        seedAccountsPackage()
+
+        let payload = await QuickViewController.fetchPayload(
+            for: .packageMember(packageOwner: "HR",
+                                packageName: "ACCOUNTS_PKG",
+                                memberName: "GET_BALANCE"),
+            preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .procedure(let proc) = payload else {
+            return XCTFail("expected .procedure for package member, got \(payload)")
+        }
+        XCTAssertEqual(proc.packageName, "ACCOUNTS_PKG")
+        XCTAssertEqual(proc.kind, "FUNCTION")
+        XCTAssertEqual(proc.returnType, "NUMBER")
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - Cache miss (the "not cached" path)
+
+    func test_endToEnd_cacheMiss_rendersNotCachedPlaceholder() async {
+        // Don't seed anything. The popover must still render — its job is to
+        // tell the user the object isn't cached.
+        let reference = ResolvedDBReference.schemaObject(
+            owner: "HR", name: "GHOST")
+        let payload = await QuickViewController.fetchPayload(
+            for: reference, preferredOwner: "HR",
+            dataSource: dataSource)
+
+        guard case .notCached(let echoed) = payload else {
+            return XCTFail("expected .notCached, got \(payload)")
+        }
+        XCTAssertEqual(echoed, reference,
+                       "notCached must echo the original reference so the placeholder can render the name")
+        XCTAssertNoThrow(try render(payload))
+    }
+
+    // MARK: - Render harness
+
+    /// Hosts `QuickViewContent(payload:)` inside an `NSHostingView`, forces
+    /// layout, and reads `fittingSize` so the body actually evaluates.
+    /// Throwing wrapper means a SwiftUI runtime trap on the main thread
+    /// will surface as a test failure rather than silently passing.
+    private func render(_ payload: QuickViewPayload) throws {
+        let view = QuickViewContent(payload: payload, openInBrowserAction: {})
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(x: 0, y: 0, width: 520, height: 600)
+        host.layoutSubtreeIfNeeded()
+        _ = host.fittingSize
+    }
+
+    // MARK: - Seed helpers
+
+    private func seedTable(owner: String, name: String) {
+        let ctx = persistence.container.viewContext
+        addObject(owner: owner, name: name, type: "TABLE")
+        let table = DBCacheTable(context: ctx)
+        table.owner_ = owner
+        table.name_ = name
+        table.isView = false
+        table.numRows = 12
+
+        addColumn(owner: owner, table: name, column: "EMPLOYEE_ID",
+                  type: "NUMBER", precision: 6, scale: 0,
+                  isNullable: false, columnID: 1)
+        addColumn(owner: owner, table: name, column: "FIRST_NAME",
+                  type: "VARCHAR2", precision: 0, scale: 0,
+                  isNullable: true, columnID: 2, length: 120)
+        addColumn(owner: owner, table: name, column: "SALARY",
+                  type: "NUMBER", precision: 10, scale: 2,
+                  isNullable: false, columnID: 3)
+
+        try! ctx.save()
+    }
+
+    private func seedView(owner: String, name: String, sql: String) {
+        let ctx = persistence.container.viewContext
+        addObject(owner: owner, name: name, type: "VIEW")
+        let view = DBCacheTable(context: ctx)
+        view.owner_ = owner
+        view.name_ = name
+        view.isView = true
+        view.sqltext = sql
+
+        addColumn(owner: owner, table: name, column: "EMPLOYEE_ID",
+                  type: "NUMBER", precision: 6, scale: 0,
+                  isNullable: false, columnID: 1)
+        addColumn(owner: owner, table: name, column: "FIRST_NAME",
+                  type: "VARCHAR2", precision: 0, scale: 0,
+                  isNullable: true, columnID: 2, length: 120)
+
+        try! ctx.save()
+    }
+
+    private func seedIndex(owner: String, table: String, name: String, isUnique: Bool) {
+        let ctx = persistence.container.viewContext
+        let row = DBCacheIndex(context: ctx)
+        row.owner_ = owner
+        row.name_ = name
+        row.tableOwner_ = owner
+        row.tableName_ = table
+        row.isUnique = isUnique
+        row.isValid = true
+        row.type_ = "NORMAL"
+        try! ctx.save()
+    }
+
+    private func seedTrigger(tableOwner: String, tableName: String,
+                             name: String, event: String, enabled: Bool) {
+        let ctx = persistence.container.viewContext
+        let row = DBCacheTrigger(context: ctx)
+        row.owner_ = tableOwner
+        row.name_ = name
+        row.objectOwner = tableOwner
+        row.objectName = tableName
+        row.event_ = event
+        row.isEnabled = enabled
+        try! ctx.save()
+    }
+
+    private func seedAccountsPackage() {
+        addObject(owner: "HR", name: "ACCOUNTS_PKG", type: "PACKAGE")
+
+        addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: nil,
+                     subprogramId: 0, overload: nil, parentType: "PACKAGE")
+        addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "GET_BALANCE",
+                     subprogramId: 1, overload: nil, parentType: "PACKAGE")
+        addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "DEBIT",
+                     subprogramId: 2, overload: "1", parentType: "PACKAGE")
+        addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "DEBIT",
+                     subprogramId: 2, overload: "2", parentType: "PACKAGE")
+
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 0, sequence: 1, name: nil,
+                    dataType: "NUMBER", inOut: "OUT")
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 1, sequence: 2, name: "ACCT_ID",
+                    dataType: "NUMBER", inOut: "IN")
+
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "1", position: 1, sequence: 1, name: "AMOUNT",
+                    dataType: "NUMBER", inOut: "IN")
+
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "2", position: 1, sequence: 1, name: "AMOUNT",
+                    dataType: "NUMBER", inOut: "IN")
+        addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "2", position: 2, sequence: 2, name: "CURRENCY",
+                    dataType: "VARCHAR2", inOut: "IN")
+
+        try! persistence.container.viewContext.save()
+    }
+
+    private func seedStandaloneFunction(owner: String, name: String,
+                                        returnType: String,
+                                        arguments: [(String, String)]) {
+        addProcedure(owner: owner, pkg: name, name: name,
+                     subprogramId: 1, overload: nil, parentType: "FUNCTION")
+        addArgument(owner: owner, pkg: name, proc: name,
+                    overload: nil, position: 0, sequence: 1,
+                    name: nil, dataType: returnType, inOut: "OUT")
+        for (i, arg) in arguments.enumerated() {
+            addArgument(owner: owner, pkg: name, proc: name,
+                        overload: nil, position: Int16(i + 1),
+                        sequence: Int16(i + 2),
+                        name: arg.0, dataType: arg.1, inOut: "IN")
+        }
+        try! persistence.container.viewContext.save()
+    }
+
+    private func seedStandaloneProcedure(owner: String, name: String,
+                                         arguments: [(String, String)]) {
+        addProcedure(owner: owner, pkg: name, name: name,
+                     subprogramId: 1, overload: nil, parentType: "PROCEDURE")
+        for (i, arg) in arguments.enumerated() {
+            addArgument(owner: owner, pkg: name, proc: name,
+                        overload: nil, position: Int16(i + 1),
+                        sequence: Int16(i + 1),
+                        name: arg.0, dataType: arg.1, inOut: "IN")
+        }
+        try! persistence.container.viewContext.save()
+    }
+
+    // MARK: - Low-level seed helpers
+
+    private func addObject(owner: String, name: String, type: String) {
+        let row = DBCacheObject(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.name_ = name
+        row.type_ = type
+        row.isValid = true
+    }
+
+    private func addColumn(owner: String, table: String, column: String,
+                           type: String, precision: Int32, scale: Int32,
+                           isNullable: Bool, columnID: Int,
+                           length: Int32 = 0) {
+        let row = DBCacheTableColumn(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.tableName_ = table
+        row.columnName_ = column
+        row.dataType_ = type
+        row.precision = precision == 0 ? nil : NSNumber(value: precision)
+        row.scale = scale == 0 ? nil : NSNumber(value: scale)
+        row.isNullable = isNullable
+        row.columnID = NSNumber(value: columnID)
+        row.internalColumnID = Int16(columnID)
+        row.length = length
+    }
+
+    private func addProcedure(owner: String, pkg: String, name: String?,
+                              subprogramId: Int32, overload: String?,
+                              parentType: String) {
+        let row = DBCacheProcedure(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = name
+        row.objectType_ = parentType
+        row.subprogramId = subprogramId
+        row.overload_ = overload
+    }
+
+    private func addArgument(owner: String, pkg: String, proc: String,
+                             overload: String?, position: Int16, sequence: Int16,
+                             name: String?, dataType: String, inOut: String) {
+        let row = DBCacheProcedureArgument(context: persistence.container.viewContext)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = proc
+        row.overload_ = overload
+        row.position = position
+        row.sequence = sequence
+        row.dataLevel = 0
+        row.argumentName_ = name
+        row.dataType_ = dataType
+        row.inOut_ = inOut
+    }
+}

--- a/MacintoraTests/Editor/Plugins/QuickView/QuickViewEndToEndTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/QuickViewEndToEndTests.swift
@@ -386,10 +386,12 @@ final class QuickViewEndToEndTests: XCTestCase {
                      subprogramId: 0, overload: nil, parentType: "PACKAGE")
         addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "GET_BALANCE",
                      subprogramId: 1, overload: nil, parentType: "PACKAGE")
+        // Distinct subprogram_id per overload — matches Oracle's
+        // ALL_PROCEDURES and avoids non-deterministic sort-tie ordering.
         addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "DEBIT",
                      subprogramId: 2, overload: "1", parentType: "PACKAGE")
         addProcedure(owner: "HR", pkg: "ACCOUNTS_PKG", name: "DEBIT",
-                     subprogramId: 2, overload: "2", parentType: "PACKAGE")
+                     subprogramId: 3, overload: "2", parentType: "PACKAGE")
 
         addArgument(owner: "HR", pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
                     overload: nil, position: 0, sequence: 1, name: nil,

--- a/MacintoraTests/Editor/Plugins/QuickView/QuickViewHotkeyTests.swift
+++ b/MacintoraTests/Editor/Plugins/QuickView/QuickViewHotkeyTests.swift
@@ -1,0 +1,74 @@
+//
+//  QuickViewHotkeyTests.swift
+//  MacintoraTests
+//
+//  Verifies the AppStorage-backed `QuickViewHotkey` enum: each preset maps
+//  to the right key/modifier combo, and the raw-value round-trip used by
+//  `EditorSettings`/`MainDocumentMenuCommands` to read the user's choice
+//  out of `UserDefaults` doesn't drift.
+//
+
+import XCTest
+import SwiftUI
+@testable import Macintora
+
+@MainActor
+final class QuickViewHotkeyTests: XCTestCase {
+
+    func test_default_isCmdI() {
+        XCTAssertEqual(QuickViewHotkey.default, .cmdI)
+    }
+
+    func test_storageKey_isStable() {
+        // The Settings picker and the menu command both read this raw
+        // string. Renaming it would silently reset every user's preference,
+        // so flag any drift loudly.
+        XCTAssertEqual(QuickViewHotkey.storageKey, "editor.quickViewHotkey")
+    }
+
+    func test_allCases_haveDistinctRawValues() {
+        let raws = Set(QuickViewHotkey.allCases.map(\.rawValue))
+        XCTAssertEqual(raws.count, QuickViewHotkey.allCases.count,
+                       "Raw values must be unique — they're stored in UserDefaults")
+    }
+
+    func test_allCases_haveDistinctDisplayNames() {
+        let names = Set(QuickViewHotkey.allCases.map(\.displayName))
+        XCTAssertEqual(names.count, QuickViewHotkey.allCases.count)
+    }
+
+    func test_cmdI_modifiersAndKey() {
+        XCTAssertEqual(QuickViewHotkey.cmdI.keyEquivalent, "i")
+        XCTAssertEqual(QuickViewHotkey.cmdI.modifiers, [.command])
+    }
+
+    func test_cmdShiftI_modifiers() {
+        XCTAssertEqual(QuickViewHotkey.cmdShiftI.keyEquivalent, "i")
+        XCTAssertEqual(QuickViewHotkey.cmdShiftI.modifiers, [.command, .shift])
+    }
+
+    func test_cmdF4_carriesFunctionKey() {
+        let key = QuickViewHotkey.cmdF4.keyEquivalent
+        XCTAssertNotNil(key)
+        XCTAssertEqual(QuickViewHotkey.cmdF4.modifiers, [.command])
+    }
+
+    func test_disabled_hasNoKeyEquivalent() {
+        XCTAssertNil(QuickViewHotkey.disabled.keyEquivalent,
+                     "Disabled state must opt out of `.keyboardShortcut(...)`")
+        XCTAssertEqual(QuickViewHotkey.disabled.modifiers, [])
+    }
+
+    func test_rawValueRoundTrip() {
+        for hotkey in QuickViewHotkey.allCases {
+            let restored = QuickViewHotkey(rawValue: hotkey.rawValue)
+            XCTAssertEqual(restored, hotkey,
+                           "raw value \(hotkey.rawValue) must round-trip through init")
+        }
+    }
+
+    func test_unknownRawValue_returnsNil() {
+        XCTAssertNil(QuickViewHotkey(rawValue: "ctrlSpace"),
+                     "Unknown stored value must return nil so callers fall back to .default")
+    }
+}

--- a/MacintoraTests/WindowFrameSanitiserTests.swift
+++ b/MacintoraTests/WindowFrameSanitiserTests.swift
@@ -1,0 +1,199 @@
+//
+//  WindowFrameSanitiserTests.swift
+//  MacintoraTests
+//
+//  Regression coverage for the launch-time crash where AppKit replays a
+//  persisted window frame that lives off-screen (typically because a
+//  secondary display was disconnected since the last save), and the
+//  resulting NavigationSplitView layout drives
+//  `_NSSplitViewItemViewWrapper.updateConstraints` past AppKit's
+//  "more passes than there are views" safety net and aborts.
+//
+//  The user's reproducer was a saved frame at `{-2270, 143, 1100, 700}`
+//  with no current screen at that position — that exact case is the
+//  primary test below.
+//
+
+import XCTest
+@testable import Macintora
+
+final class WindowFrameSanitiserTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "com.iliasazonov.macintora.tests.window-frame-sanitiser"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        defaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - frameIsOnScreen
+
+    func test_frameOnPrimary_isOnScreen() {
+        let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        XCTAssertTrue(WindowFrameSanitiser.frameIsOnScreen(
+            CGRect(x: 100, y: 100, width: 800, height: 600),
+            screens: [primary]))
+    }
+
+    func test_frameOnSecondaryToTheLeft_isOnScreen() {
+        // 1920×1080 main + 1920×1080 secondary at x=-1920 (left of primary).
+        let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let secondary = CGRect(x: -1920, y: 0, width: 1920, height: 1080)
+        let frame = CGRect(x: -1500, y: 100, width: 800, height: 600)
+        XCTAssertTrue(WindowFrameSanitiser.frameIsOnScreen(frame,
+                                                           screens: [primary, secondary]))
+    }
+
+    func test_userReproFrame_doesNotIntersectSingleScreen() {
+        // The exact frame from the user's bug report: window at -2270,
+        // extending to -1170. With only the primary 1920×1080 connected,
+        // there's no overlap and the sanitiser must reject it.
+        let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let badFrame = CGRect(x: -2270, y: 143, width: 1100, height: 700)
+        XCTAssertFalse(WindowFrameSanitiser.frameIsOnScreen(badFrame,
+                                                            screens: [primary]))
+    }
+
+    func test_smallSliverIntersection_isNotOnScreen() {
+        // 50×50 sliver overlap doesn't clear the 100×100 minimum visible
+        // area threshold — the window would be effectively unreachable.
+        let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let frame = CGRect(x: 1870, y: 1030, width: 800, height: 600)
+        XCTAssertFalse(WindowFrameSanitiser.frameIsOnScreen(frame,
+                                                            screens: [primary]))
+    }
+
+    func test_zeroSizeFrame_isNotOnScreen() {
+        let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let frame = CGRect(x: 100, y: 100, width: 0, height: 0)
+        XCTAssertFalse(WindowFrameSanitiser.frameIsOnScreen(frame,
+                                                            screens: [primary]))
+    }
+
+    func test_noScreens_treatsEverythingAsOffScreen() {
+        let frame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        XCTAssertFalse(WindowFrameSanitiser.frameIsOnScreen(frame, screens: []))
+    }
+
+    // MARK: - parseWindowFrame
+
+    func test_parseWindowFrame_acceptsCanonicalFormat() {
+        // `NSWindow.saveFrame(usingName:)` stores
+        // "wx wy ww wh sx sy sw sh".
+        let raw = "100 200 800 600 0 0 1920 1080"
+        XCTAssertEqual(WindowFrameSanitiser.parseWindowFrame(from: raw),
+                       CGRect(x: 100, y: 200, width: 800, height: 600))
+    }
+
+    func test_parseWindowFrame_acceptsNegativeOrigin() {
+        let raw = "-2270 143 1100 700 -1920 0 1920 1080"
+        XCTAssertEqual(WindowFrameSanitiser.parseWindowFrame(from: raw),
+                       CGRect(x: -2270, y: 143, width: 1100, height: 700))
+    }
+
+    func test_parseWindowFrame_rejectsTooFewComponents() {
+        XCTAssertNil(WindowFrameSanitiser.parseWindowFrame(from: "100 200"))
+    }
+
+    func test_parseWindowFrame_rejectsNonNumeric() {
+        XCTAssertNil(WindowFrameSanitiser.parseWindowFrame(from: "abc def 100 200 0 0 1920 1080"))
+    }
+
+    func test_parseWindowFrame_rejectsZeroSize() {
+        XCTAssertNil(WindowFrameSanitiser.parseWindowFrame(from: "100 200 0 0 0 0 1920 1080"))
+    }
+
+    // MARK: - Defaults sanitisation
+
+    func test_sanitise_dropsOffScreenFrame_userRepro() {
+        // The user's exact reproducer: bad frame saved, only the primary
+        // display connected at launch.
+        let key = "NSWindow Frame Macintora.MainDocument"
+        defaults.set("-2270 143 1100 700 -2560 0 1440 900", forKey: key)
+
+        let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        WindowFrameSanitiser.sanitisePersistedFrames(
+            autosaveNames: ["Macintora.MainDocument"],
+            in: defaults,
+            screenFrames: [primary])
+
+        XCTAssertNil(defaults.string(forKey: key),
+                     "Sanitiser must delete the off-screen entry so AppKit falls back to default placement")
+    }
+
+    func test_sanitise_keepsOnScreenFrame() {
+        let key = "NSWindow Frame Macintora.MainDocument"
+        let valid = "100 100 800 600 0 0 1920 1080"
+        defaults.set(valid, forKey: key)
+
+        WindowFrameSanitiser.sanitisePersistedFrames(
+            autosaveNames: ["Macintora.MainDocument"],
+            in: defaults,
+            screenFrames: [CGRect(x: 0, y: 0, width: 1920, height: 1080)])
+
+        XCTAssertEqual(defaults.string(forKey: key), valid,
+                       "Valid persisted frame must survive sanitisation untouched")
+    }
+
+    func test_sanitise_keepsFrameOnSecondaryDisplay_whenSecondaryStillConnected() {
+        let key = "NSWindow Frame Macintora.MainDocument"
+        let onSecondary = "-1500 100 800 600 -1920 0 1920 1080"
+        defaults.set(onSecondary, forKey: key)
+
+        WindowFrameSanitiser.sanitisePersistedFrames(
+            autosaveNames: ["Macintora.MainDocument"],
+            in: defaults,
+            screenFrames: [
+                CGRect(x: 0, y: 0, width: 1920, height: 1080),
+                CGRect(x: -1920, y: 0, width: 1920, height: 1080)
+            ])
+
+        XCTAssertNotNil(defaults.string(forKey: key))
+    }
+
+    func test_sanitise_dropsGarbageEntry() {
+        let key = "NSWindow Frame Macintora.MainDocument"
+        defaults.set("not a frame", forKey: key)
+
+        WindowFrameSanitiser.sanitisePersistedFrames(
+            autosaveNames: ["Macintora.MainDocument"],
+            in: defaults,
+            screenFrames: [CGRect(x: 0, y: 0, width: 1920, height: 1080)])
+
+        XCTAssertNil(defaults.string(forKey: key),
+                     "Unparseable persisted value must be cleared so AppKit doesn't try to interpret it")
+    }
+
+    func test_sanitise_isNoOpWhenNoEntryExists() {
+        // No value set at all — sanitiser must not invent one.
+        WindowFrameSanitiser.sanitisePersistedFrames(
+            autosaveNames: ["Macintora.MainDocument"],
+            in: defaults,
+            screenFrames: [CGRect(x: 0, y: 0, width: 1920, height: 1080)])
+
+        XCTAssertNil(defaults.string(forKey: "NSWindow Frame Macintora.MainDocument"))
+    }
+
+    func test_sanitise_handlesMultipleAutosaveNames() {
+        defaults.set("-2270 143 1100 700 0 0 1920 1080", forKey: "NSWindow Frame DocA")
+        defaults.set("100 100 800 600 0 0 1920 1080", forKey: "NSWindow Frame DocB")
+
+        WindowFrameSanitiser.sanitisePersistedFrames(
+            autosaveNames: ["DocA", "DocB"],
+            in: defaults,
+            screenFrames: [CGRect(x: 0, y: 0, width: 1920, height: 1080)])
+
+        XCTAssertNil(defaults.string(forKey: "NSWindow Frame DocA"),
+                     "Off-screen entry must be cleared")
+        XCTAssertNotNil(defaults.string(forKey: "NSWindow Frame DocB"),
+                        "On-screen entry must be preserved")
+    }
+}

--- a/MacintoraUITests/MacintoraUITests.swift
+++ b/MacintoraUITests/MacintoraUITests.swift
@@ -225,7 +225,7 @@ final class MacintoraUITests: XCTestCase {
         textView.typeKey("a", modifierFlags: .command)
         textView.typeKey(.delete, modifierFlags: [])
 
-        let stmts = (0..<20)
+        let stmts = (0..<6)
             .map { "SELECT \($0) FROM dual WHERE x = \($0);\n" }
             .joined()
         let start = Date()

--- a/MacintoraUITests/QuickViewUITests.swift
+++ b/MacintoraUITests/QuickViewUITests.swift
@@ -1,0 +1,149 @@
+//
+//  QuickViewUITests.swift
+//  MacintoraUITests
+//
+//  End-to-end smoke tests for the Quick View popover (issue #12). Drives the
+//  real app via XCUI keystroke events to exercise the trigger paths that
+//  unit tests can't reach: hotkey + context menu + ⌘+Click.
+//
+//  Skips when `~/Documents/macintora/local.macintora` isn't present —
+//  matches the convention in `MacintoraUITests`. The fixture provides a
+//  document scene with a wired editor so we don't have to drive the
+//  New Document UI.
+//
+
+import XCTest
+
+final class QuickViewUITests: XCTestCase {
+
+    private static let fixtureURL = URL(fileURLWithPath:
+        "/Users/ilia/Documents/macintora/local.macintora")
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        let path = Self.fixtureURL.path
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: path),
+            "Fixture document \(path) does not exist — required for Quick View UI tests."
+        )
+    }
+
+    @MainActor
+    private func launchAppWithFixture() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [Self.fixtureURL.path]
+        app.launchEnvironment["OS_ACTIVITY_MODE"] = "disable"
+        // Force the Quick View hotkey to ⌘I so the test is independent of
+        // any user override stored in UserDefaults from manual testing.
+        app.launchEnvironment["NSDoubleLocalizedStrings"] = "NO"
+        app.launch()
+        return app
+    }
+
+    /// ⌘I with the cursor on a recognisable identifier opens the popover.
+    /// Regression coverage for: focused-value plumbing
+    /// (`MainDocumentView.focusedSceneValue(.editorQuickViewBox)`),
+    /// `MainDocumentMenuCommands.Quick View` button → `box.trigger?()`,
+    /// `EditorQuickViewBox.trigger` → `QuickViewController.triggerAtCursor`.
+    @MainActor
+    func test_hotkey_opensQuickViewPopover() throws {
+        let app = launchAppWithFixture()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10), "document window did not appear")
+
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(textView.waitForExistence(timeout: 5), "editor text view not found")
+
+        // Clear and type a stable fragment whose last token is `DUAL`.
+        textView.click()
+        textView.typeKey("a", modifierFlags: .command)
+        textView.typeKey(.delete, modifierFlags: [])
+        textView.typeText("select * from DUAL")
+
+        // Cursor lands at end of typed text — that's already on the trailing
+        // identifier `DUAL`, perfect for Quick View.
+
+        // Pre-trigger: confirm no popover up yet so we know the post-state
+        // assertion is meaningful.
+        XCTAssertFalse(app.popovers.firstMatch.exists,
+                       "A popover was already visible before the hotkey fired")
+
+        // Trigger the hotkey at the document scope.
+        window.typeKey("i", modifierFlags: .command)
+
+        let popover = app.popovers.firstMatch
+        XCTAssertTrue(
+            popover.waitForExistence(timeout: 4),
+            "Quick View popover did not appear after ⌘I on `DUAL`"
+        )
+
+        // Attach the popover screenshot for diagnosability.
+        if popover.exists {
+            let shot = popover.screenshot().pngRepresentation
+            let att = XCTAttachment(data: shot, uniformTypeIdentifier: "public.png")
+            att.name = "quickview-popover"
+            att.lifetime = .keepAlways
+            add(att)
+        }
+
+        // Cleanup: NSPopover.behavior == .transient dismisses on click-
+        // outside (the canonical macOS contract). Click somewhere harmless
+        // so the popover doesn't bleed into the next test in this suite.
+        // Note: we deliberately don't assert dismissal — that's AppKit's
+        // contract, not ours.
+        window.toolbars.firstMatch.click()
+    }
+
+    /// ⌘I with the cursor on whitespace must NOT open a popover — the
+    /// resolver returns `.unresolved` and the controller short-circuits
+    /// before fetching any cache row. Regression test for the "no-op when
+    /// nothing's selected" contract.
+    @MainActor
+    func test_hotkey_onWhitespace_doesNothing() throws {
+        let app = launchAppWithFixture()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10))
+
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(textView.waitForExistence(timeout: 5))
+
+        textView.click()
+        textView.typeKey("a", modifierFlags: .command)
+        textView.typeKey(.delete, modifierFlags: [])
+        textView.typeText("   ")  // cursor sits on whitespace
+
+        window.typeKey("i", modifierFlags: .command)
+
+        // Brief wait window — if a popover were going to appear it'd be up
+        // by now (the controller is sync up to the cache fetch).
+        let popover = app.popovers.firstMatch
+        let appeared = popover.waitForExistence(timeout: 1)
+        XCTAssertFalse(appeared,
+                       "Quick View popover appeared on whitespace — resolver should have returned unresolved")
+    }
+
+    /// The Database menu carries a "Quick View" item that mirrors the
+    /// hotkey. Verifies the menu command is wired and reads the focused
+    /// box from `MainDocumentMenuCommands` when invoked via the menu bar.
+    @MainActor
+    func test_menuCommand_quickView_isPresent() throws {
+        let app = launchAppWithFixture()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+
+        let menuBar = app.menuBars.firstMatch
+        let databaseMenu = menuBar.menuBarItems["Database"]
+        XCTAssertTrue(databaseMenu.waitForExistence(timeout: 5),
+                      "Database menu missing from menu bar")
+        databaseMenu.click()
+
+        // The item's title in the open menu.
+        let quickViewItem = app.menuItems["Quick View"]
+        XCTAssertTrue(quickViewItem.waitForExistence(timeout: 3),
+                      "Quick View menu item missing from Database menu")
+
+        // Close the menu without invoking the item — the trigger may need
+        // an editor focus the menu bar invocation steals. The item's
+        // existence is what we're asserting.
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+    }
+}

--- a/MacintoraUITests/QuickViewUITests.swift
+++ b/MacintoraUITests/QuickViewUITests.swift
@@ -86,12 +86,14 @@ final class QuickViewUITests: XCTestCase {
             add(att)
         }
 
-        // Cleanup: NSPopover.behavior == .transient dismisses on click-
-        // outside (the canonical macOS contract). Click somewhere harmless
-        // so the popover doesn't bleed into the next test in this suite.
-        // Note: we deliberately don't assert dismissal — that's AppKit's
-        // contract, not ours.
-        window.toolbars.firstMatch.click()
+        // Cleanup: dismiss the popover so it doesn't bleed into the next
+        // test. NSPopover.behavior == .transient dismisses on click-outside;
+        // clicking back into the editor reliably triggers that even when
+        // the window is positioned off-screen on the test runner. We don't
+        // assert the dismissal — that's AppKit's contract, not ours.
+        if textView.isHittable {
+            textView.click()
+        }
     }
 
     /// ⌘I with the cursor on whitespace must NOT open a popover — the

--- a/MacintoraUITests/QuickViewUITests.swift
+++ b/MacintoraUITests/QuickViewUITests.swift
@@ -96,6 +96,50 @@ final class QuickViewUITests: XCTestCase {
         }
     }
 
+    /// Esc dismisses the popover even when it shows the "not cached"
+    /// placeholder — that path has no interactive SwiftUI elements before
+    /// issue #13 wires the Open in Browser button, so the responder
+    /// chain wouldn't receive `cancelOperation(_:)` without an explicit
+    /// `acceptsFirstResponder = true` override on the hosting controller.
+    /// Regression test for that fix.
+    @MainActor
+    func test_escape_dismissesNotCachedPopover() throws {
+        let app = launchAppWithFixture()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10))
+
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(textView.waitForExistence(timeout: 5))
+
+        // Type a token guaranteed not to exist in any cache so the popover
+        // shows the "not cached" placeholder. The token is also unlikely
+        // to match against any auto-completed identifier.
+        textView.click()
+        textView.typeKey("a", modifierFlags: .command)
+        textView.typeKey(.delete, modifierFlags: [])
+        textView.typeText("select * from ZZZ_NEVER_CACHED_OBJ_X9")
+
+        window.typeKey("i", modifierFlags: .command)
+
+        let popover = app.popovers.firstMatch
+        XCTAssertTrue(
+            popover.waitForExistence(timeout: 4),
+            "Quick View popover (not-cached state) did not appear after ⌘I"
+        )
+
+        // Esc must now dismiss without needing a mouse click anywhere.
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+
+        // Polling — the popover dismiss is animated (NSPopover.animates).
+        let dismissed = !popover.exists
+            || (0..<10).contains { _ in
+                Thread.sleep(forTimeInterval: 0.1)
+                return !popover.exists
+            }
+        XCTAssertFalse(popover.exists,
+                       "Esc must dismiss the not-cached popover; popover.exists=\(popover.exists), waited=\(dismissed)")
+    }
+
     /// ⌘I with the cursor on whitespace must NOT open a popover — the
     /// resolver returns `.unresolved` and the controller short-circuits
     /// before fetching any cache row. Regression test for the "no-op when

--- a/README.md
+++ b/README.md
@@ -3,12 +3,32 @@ A macOS native IDE tool for Oracle Database developers.
 
 ## What's new
 
-Macintora now uses a **pure-Swift** Oracle driver, [oracle-nio](https://github.com/lovetodream/oracle-nio). This means:
-
-- No Oracle Instant Client download or install — Macintora speaks Oracle's native TTC/TNS wire protocol directly.
-- Native Apple Silicon builds (no Rosetta).
-- Full Swift 6 strict concurrency across the app.
-- TLS, SYSDBA, and Cloud-IAM authentication supported via oracle-nio's configuration.
+- **DB Object Quick View in the editor.** ⌘-click or press ⌘I on any
+  table, view, package, procedure, function, type, or column reference
+  to pop up a compact details popover — columns with types and flags,
+  indexes, triggers, package members with argument signatures, view
+  SQL. Configurable hotkey in *Settings → Editor*; works against the
+  per-connection cache, no live DB round-trip.
+- **Code completion** for tables, views, and columns (alias-resolved),
+  driven by the tree-sitter parse tree and the cached DB objects.
+- **Oracle SQL and PL/SQL syntax highlighting** via my tree-sitter
+  grammar [tree-sitter-sql-orcl](https://github.com/iliasaz/tree-sitter-sql-orcl).
+  Incremental highlighting via STTextView's Neon plugin.
+- **Connection Manager** in *Settings → Connections* — import
+  connections from your existing `tnsnames.ora` once, then manage
+  everything in-app. Macintora no longer requires a maintained
+  `tnsnames.ora` on disk.
+- **Trivadis SQL & PL/SQL formatter** wired into the editor. Format the
+  current statement or the whole document; settings ship with sensible
+  defaults and can be customised by pointing at your own Trivadis
+  config (see *Settings → Formatter Path*).
+- **Pure-Swift Oracle driver** ([oracle-nio](https://github.com/lovetodream/oracle-nio)):
+  - No Oracle Instant Client download or install — Macintora speaks
+    Oracle's native TTC/TNS wire protocol directly.
+  - Native Apple Silicon builds (no Rosetta).
+  - Full Swift 6 strict concurrency across the app.
+  - TLS, SYSDBA, and Cloud-IAM authentication supported via
+    oracle-nio's configuration.
 
 Oracle Database 12.1 or later is supported.
 
@@ -28,24 +48,24 @@ Oracle Database 12.1 or later is supported.
 
 Clone the repo and open `Macintora.xcodeproj` in Xcode. Build and run the `MacOra` scheme.
 
-### Optional: SQL formatter
-For the built-in *Format&View* action, install the [Trivadis PL/SQL & SQL Formatter](https://github.com/Trivadis/plsql-formatter-settings#plsql--sql-formatter-settings) and point Macintora to it via *Settings → Formatter Path*.
+### SQL & PL/SQL formatter
+
+Install the [Trivadis PL/SQL & SQL Formatter](https://github.com/Trivadis/plsql-formatter-settings#plsql--sql-formatter-settings) and point Macintora to it via *Settings → Formatter Path*. After that, the editor's Format action runs the formatter on the current statement or the entire document. Trivadis configuration files (`format.xml`, `arbori-program.txt`) are picked up from the same directory if present, so you can tune output to your team's standards.
 
 ## Connection setup
 
-Macintora reads **tnsnames.ora** for connection aliases. By default it looks at `~/.oracle/tnsnames.ora`; you can change the path in *Settings → TNS Names Path*.
+Macintora's **Connection Manager** lives in *Settings → Connections*. The first time you open it you can import your existing `tnsnames.ora` in one click; after that, all connection metadata is stored inside Macintora and you don't need to maintain the `tnsnames.ora` file anymore.
 
-Sample `tnsnames.ora`:
+You can also add connections by hand via the form, or paste a JDBC-style URL:
 
 ```
-ORCL =
-  (DESCRIPTION =
-    (ADDRESS = (PROTOCOL = TCP)(HOST = db.example.com)(PORT = 1521))
-    (CONNECT_DATA = (SERVICE_NAME = orcl))
-  )
+host:port/service
+host/service                 # port defaults to 1521
+jdbc:oracle:thin:@host:port/service
+jdbc:oracle:thin:@(DESCRIPTION = ...)
 ```
 
-As an alternative, you can type a manual endpoint in the TNS field in the format `host:port/service` (port defaults to 1521 if omitted). `host/service` and `host:port/service` are both accepted.
+Passwords are stored in the macOS Keychain. Per-connection details (TLS, SYSDBA, edition, etc.) are exposed in the editor form.
 
 ## Documentation
 
@@ -57,12 +77,17 @@ Future-feature roadmaps (designed, not yet implemented):
 
 - [Outline view](./docs/roadmap-outline.md) — sidebar listing top-level symbols and package members; click to jump.
 - [Jump-to-symbol (and back)](./docs/roadmap-jump-to-symbol.md) — Cmd-click navigation, in-buffer first, then cross-file, then DBCache; with a back/forward stack.
-- [Code completion](./docs/roadmap-code-completion.md) — context-aware suggestions for keywords, schema objects, package members, and in-scope PL/SQL variables.
-- [Basic formatter](./docs/roadmap-basic-formatter.md) — native Swift Wadler-style pretty-printer for SQL and PL/SQL; format-on-save / `⌘-Shift-I`.
+- [Basic formatter](./docs/roadmap-basic-formatter.md) — native Swift Wadler-style pretty-printer for SQL and PL/SQL (a lighter alternative to the Trivadis integration).
 - [Advanced formatter with user-defined patterns](./docs/roadmap-advanced-formatter.md) — second-stage formatter that accepts `.scm` rule files, ships a curated default rule set, and adds column-anchored alignment.
+
+Implemented (originally listed here):
+
+- [Code completion](./docs/roadmap-code-completion.md) — tables, views, alias-resolved columns, and package members are live; PL/SQL in-scope variables remain on the roadmap.
 
 ## Other projects used
 - [oracle-nio](https://github.com/lovetodream/oracle-nio) — pure-Swift Oracle driver (replaces SwiftOracle/OCILIB).
 - [STTextView](https://github.com/krzyzanowskim/STTextView) — TextKit 2 source editor (replaces CodeEditor).
+- [STTextView-Plugin-Neon](https://github.com/krzyzanowskim/STTextView-Plugin-Neon) — tree-sitter highlighting plugin.
+- [tree-sitter-sql-orcl](https://github.com/iliasaz/tree-sitter-sql-orcl) — my Oracle SQL & PL/SQL grammar; powers the highlighter, completion, and Quick View.
 - [SwiftUIWindow](https://github.com/mortenjust/SwiftUIWindow) (inspiration)
 - [Trivadis PL/SQL & SQL Formatter Settings](https://github.com/Trivadis/plsql-formatter-settings#plsql--sql-formatter-settings)


### PR DESCRIPTION
Closes #12 (phase 1).

## Summary
- Adds a Quick View popover that shows compact details for the DB object under the cursor — table columns/indexes/triggers, view SQL, package members with argument signatures, single procedures, and a column mini-popover. Triggered by right-click → "Quick View", ⌘I (configurable in Settings → Editor), or ⌘-click on a token.
- Object identification is a new pure `ObjectAtCursorResolver` that walks the tree-sitter parse tree, reuses `AliasResolver` for column-via-alias upgrades, and falls back to a source-text scan when the parse tree hasn't caught up. Quoted identifiers preserve case; unquoted are folded to upper.
- Cache reads run on `CompletionDataSource` returning Sendable structs so SwiftUI renders without crossing actor boundaries. Cache miss surfaces a "not cached" placeholder.
- Implemented as `STDBObjectQuickViewPlugin` (an STTextView plugin) installed alongside Neon. The right-click item appends to STTextView's standard context menu via `STPluginEvents.onContextMenu`; ⌘-click is handled by an `NSEvent.addLocalMonitorForEvents` monitor scoped to the editor's window.
- README updated to document Quick View plus the recently-shipped Connection Manager, code completion, tree-sitter highlighter (linking the [tree-sitter-sql-orcl](https://github.com/iliasaz/tree-sitter-sql-orcl) grammar), and the Trivadis formatter integration.

Companion issue #13 ("Open in Browser pre-fetched on the cursor object") is not part of this PR — the popover already has a footer hook ready to wire up.

## Notable fixes caught while building this
- `DBCacheTrigger` predicate in `tableDetail` referenced `tableOwner` / `objectName_`; the entity actually keys via `objectOwner` / `objectName`. Wrong predicate would have crashed the popover the first time someone hovered Quick View on a table with triggers — caught only because the new tests forced the path.
- `EditorQuickViewBox` was originally `@Observable` and the menu's `.disabled(box?.trigger == nil)` read the trigger property; rebinding the closure from `updateNSView` cascaded through `@FocusedSceneValue` and tripped the same `_NSSplitViewItemViewWrapper.updateConstraints` infinite-loop crash that `SidebarToggleCrashRegressionTests` covers. Box is now a plain reference holder; menu disables on identity instead.
- "Not cached" popover couldn't be dismissed with Esc because the SwiftUI tree had no interactive elements before #13's "Open in Browser" button is wired. Subclassed `NSHostingController` to override `acceptsFirstResponder` / `cancelOperation(_:)` and explicitly set it as the popover window's first responder after `popover.show(...)`.

## Test plan

- [x] `ObjectAtCursorResolverTests` — 15 cases for cursor → `ResolvedDBReference` (table, view, schema-qualified, alias-qualified column, unknown alias, package member with and without owner, standalone proc/function, multi-statement scoping, string/comment/whitespace, mid-typing fallback, end-of-buffer)
- [x] `CompletionDataSourceTests` — 18 new cases covering `resolveSchemaObject`, `tableDetail`, `columnDetail`, `packageDetail`, `procedureDetail`, `unknownObjectDetail` against an in-memory CoreData store
- [x] `QuickViewControllerTests` — 19 cases drilling every routing branch in `fetchPayload`
- [x] `QuickViewHotkeyTests` — 10 cases over the AppStorage-backed hotkey enum
- [x] `EditorQuickViewBoxTests` — 4 cases for trigger lifecycle
- [x] `QuickViewContentRenderTests` — 15 cases force-rendering each `QuickViewPayload` variant through `NSHostingView`
- [x] `QuickViewEndToEndTests` — 12 cases that seed an in-memory cache for **every supported `OracleObjectType`** (TABLE, VIEW, PACKAGE, TYPE, standalone PROCEDURE / FUNCTION, INDEX, SYNONYM, TRIGGER, COLUMN reference, package-member call, cache-miss) and run cache → fetch → SwiftUI render
- [x] `QuickViewUITests` — 4 XCUI smoke tests gated on `~/Documents/macintora/local.macintora`: ⌘I opens the popover, ⌘I on whitespace no-ops, the Database menu has the Quick View item, Esc dismisses the not-cached popover
- [x] Full unit suite (`-only-testing:MacintoraTests`) — 374 tests, 1 skipped (pre-existing live-DB integration test), 0 failures
- [x] Manual: ⌘I, ⌘-click, right-click → Quick View, ⌘+F4 hotkey override in Settings, Esc dismissal in both cached and not-cached states