### PR TITLE
Editor: list package members on `pkg.` completion (#10 phase 1)

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		49C0301300000013 /* SQLContextAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301200000013 /* SQLContextAnalyzerTests.swift */; };
 		49C0301500000015 /* AliasResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301400000015 /* AliasResolverTests.swift */; };
 		49C0301700000017 /* CompletionDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301600000017 /* CompletionDataSourceTests.swift */; };
+		49C0301900000019 /* CompletionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0301800000019 /* CompletionCoordinatorTests.swift */; };
 		49C62C1C27DD7BAF00DE69E4 /* MainDocumentVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */; };
 		49C62C2427E010AE00DE69E4 /* ConnectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */; };
 		49CE5FF027279F3A009C2A94 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CE5FEF27279F3A009C2A94 /* ResultView.swift */; };
@@ -307,6 +308,7 @@
 		49C0301200000013 /* SQLContextAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLContextAnalyzerTests.swift; sourceTree = "<group>"; };
 		49C0301400000015 /* AliasResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasResolverTests.swift; sourceTree = "<group>"; };
 		49C0301600000017 /* CompletionDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDataSourceTests.swift; sourceTree = "<group>"; };
+		49C0301800000019 /* CompletionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCoordinatorTests.swift; sourceTree = "<group>"; };
 		49DB000100000001 /* QuickViewPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewPayload.swift; sourceTree = "<group>"; };
 		49DB000200000002 /* QuickViewColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewColumnView.swift; sourceTree = "<group>"; };
 		49DB000300000003 /* QuickViewTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickViewTableView.swift; sourceTree = "<group>"; };
@@ -660,6 +662,7 @@
 				49C0301200000013 /* SQLContextAnalyzerTests.swift */,
 				49C0301400000015 /* AliasResolverTests.swift */,
 				49C0301600000017 /* CompletionDataSourceTests.swift */,
+				49C0301800000019 /* CompletionCoordinatorTests.swift */,
 				49DB000C0000000C /* ObjectAtCursorResolverTests.swift */,
 			);
 			path = Completion;
@@ -937,6 +940,7 @@
 				49C0301300000013 /* SQLContextAnalyzerTests.swift in Sources */,
 				49C0301500000015 /* AliasResolverTests.swift in Sources */,
 				49C0301700000017 /* CompletionDataSourceTests.swift in Sources */,
+				49C0301900000019 /* CompletionCoordinatorTests.swift in Sources */,
 				49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */,
 				49DB301000000010 /* QuickViewControllerTests.swift in Sources */,
 				49DB301100000011 /* QuickViewHotkeyTests.swift in Sources */,

--- a/Macintora/Editor/Completion/CompletionCoordinator.swift
+++ b/Macintora/Editor/Completion/CompletionCoordinator.swift
@@ -236,28 +236,39 @@ final class CompletionCoordinator: @unchecked Sendable {
         return items
     }
 
