### PR TITLE
Editor: signature popup on `pkg.proc(` (#10 phase 2)

### DIFF
--- a/Macintora/Editor/Completion/CompletionCoordinator.swift
+++ b/Macintora/Editor/Completion/CompletionCoordinator.swift
@@ -94,6 +94,12 @@ final class CompletionCoordinator: @unchecked Sendable {
                                                  tree: tree,
                                                  offset: offset)
 
+        case .procedureCall(let packageName, let procedureName, let argumentIndex):
+            return await procedureCallSignatures(packageName: packageName,
+                                                 procedureName: procedureName,
+                                                 currentArgumentIndex: argumentIndex,
+                                                 owner: owner)
+
         case .identifierPrefix(let prefix):
             // Soft fallback: if the prefix is non-trivial, surface objects
             // across all cached schemas; the user's connected schema is
@@ -188,7 +194,11 @@ final class CompletionCoordinator: @unchecked Sendable {
 
     private func shouldAutoTrigger(textView: STTextView, replacement: String) -> Bool {
         guard let last = replacement.unicodeScalars.last else { return false }
-        if last == "." { return true }
+        // `.` triggers dotted-member completion; `(` and `,` trigger the
+        // signature popup for the enclosing call. The analyzer is the
+        // authority on whether the cursor is actually inside a call — this
+        // gate just decides whether to fire `complete(_:)` at all.
+        if last == "." || last == "(" || last == "," { return true }
         if SourceScanner.isIdentifierChar(last) {
             // Require at least one identifier character before the cursor to
             // avoid popping for a stray keystroke.
@@ -297,6 +307,62 @@ final class CompletionCoordinator: @unchecked Sendable {
                                                      search: prefix,
                                                      limit: fetchLimit)
         return procedures.map { MacintoraCompletionItem.make(from: $0) }
+    }
+
+    /// Builds one popup row per overload of the call target, with the
+    /// formatted parameter list as the primary text. Phase 2 scope is
+    /// package members only — standalone procedures (no qualifier) are
+    /// deferred to phase 3 and skipped here. The matching-arity overload
+    /// is sorted first as a hint for which signature applies; the user
+    /// can still arrow through the rest.
+    private func procedureCallSignatures(packageName: String?,
+                                         procedureName: String,
+                                         currentArgumentIndex: Int,
+                                         owner: String) async -> [MacintoraCompletionItem] {
+        guard let packageName else {
+            // Phase 3 will resolve the standalone via DBCacheObject lookup.
+            editorCompletionLog.info("procedureCall: standalone procs deferred to phase 3 — skipping")
+            return []
+        }
+        guard let pkg = await dataSource.resolvePackage(name: packageName,
+                                                        preferredOwner: owner) else {
+            editorCompletionLog.info("procedureCall: no cached package for \(packageName, privacy: .public)")
+            return []
+        }
+        // procedures(...) does substring matching; filter the result to
+        // exact-name overloads. Overload count is small (typically 1-3),
+        // so the per-overload argument fetch is cheap.
+        let upperProc = procedureName.uppercased()
+        let allMatches = await dataSource.procedures(packageName: pkg.name,
+                                                     owner: pkg.owner,
+                                                     search: procedureName,
+                                                     limit: fetchLimit)
+        let overloads = allMatches.filter { $0.procedureName == upperProc }
+        guard !overloads.isEmpty else {
+            editorCompletionLog.info("procedureCall: \(pkg.name, privacy: .public).\(upperProc, privacy: .public) not in cache")
+            return []
+        }
+
+        var rendered: [(item: MacintoraCompletionItem, arity: Int)] = []
+        for overload in overloads {
+            let args = await dataSource.procedureArguments(owner: overload.owner,
+                                                           packageName: overload.packageName,
+                                                           procedureName: overload.procedureName,
+                                                           overload: overload.overload)
+            rendered.append((MacintoraCompletionItem.make(signatureFrom: overload, arguments: args),
+                             args.count))
+        }
+        // Bubble matching-arity overloads first; ties retain fetch order.
+        let needed = currentArgumentIndex + 1
+        return rendered
+            .enumerated()
+            .sorted { lhs, rhs in
+                let lhsMatch = lhs.element.arity >= needed
+                let rhsMatch = rhs.element.arity >= needed
+                if lhsMatch != rhsMatch { return lhsMatch && !rhsMatch }
+                return lhs.offset < rhs.offset
+            }
+            .map { $0.element.item }
     }
 
     private func fetchColumns(table: ResolvedTable, prefix: String) async -> [MacintoraCompletionItem] {

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -230,4 +230,44 @@ extension MacintoraCompletionItem {
             secondaryText: secondary,
             kind: kind)
     }
+
+    /// Builds a row that shows the call signature of a single overload —
+    /// `proc(arg1 IN NUMBER, arg2 IN VARCHAR2)`. `insertText` is empty so
+    /// accepting a row is a no-op (it just dismisses the popup); the row's
+    /// purpose is informational while the user types arguments.
+    static func make(signatureFrom p: ProcedureSuggestion,
+                     arguments: [ProcedureArgumentSuggestion]) -> MacintoraCompletionItem {
+        let kind: Kind = p.kind == "FUNCTION" ? .function : .procedure
+        let formattedArgs = arguments.map(formatArgument).joined(separator: ", ")
+        let display = "\(p.procedureName)(\(formattedArgs))"
+        var secondary = p.kind
+        if let overload = p.overload, !overload.isEmpty {
+            secondary += " #\(overload)"
+        }
+        if let returnType = p.returnType, !returnType.isEmpty {
+            secondary += " → \(returnType)"
+        }
+        return MacintoraCompletionItem(
+            displayText: display,
+            insertText: "",
+            secondaryText: secondary,
+            kind: kind)
+    }
+
+    /// Renders one argument like `name IN VARCHAR2` or `name IN NUMBER
+    /// DEFAULT 0`. Anonymous arguments (Oracle ALL_ARGUMENTS allows
+    /// nameless positional params for some bind shapes) fall back to the
+    /// position number.
+    private static func formatArgument(_ arg: ProcedureArgumentSuggestion) -> String {
+        let name = arg.argumentName ?? "arg\(arg.position)"
+        var rendered = "\(name) \(arg.inOut) \(arg.dataType)"
+        if arg.defaulted {
+            if let value = arg.defaultValue, !value.isEmpty {
+                rendered += " DEFAULT \(value)"
+            } else {
+                rendered += " DEFAULT"
+            }
+        }
+        return rendered
+    }
 }

--- a/Macintora/Editor/Completion/SQLContextAnalyzer.swift
+++ b/Macintora/Editor/Completion/SQLContextAnalyzer.swift
@@ -26,6 +26,15 @@ enum CompletionContext: Equatable, Sendable {
     /// alias → table columns, schema → objects (no package members in v1).
     case dottedMember(qualifier: String, prefix: String)
 
+    /// Cursor is inside the argument list of a procedure or function call —
+    /// surface the signature(s) of the call target. `packageName` is nil for
+    /// standalone procedures (phase 3); package members emit a non-nil owner.
+    /// `currentArgumentIndex` is 0-based at the position the user is filling
+    /// (counting top-level commas between the opening `(` and the cursor).
+    case procedureCall(packageName: String?,
+                       procedureName: String,
+                       currentArgumentIndex: Int)
+
     /// No structural cue; just a bare identifier prefix. Used as a soft
     /// fallback (the data source may still surface relevant tables/objects).
     case identifierPrefix(prefix: String)
@@ -58,6 +67,20 @@ struct SQLContextAnalyzer {
 
         if scan.insideStringOrComment {
             return .none
+        }
+
+        // Procedure-call signature takes priority over the dotted-member /
+        // identifier-prefix dispatch, but only when the user has not yet
+        // started typing an argument: an empty prefix means they just hit
+        // `(` or `,`, the moments where the signature is most useful. Once
+        // identifier characters appear, fall through to the regular
+        // column / identifier completion so the user can pick names.
+        if scan.prefix.isEmpty,
+           scan.qualifier == nil,
+           let call = enclosingProcedureCall(source: source, cursor: utf16Offset) {
+            return .procedureCall(packageName: call.packageName,
+                                  procedureName: call.procedureName,
+                                  currentArgumentIndex: call.argumentIndex)
         }
 
         if let qualifier = scan.qualifier {
@@ -140,6 +163,106 @@ struct SQLContextAnalyzer {
             // Continue backwards from before this word.
         }
         return ""
+    }
+
+    // MARK: - Procedure-call detection
+
+    /// Result of walking back from the cursor and identifying the call
+    /// target whose argument list the user is editing.
+    private struct EnclosingCall {
+        let packageName: String?
+        let procedureName: String
+        let argumentIndex: Int
+    }
+
+    /// Walks the source backward from `cursor` looking for an unmatched `(`
+    /// — the opening paren of the call we're nested in. Counts top-level
+    /// commas to derive the current argument index. Returns nil when the
+    /// cursor isn't inside a call's argument list, or the call target
+    /// can't be identified. A `;` aborts the walk: signatures don't span
+    /// statement boundaries.
+    ///
+    /// Limitations (acceptable for v1): pretends string literals don't
+    /// exist. The caller already short-circuits via `insideStringOrComment`
+    /// when the cursor is inside a string, so the typical paths are safe.
+    private func enclosingProcedureCall(source: String, cursor: Int) -> EnclosingCall? {
+        let ns = source as NSString
+        let safe = max(0, min(cursor, ns.length))
+        var depth = 0
+        var argIndex = 0
+        var i = safe
+        while i > 0 {
+            let c = ns.character(at: i - 1)
+            switch c {
+            case 0x29: // ')'
+                depth += 1
+            case 0x28: // '('
+                if depth == 0 {
+                    return readCallTarget(ns: ns,
+                                          openParenIndex: i - 1,
+                                          argumentIndex: argIndex)
+                }
+                depth -= 1
+            case 0x2C: // ','
+                if depth == 0 { argIndex += 1 }
+            case 0x3B: // ';'
+                return nil
+            default:
+                break
+            }
+            i -= 1
+        }
+        return nil
+    }
+
+    /// Reads the identifier (and optional `package.` qualifier) immediately
+    /// preceding the call's open paren. Returns nil when the position
+    /// before the paren isn't a recognisable identifier — e.g.
+    /// parenthesised expressions like `(a + b) * 2` where the paren has no
+    /// callable name in front of it.
+    private func readCallTarget(ns: NSString,
+                                openParenIndex: Int,
+                                argumentIndex: Int) -> EnclosingCall? {
+        var i = openParenIndex
+        // Skip whitespace between the name and the paren.
+        while i > 0 {
+            let c = ns.character(at: i - 1)
+            if c == 0x20 || c == 0x09 || c == 0x0A || c == 0x0D {
+                i -= 1
+            } else {
+                break
+            }
+        }
+        let procEnd = i
+        var procStart = procEnd
+        while procStart > 0 {
+            let c = ns.character(at: procStart - 1)
+            guard let scalar = Unicode.Scalar(c),
+                  SourceScanner.isIdentifierChar(scalar) else { break }
+            procStart -= 1
+        }
+        guard procStart < procEnd else { return nil }
+        let procName = ns.substring(with: NSRange(location: procStart,
+                                                  length: procEnd - procStart))
+
+        var packageName: String?
+        if procStart > 0, ns.character(at: procStart - 1) == 0x2E /* '.' */ {
+            let qualEnd = procStart - 1
+            var qualStart = qualEnd
+            while qualStart > 0 {
+                let c = ns.character(at: qualStart - 1)
+                guard let scalar = Unicode.Scalar(c),
+                      SourceScanner.isIdentifierChar(scalar) else { break }
+                qualStart -= 1
+            }
+            if qualStart < qualEnd {
+                packageName = ns.substring(with: NSRange(location: qualStart,
+                                                         length: qualEnd - qualStart))
+            }
+        }
+        return EnclosingCall(packageName: packageName,
+                             procedureName: procName,
+                             argumentIndex: argumentIndex)
     }
 
     // MARK: - Tree walk

--- a/MacintoraTests/Editor/Completion/CompletionCoordinatorTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionCoordinatorTests.swift
@@ -11,6 +11,7 @@
 
 import XCTest
 import CoreData
+import STTextView
 @testable import Macintora
 
 @MainActor
@@ -138,7 +139,73 @@ final class CompletionCoordinatorTests: XCTestCase {
         XCTAssertTrue(items.contains { $0.displayText == "GET_BALANCE" })
     }
 
+    // MARK: - Phase 2: signature popup on `pkg.proc(`
+
+    func test_procedureCall_packageMember_listsAllOverloadsWithSignature() async {
+        seedAccountsPackageWithObject(owner: "HR")
+        let items = await coordinator.items(for: makeTextView("BEGIN accounts_pkg.debit("),
+                                            atUTF16Offset: "BEGIN accounts_pkg.debit(".utf16.count)
+
+        // Both DEBIT overloads must appear, formatted as call signatures.
+        let display = items.map(\.displayText)
+        XCTAssertTrue(display.contains { $0 == "DEBIT(AMOUNT IN NUMBER)" })
+        XCTAssertTrue(display.contains { $0 == "DEBIT(AMOUNT IN NUMBER, CURRENCY IN VARCHAR2)" })
+        XCTAssertTrue(items.allSatisfy { $0.insertText.isEmpty },
+                      "Signature rows are informational — accepting one must be a no-op")
+    }
+
+    func test_procedureCall_function_signatureCarriesReturnType() async {
+        seedAccountsPackageWithObject(owner: "HR")
+        let items = await coordinator.items(for: makeTextView("BEGIN accounts_pkg.get_balance("),
+                                            atUTF16Offset: "BEGIN accounts_pkg.get_balance(".utf16.count)
+
+        let row = items.first { $0.displayText == "GET_BALANCE(ACCT_ID IN NUMBER)" }
+        XCTAssertNotNil(row, "Function signature must surface")
+        XCTAssertTrue(row?.secondaryText?.contains("→ NUMBER") ?? false,
+                      "Function row must show the return type hint")
+    }
+
+    func test_procedureCall_arityMatchingOverloadComesFirst() async {
+        seedAccountsPackageWithObject(owner: "HR")
+        // Cursor is positioned for the second argument — the matching
+        // overload (two parameters) must rank ahead of the single-arg one.
+        let source = "BEGIN accounts_pkg.debit(100, "
+        let items = await coordinator.items(for: makeTextView(source),
+                                            atUTF16Offset: source.utf16.count)
+
+        let display = items.map(\.displayText)
+        XCTAssertEqual(display.first, "DEBIT(AMOUNT IN NUMBER, CURRENCY IN VARCHAR2)",
+                       "Two-arg overload must lead when the user is filling the second slot")
+    }
+
+    func test_procedureCall_unknownPackage_returnsEmpty() async {
+        // No cache entries — the popup should produce nothing rather than
+        // dump unrelated suggestions.
+        let source = "BEGIN unknown_pkg.foo("
+        let items = await coordinator.items(for: makeTextView(source),
+                                            atUTF16Offset: source.utf16.count)
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    func test_procedureCall_standalone_skippedInPhase2() async {
+        // No qualifier → analyzer routes to .procedureCall(packageName: nil)
+        // and the coordinator currently no-ops; phase 3 will surface the
+        // standalone signature.
+        seedAccountsPackageWithObject(owner: "HR")
+        let source = "BEGIN debit("
+        let items = await coordinator.items(for: makeTextView(source),
+                                            atUTF16Offset: source.utf16.count)
+        XCTAssertTrue(items.isEmpty)
+    }
+
     // MARK: - Seed helpers
+
+    private func makeTextView(_ source: String) -> STTextView {
+        let view = STTextView()
+        view.text = source
+        return view
+    }
+
 
     /// Adds the same `DBCacheProcedure` / `DBCacheProcedureArgument` rows as
     /// `CompletionDataSourceTests.seedAccountsPackage`, plus a parent

--- a/MacintoraTests/Editor/Completion/SQLContextAnalyzerTests.swift
+++ b/MacintoraTests/Editor/Completion/SQLContextAnalyzerTests.swift
@@ -81,6 +81,101 @@ final class SQLContextAnalyzerTests: XCTestCase {
         XCTAssertEqual(context, .none)
     }
 
+    // MARK: - Procedure call (signature popup)
+
+    func test_procedureCall_packageMember_emptyArgList() {
+        let source = "BEGIN accounts_pkg.debit("
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(context,
+                       .procedureCall(packageName: "accounts_pkg",
+                                      procedureName: "debit",
+                                      currentArgumentIndex: 0))
+    }
+
+    func test_procedureCall_afterFirstComma_indexAdvances() {
+        let source = "BEGIN accounts_pkg.debit(100, "
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(context,
+                       .procedureCall(packageName: "accounts_pkg",
+                                      procedureName: "debit",
+                                      currentArgumentIndex: 1))
+    }
+
+    func test_procedureCall_skipsNestedParens() {
+        // Nested call's args/commas must not perturb the outer index.
+        let source = "BEGIN accounts_pkg.debit(get_amount(100, 200), "
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(context,
+                       .procedureCall(packageName: "accounts_pkg",
+                                      procedureName: "debit",
+                                      currentArgumentIndex: 1))
+    }
+
+    func test_procedureCall_standalone_noPackageQualifier() {
+        // Phase 3 lifts this case to surfacing in the popup; the analyzer
+        // already classifies it correctly with packageName == nil.
+        let source = "BEGIN purge_old("
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        XCTAssertEqual(context,
+                       .procedureCall(packageName: nil,
+                                      procedureName: "purge_old",
+                                      currentArgumentIndex: 0))
+    }
+
+    func test_procedureCall_partialArgPrefix_fallsThroughToIdentifier() {
+        // Once the user starts typing an argument identifier, the regular
+        // completion should take over so they can pick column / variable
+        // names rather than the signature row.
+        let source = "BEGIN accounts_pkg.debit(am"
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        switch context {
+        case .columnReference(_, let prefix), .identifierPrefix(let prefix):
+            XCTAssertEqual(prefix, "am")
+        default:
+            XCTFail("expected identifier-flavoured context, got \(context)")
+        }
+    }
+
+    func test_procedureCall_dottedArgument_routesToDottedMember() {
+        // Inside the call but typing a qualified reference — the dotted
+        // member branch wins. Tests that the procedure-call probe doesn't
+        // swallow legitimate dotted-member contexts.
+        let source = "BEGIN accounts_pkg.debit(emp."
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        if case .dottedMember(let qualifier, let prefix) = context {
+            XCTAssertEqual(qualifier, "emp")
+            XCTAssertEqual(prefix, "")
+        } else {
+            XCTFail("expected dottedMember, got \(context)")
+        }
+    }
+
+    func test_procedureCall_outsideAnyCall_returnsIdentifier() {
+        // No enclosing `(` — must not invent one.
+        let source = "SELECT "
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        switch context {
+        case .columnReference, .identifierPrefix, .afterFromKeyword:
+            break
+        default:
+            XCTFail("expected fallthrough context, got \(context)")
+        }
+    }
+
+    func test_procedureCall_statementBoundary_abortsWalk() {
+        // A `;` between `(` and the cursor means the call isn't really
+        // open; the walk should abort rather than reach back into the
+        // previous statement.
+        let source = "accounts_pkg.debit(100); BEGIN "
+        let context = SQLContextAnalyzer.parseAndAnalyze(source, utf16Offset: source.utf16.count)
+        switch context {
+        case .procedureCall:
+            XCTFail("statement boundary must terminate the call walk")
+        default:
+            break
+        }
+    }
+
     // MARK: - ERROR-node fallback (mid-typing tolerance)
 
     func test_brokenSyntax_stillReturnsContext() {


### PR DESCRIPTION
Phase 2 of #10. Stacks on top of #17 (phase 1) — base branch is set to
`fix/issue-10-package-member-completion`; please merge #17 first so
GitHub re-targets this PR's base to `main`.

## What changed

- **`SQLContextAnalyzer`** — new `CompletionContext.procedureCall(packageName, procedureName, currentArgumentIndex)` plus an `enclosingProcedureCall(...)` backward-scanner that walks through nested parens/commas to identify the enclosing call. A `;` aborts the walk so signatures don't span statement boundaries. The probe runs only when the user has no in-progress identifier prefix (i.e. they just hit `(` or `,`); once they start typing an argument, the regular column/identifier completion takes over.
- **`CompletionCoordinator`** — routes `.procedureCall` to a new helper that resolves the package via `resolvePackage(...)`, fetches all overloads (filtered to exact-name matches), pulls each overload's arguments via `procedureArguments(...)`, and renders one popup row per overload. Arity-matching overloads sort first. `(` and `,` added to `shouldAutoTrigger` so the popup appears automatically.
- **`MacintoraCompletionItem.make(signatureFrom:arguments:)`** — new factory that formats `proc(arg1 IN NUMBER DEFAULT 0, arg2 IN VARCHAR2)` for primary text and `PROCEDURE #2 → NUMBER` for secondary. `insertText` is empty — the rows are informational, accepting one just dismisses the popup.

## Test coverage

`xcodebuild test -scheme Macintora -destination 'platform=macOS'` for the four completion suites: 78/78 pass.

- **`SQLContextAnalyzerTests` (+9):** package-member call with empty arg list, arg index advances after first `,`, nested parens don't perturb the outer index, standalone-call shape (packageName == nil), partial-arg prefix falls through to identifier completion, dotted argument routes to `dottedMember`, no enclosing `(` returns identifier context, `;` aborts the walk.
- **`CompletionCoordinatorTests` (+5):** lists all overloads with formatted signatures, function row carries `→ returnType`, arity-matching overload comes first, unknown package returns empty, standalone is no-op'd in phase 2.

## Out of scope (deferred to phase 3)

- Standalone procedures / functions at top level (`proc(`).
- Persistent cursor-tracking signature tooltip — the v1 popup uses the existing completion popup as the host.
- Per-argument highlighting beyond arity-based sort.
- Composite-type expansion for `dataLevel > 0` rows.

Issue #10 stays open until phase 3 lands.