-    private func dottedMemberSuggestions(qualifier: String,
-                                         prefix: String,
-                                         owner: String,
-                                         source: String,
-                                         tree: SwiftTreeSitter.Tree?,
-                                         offset: Int) async -> [MacintoraCompletionItem] {
+    func dottedMemberSuggestions(qualifier: String,
+                                 prefix: String,
+                                 owner: String,
+                                 source: String,
+                                 tree: SwiftTreeSitter.Tree?,
+                                 offset: Int) async -> [MacintoraCompletionItem] {
         let aliases = currentAliases(source: source, tree: tree, offset: offset)
         let upper = qualifier.uppercased()
 
-        // 1) Alias → table columns.
+        // 1) Alias → table columns. Aliases resolve unambiguously, so this
+        // short-circuits the rest.
         if let resolved = aliases[upper] ?? nil {
             return await fetchColumns(table: resolved, prefix: prefix)
         }
 
-        // 2) Treat as schema → list its objects (tables/views/packages).
-        let objects = await dataSource.objects(
+        // 2) `qualifier.` is ambiguous without semantic resolution: it could
+        // be `schema.object` *or* `package.member`, and a cached
+        // `qualifier`-named TABLE could coexist with a `qualifier`-named
+        // PACKAGE in another schema. Probe both in parallel and merge —
+        // showing both kinds in the popup is the pragmatic answer.
+        async let schemaObjects = dataSource.objects(
             search: prefix,
             owner: upper,
             types: ["TABLE", "VIEW", "PACKAGE"],
             limit: fetchLimit)
-        if !objects.isEmpty {
-            return objects.map { MacintoraCompletionItem.make(from: $0) }
+        async let packageMembers = packageMemberSuggestions(qualifier: upper,
+                                                            prefix: prefix,
+                                                            owner: owner)
+
+        let objs = await schemaObjects
+        let procs = await packageMembers
+        if !objs.isEmpty || !procs.isEmpty {
+            return objs.map { MacintoraCompletionItem.make(from: $0) } + procs
         }
 
         // 3) Treat as table → columns of any cached table with this name,
@@ -266,6 +277,26 @@ final class CompletionCoordinator: @unchecked Sendable {
         return await dataSource
             .columns(tableName: upper, owner: nil, search: prefix, limit: fetchLimit)
             .map { MacintoraCompletionItem.make(from: $0) }
+    }
+
+    /// Resolves `qualifier` to a cached PACKAGE and surfaces its procedures
+    /// and functions. Empty result when the qualifier doesn't name a package
+    /// in any cached schema. The package is selected by `resolvePackage`'s
+    /// preferred-owner-first ranking; cross-schema name collisions
+    /// (rare — same package name in two schemas the user has cached) pick
+    /// the connected schema if it has one, otherwise the alphabetically
+    /// first match.
+    private func packageMemberSuggestions(qualifier: String,
+                                          prefix: String,
+                                          owner: String) async -> [MacintoraCompletionItem] {
+        guard let pkg = await dataSource.resolvePackage(name: qualifier,
+                                                        preferredOwner: owner)
+        else { return [] }
+        let procedures = await dataSource.procedures(packageName: pkg.name,
+                                                     owner: pkg.owner,
+                                                     search: prefix,
+                                                     limit: fetchLimit)
+        return procedures.map { MacintoraCompletionItem.make(from: $0) }
     }
 
     private func fetchColumns(table: ResolvedTable, prefix: String) async -> [MacintoraCompletionItem] {

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -287,6 +287,42 @@ actor CompletionDataSource {
         }
     }
 
+    /// Resolves `name` to the best-ranked `DBCacheObject` of type `PACKAGE`
+    /// across all cached schemas. The preferred owner wins; otherwise the
+    /// alphabetically first match. Returns nil when the name doesn't refer to
+    /// any cached package — used by the completion coordinator to decide
+    /// whether `qualifier.` should expand into package members.
+    func resolvePackage(name: String,
+                        preferredOwner: String) async -> ResolvedSchemaObject? {
+        await fetch { ctx -> ResolvedSchemaObject? in
+            let upperName = name.uppercased()
+            let upperPreferred = preferredOwner.uppercased()
+            let request = DBCacheObject.fetchRequest()
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "name_ = %@", upperName),
+                NSPredicate(format: "type_ = %@", "PACKAGE")
+            ])
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "owner_", ascending: true),
+                NSSortDescriptor(key: "name_", ascending: true)
+            ]
+            do {
+                let rows = try ctx.fetch(request)
+                guard !rows.isEmpty else { return nil }
+                let chosen = rows.first { ($0.owner_ ?? "") == upperPreferred } ?? rows[0]
+                return ResolvedSchemaObject(
+                    owner: chosen.owner_ ?? "",
+                    name: chosen.name_ ?? "",
+                    objectType: chosen.type_ ?? "PACKAGE",
+                    isValid: chosen.isValid,
+                    lastDDLDate: chosen.lastDDLDate)
+            } catch {
+                self.logger.error("resolvePackage fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
     /// Arguments of a single procedure / function invocation. Excludes the
     /// `position == 0` return-value row (callers consume return type via
     /// `procedures(...).returnType`) and `dataLevel > 0` composite expansions.

--- a/MacintoraTests/Editor/Completion/CompletionCoordinatorTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionCoordinatorTests.swift
@@ -1,0 +1,223 @@
+//
+//  CompletionCoordinatorTests.swift
+//  MacintoraTests
+//
+//  Exercises `CompletionCoordinator.dottedMemberSuggestions` against an
+//  in-memory CoreData store. Phase 1 of issue #10: typing `pkg.` must
+//  surface the cached package's procedures and functions while still
+//  showing schema-scoped objects when the qualifier collides with a
+//  schema name.
+//
+
+import XCTest
+import CoreData
+@testable import Macintora
+
+@MainActor
+final class CompletionCoordinatorTests: XCTestCase {
+
+    private var persistence: PersistenceController!
+    private var dataSource: CompletionDataSource!
+    private var coordinator: CompletionCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistence = PersistenceController(inMemory: true)
+        dataSource = CompletionDataSource(persistenceController: persistence)
+        coordinator = CompletionCoordinator(
+            treeStore: SQLTreeStore(),
+            dataSource: dataSource,
+            defaultOwnerProvider: { "HR" })
+    }
+
+    override func tearDown() async throws {
+        coordinator = nil
+        dataSource = nil
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Phase 1: package members on `pkg.`
+
+    func test_dottedMember_packageQualifier_listsProcedureMembers() async {
+        seedAccountsPackageWithObject(owner: "HR")
+
+        let items = await coordinator.dottedMemberSuggestions(
+            qualifier: "ACCOUNTS_PKG", prefix: "",
+            owner: "HR", source: "", tree: nil, offset: 0)
+
+        let names = Set(items.map(\.displayText))
+        XCTAssertTrue(names.contains("GET_BALANCE"))
+        XCTAssertTrue(names.contains("DEBIT"),
+                      "Both DEBIT overloads should be present (one row each)")
+        XCTAssertEqual(items.filter { $0.displayText == "DEBIT" }.count, 2,
+                       "Each overload renders as its own popup row")
+    }
+
+    func test_dottedMember_packageQualifier_filtersByPrefix() async {
+        seedAccountsPackageWithObject(owner: "HR")
+
+        let items = await coordinator.dottedMemberSuggestions(
+            qualifier: "ACCOUNTS_PKG", prefix: "GET",
+            owner: "HR", source: "", tree: nil, offset: 0)
+
+        XCTAssertEqual(items.map(\.displayText), ["GET_BALANCE"])
+    }
+
+    func test_dottedMember_packageQualifier_caseInsensitive() async {
+        // User typed `accounts_pkg.` — the cache stores upper-case names; the
+        // qualifier must be normalised before the lookup.
+        seedAccountsPackageWithObject(owner: "HR")
+
+        let items = await coordinator.dottedMemberSuggestions(
+            qualifier: "accounts_pkg", prefix: "",
+            owner: "HR", source: "", tree: nil, offset: 0)
+
+        XCTAssertFalse(items.isEmpty)
+        XCTAssertTrue(items.contains { $0.displayText == "GET_BALANCE" })
+    }
+
+    func test_dottedMember_unresolvedQualifier_returnsEmpty() async {
+        // No cached schema, no cached package, no cached table by this name —
+        // dotted-member completion should produce nothing rather than dump
+        // the cache.
+        let items = await coordinator.dottedMemberSuggestions(
+            qualifier: "MYSTERY_PKG", prefix: "",
+            owner: "HR", source: "", tree: nil, offset: 0)
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    func test_dottedMember_schemaQualifier_unaffectedByPackageProbe() async {
+        // `HR.` should still list HR's tables/views/packages. The new package
+        // probe runs in parallel; it must not suppress this result.
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "HR", name: "EMPLOYEES", type: "TABLE")
+        addObject(in: ctx, owner: "HR", name: "DEPARTMENTS", type: "TABLE")
+        try! ctx.save()
+
+        let items = await coordinator.dottedMemberSuggestions(
+            qualifier: "HR", prefix: "",
+            owner: "HR", source: "", tree: nil, offset: 0)
+
+        let names = Set(items.map(\.displayText))
+        XCTAssertTrue(names.contains("EMPLOYEES"))
+        XCTAssertTrue(names.contains("DEPARTMENTS"))
+    }
+
+    func test_dottedMember_qualifierIsBothSchemaAndPackage_mergesResults() async {
+        // Edge case: the same identifier names a schema (with at least one
+        // table inside) AND a package in another schema. Showing both kinds
+        // is the pragmatic answer when the analyzer can't disambiguate.
+        let ctx = persistence.container.viewContext
+        // BILLING owns a TABLE called "ACCOUNTS_PKG" (silly but legal).
+        addObject(in: ctx, owner: "ACCOUNTS_PKG", name: "LEDGER", type: "TABLE")
+        try! ctx.save()
+        seedAccountsPackageWithObject(owner: "HR")
+
+        let items = await coordinator.dottedMemberSuggestions(
+            qualifier: "ACCOUNTS_PKG", prefix: "",
+            owner: "HR", source: "", tree: nil, offset: 0)
+
+        let names = Set(items.map(\.displayText))
+        XCTAssertTrue(names.contains("LEDGER"),
+                      "Schema-scoped objects must still surface")
+        XCTAssertTrue(names.contains("GET_BALANCE"),
+                      "Package members must surface alongside schema objects")
+    }
+
+    func test_dottedMember_packageInOtherSchema_resolvesViaPreferredOwner() async {
+        // Package only exists in BILLING; preferred owner is HR. The probe
+        // must still find it via the alphabetical-fallback branch of
+        // resolvePackage.
+        seedAccountsPackageWithObject(owner: "BILLING")
+
+        let items = await coordinator.dottedMemberSuggestions(
+            qualifier: "ACCOUNTS_PKG", prefix: "",
+            owner: "HR", source: "", tree: nil, offset: 0)
+
+        XCTAssertTrue(items.contains { $0.displayText == "GET_BALANCE" })
+    }
+
+    // MARK: - Seed helpers
+
+    /// Adds the same `DBCacheProcedure` / `DBCacheProcedureArgument` rows as
+    /// `CompletionDataSourceTests.seedAccountsPackage`, plus a parent
+    /// `DBCacheObject(type: "PACKAGE")` so `resolvePackage` can find it.
+    private func seedAccountsPackageWithObject(owner: String) {
+        let ctx = persistence.container.viewContext
+
+        let pkgObject = DBCacheObject(context: ctx)
+        pkgObject.owner_ = owner
+        pkgObject.name_ = "ACCOUNTS_PKG"
+        pkgObject.type_ = "PACKAGE"
+
+        addProcedure(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG",
+                     name: nil, subprogramId: 0, overload: nil,
+                     parentType: "PACKAGE")
+        addProcedure(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG",
+                     name: "GET_BALANCE", subprogramId: 1, overload: nil,
+                     parentType: "PACKAGE")
+        addProcedure(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG",
+                     name: "DEBIT", subprogramId: 2, overload: "1",
+                     parentType: "PACKAGE")
+        addProcedure(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG",
+                     name: "DEBIT", subprogramId: 3, overload: "2",
+                     parentType: "PACKAGE")
+
+        addArgument(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 0, sequence: 1, name: nil,
+                    dataType: "NUMBER", inOut: "OUT")
+        addArgument(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG", proc: "GET_BALANCE",
+                    overload: nil, position: 1, sequence: 2, name: "ACCT_ID",
+                    dataType: "NUMBER", inOut: "IN")
+        addArgument(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "1", position: 1, sequence: 1, name: "AMOUNT",
+                    dataType: "NUMBER", inOut: "IN")
+        addArgument(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "2", position: 1, sequence: 1, name: "AMOUNT",
+                    dataType: "NUMBER", inOut: "IN")
+        addArgument(in: ctx, owner: owner, pkg: "ACCOUNTS_PKG", proc: "DEBIT",
+                    overload: "2", position: 2, sequence: 2, name: "CURRENCY",
+                    dataType: "VARCHAR2", inOut: "IN")
+
+        try! ctx.save()
+    }
+
+    private func addObject(in ctx: NSManagedObjectContext,
+                           owner: String, name: String, type: String) {
+        let row = DBCacheObject(context: ctx)
+        row.owner_ = owner
+        row.name_ = name
+        row.type_ = type
+    }
+
+    private func addProcedure(in ctx: NSManagedObjectContext,
+                              owner: String, pkg: String, name: String?,
+                              subprogramId: Int32, overload: String?,
+                              parentType: String) {
+        let row = DBCacheProcedure(context: ctx)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = name
+        row.objectType_ = parentType
+        row.subprogramId = subprogramId
+        row.overload_ = overload
+    }
+
+    private func addArgument(in ctx: NSManagedObjectContext,
+                             owner: String, pkg: String, proc: String,
+                             overload: String?, position: Int16, sequence: Int16,
+                             name: String?, dataType: String, inOut: String) {
+        let row = DBCacheProcedureArgument(context: ctx)
+        row.owner_ = owner
+        row.objectName_ = pkg
+        row.procedureName_ = proc
+        row.overload_ = overload
+        row.position = position
+        row.sequence = sequence
+        row.dataLevel = 0
+        row.argumentName_ = name
+        row.dataType_ = dataType
+        row.inOut_ = inOut
+    }
+}

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -149,6 +149,64 @@ final class CompletionDataSourceTests: XCTestCase {
         XCTAssertTrue(args.allSatisfy { $0.position > 0 })
     }
 
+    // MARK: - Completion: resolvePackage
+
+    func test_resolvePackage_returnsNilWhenNoCachedPackage() async {
+        seedAccountsPackage()
+        // seedAccountsPackage seeds the procedure rows but no parent
+        // DBCacheObject of type PACKAGE — resolvePackage must miss.
+        let resolved = await dataSource.resolvePackage(
+            name: "ACCOUNTS_PKG", preferredOwner: "HR")
+        XCTAssertNil(resolved)
+    }
+
+    func test_resolvePackage_findsByName() async {
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "HR", name: "ACCOUNTS_PKG", type: "PACKAGE")
+        try! ctx.save()
+
+        let resolved = await dataSource.resolvePackage(
+            name: "accounts_pkg", preferredOwner: "HR")
+        XCTAssertEqual(resolved?.owner, "HR")
+        XCTAssertEqual(resolved?.name, "ACCOUNTS_PKG")
+        XCTAssertEqual(resolved?.objectType, "PACKAGE")
+    }
+
+    func test_resolvePackage_ignoresNonPackageObjectsWithSameName() async {
+        // A TABLE with the same identifier as a package must not satisfy a
+        // package lookup. Without this guard a `pkg.` qualifier pointing at
+        // a table would attempt to surface non-existent procedure members.
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "HR", name: "ACCOUNTS_PKG", type: "TABLE")
+        try! ctx.save()
+
+        let resolved = await dataSource.resolvePackage(
+            name: "ACCOUNTS_PKG", preferredOwner: "HR")
+        XCTAssertNil(resolved)
+    }
+
+    func test_resolvePackage_prefersConnectedSchema() async {
+        // Same package name in two schemas — preferred owner wins.
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "BILLING", name: "ACCOUNTS_PKG", type: "PACKAGE")
+        addObject(in: ctx, owner: "HR", name: "ACCOUNTS_PKG", type: "PACKAGE")
+        try! ctx.save()
+
+        let resolved = await dataSource.resolvePackage(
+            name: "ACCOUNTS_PKG", preferredOwner: "HR")
+        XCTAssertEqual(resolved?.owner, "HR")
+    }
+
+    func test_resolvePackage_fallsBackToFirstWhenPreferredAbsent() async {
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "BILLING", name: "ACCOUNTS_PKG", type: "PACKAGE")
+        try! ctx.save()
+
+        let resolved = await dataSource.resolvePackage(
+            name: "ACCOUNTS_PKG", preferredOwner: "HR")
+        XCTAssertEqual(resolved?.owner, "BILLING")
+    }
+
     // MARK: - Quick View: resolveSchemaObject
 
     func test_resolveSchemaObject_explicitOwner_findsExactRow() async {


### PR DESCRIPTION
Phase 1 of #10 — wires cached `DBCacheProcedure` rows into the editor's
dotted-member completion popup so typing `<package>.` surfaces the
package's procedures and functions. Phases 2 (`pkg.proc(` signature
popup) and 3 (standalone procs, multi-overload picker) will land in
separate PRs per the issue's rollout plan.

## What changed

- **`CompletionDataSource.resolvePackage(name:preferredOwner:)`** — new
  actor method that finds a `DBCacheObject` of `type_ = "PACKAGE"`
  matching `name`, with preferred-owner-first ranking and a strict type
  filter so a same-named TABLE can't impersonate a package.
- **`CompletionCoordinator.dottedMemberSuggestions`** — now runs the
  schema-objects probe and a new package-members probe in parallel via
  `async let` and merges results. The two probes can both apply when a
  qualifier collides with a schema name, and the analyzer can't
  disambiguate without semantic resolution — showing both kinds in the
  popup is the pragmatic answer per the issue. Method also relaxed from
  `private → internal` so the new tests can drive it directly.

## Test coverage

`xcodebuild test -scheme Macintora -destination 'platform=macOS'` for
the new and existing completion suites: 46/46 pass.

- **`CompletionDataSourceTests` (+5):** `resolvePackage` returns nil
  when no `DBCacheObject` exists, finds the row case-insensitively,
  ignores same-named non-PACKAGE objects, prefers the connected
  schema, falls back to the alphabetically first match.
- **`CompletionCoordinatorTests` (new, +7):** dotted-member with a
  package qualifier lists members, filters by prefix, is
  case-insensitive, returns empty when the qualifier resolves to
  nothing, leaves schema-qualifier behavior unchanged, merges
  schema-objects + package-members when the qualifier is both, and
  resolves a package whose owner isn't the connected schema.

## Out of scope (deferred to phases 2/3)

- `pkg.proc(` signature / argument popup
- Standalone-procedure call detection
- Multi-overload picker, current-argument-index highlighting
- Composite-type expansion (`dataLevel > 0`)

Closes part of #10 — issue stays open until phases 2 and 3 land.