### PR TITLE
Fix #14: detect anonymous PL/SQL blocks on Cmd+R

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -130,6 +130,8 @@
 		49C62C1C27DD7BAF00DE69E4 /* MainDocumentVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */; };
 		49C62C2427E010AE00DE69E4 /* ConnectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */; };
 		49CE5FF027279F3A009C2A94 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CE5FEF27279F3A009C2A94 /* ResultView.swift */; };
+		49141400000000000000A002 /* PlsqlBlockDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49141400000000000000A001 /* PlsqlBlockDetector.swift */; };
+		49141400000000000000A004 /* PlsqlBlockDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49141400000000000000A003 /* PlsqlBlockDetectorTests.swift */; };
 		49D0ECEB2F9C1D970047540A /* EditorSelectionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEA2F9C1D970047540A /* EditorSelectionBridge.swift */; };
 		49D0ECED2F9C1D9D0047540A /* EditorLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */; };
 		49D0ECEF2F9C1DB20047540A /* MacintoraEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */; };
@@ -332,6 +334,8 @@
 		49C62C1B27DD7BAF00DE69E4 /* MainDocumentVM.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentVM.swift; sourceTree = "<group>"; };
 		49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionListView.swift; sourceTree = "<group>"; };
 		49CE5FEF27279F3A009C2A94 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
+		49141400000000000000A001 /* PlsqlBlockDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlsqlBlockDetector.swift; sourceTree = "<group>"; };
+		49141400000000000000A003 /* PlsqlBlockDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlsqlBlockDetectorTests.swift; sourceTree = "<group>"; };
 		49D0ECEA2F9C1D970047540A /* EditorSelectionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSelectionBridge.swift; sourceTree = "<group>"; };
 		49D0ECEC2F9C1D9D0047540A /* EditorLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLanguage.swift; sourceTree = "<group>"; };
 		49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacintoraEditor.swift; sourceTree = "<group>"; };
@@ -722,6 +726,7 @@
 				49D0ECEE2F9C1DB20047540A /* MacintoraEditor.swift */,
 				49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */,
 				49C0000700000007 /* MacintoraEditor+Completion.swift */,
+				49141400000000000000A001 /* PlsqlBlockDetector.swift */,
 				49C0200000000000 /* Completion */,
 				49DB000D0000000D /* Plugins */,
 			);
@@ -733,6 +738,7 @@
 			children = (
 				49D0ECF32F9C1E1E0047540A /* EditorSelectionBridgeTests.swift */,
 				49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */,
+				49141400000000000000A003 /* PlsqlBlockDetectorTests.swift */,
 				49C0300000000010 /* Completion */,
 				49DB001E0000001E /* Plugins */,
 			);
@@ -972,6 +978,7 @@
 				AA0000C00000000000000000 /* LegacyDocumentMigrationTests.swift in Sources */,
 				AA0000F00000000000000000 /* FullRefreshReproTests.swift in Sources */,
 				49D0ECF62F9C1EB90047540A /* GetCurrentSqlTests.swift in Sources */,
+				49141400000000000000A004 /* PlsqlBlockDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1088,6 +1095,7 @@
 				49D0ECEB2F9C1D970047540A /* EditorSelectionBridge.swift in Sources */,
 				49D0ED202F9C40000047540A /* EditorTheme.swift in Sources */,
 				49D0ECEF2F9C1DB20047540A /* MacintoraEditor.swift in Sources */,
+				49141400000000000000A002 /* PlsqlBlockDetector.swift in Sources */,
 				49C0100100000001 /* SQLTreeStore.swift in Sources */,
 				49C0100200000002 /* SQLContextAnalyzer.swift in Sources */,
 				49C0100300000003 /* AliasResolver.swift in Sources */,

--- a/Macintora/Editor/PlsqlBlockDetector.swift
+++ b/Macintora/Editor/PlsqlBlockDetector.swift
@@ -1,0 +1,217 @@
+// PlsqlBlockDetector.swift
+// Detects PL/SQL anonymous blocks (BEGIN…END; / DECLARE…BEGIN…END;)
+// at the cursor position for the Run action (fixes issue #14).
+
+import Foundation
+
+// MARK: - Public API
+
+enum PlsqlBlockDetector {
+
+    /// Returns the outermost PL/SQL anonymous block SQL text that contains
+    /// `cursor` in `text`. Any trailing `/` terminator line is NOT included.
+    /// Returns `nil` if the cursor is not inside such a block.
+    static func plsqlAnonBlockSQL(at cursor: String.Index, in text: String) -> String? {
+        let blocks = findAllPlsqlAnonBlocks(in: text)
+        let containing = blocks.filter { $0.lowerBound <= cursor && cursor < $0.upperBound }
+        // Outermost = earliest start; break ties with largest range (latest end).
+        guard let outermost = containing.min(by: { lhs, rhs in
+            if lhs.lowerBound != rhs.lowerBound { return lhs.lowerBound < rhs.lowerBound }
+            return lhs.upperBound > rhs.upperBound
+        }) else { return nil }
+        return String(text[outermost])
+    }
+
+    /// Returns the ranges of all outermost anonymous PL/SQL blocks found in
+    /// `text`. Each range spans from the optional `DECLARE` keyword (or `BEGIN`)
+    /// through the `;` of the matching `END`. Trailing `/` lines are excluded.
+    static func findAllPlsqlAnonBlocks(in text: String) -> [Range<String.Index>] {
+        let tokens = collectBlockTokens(in: text)
+
+        // Pass 1: collect (begin, end) pairs at outermost depth only.
+        var pairs: [(beginIdx: Int, endIdx: Int)] = []
+        var stack: [Int] = []
+        for (idx, token) in tokens.enumerated() {
+            switch token.kind {
+            case .begin:
+                stack.append(idx)
+            case .end:
+                guard let beginIdx = stack.popLast() else { break }
+                if stack.isEmpty {
+                    pairs.append((beginIdx: beginIdx, endIdx: idx))
+                }
+            default:
+                break
+            }
+        }
+
+        // Pass 2: for each pair, find the DECLARE that precedes the BEGIN
+        // (scanning backward through any nested subprogram bodies), then build
+        // the block range.
+        var result: [Range<String.Index>] = []
+        for pair in pairs {
+            guard let semiPos = findSemicolon(after: tokens[pair.endIdx].range.upperBound,
+                                              in: text) else { continue }
+            let blockEnd = text.index(after: semiPos)
+            let declareIdx = findAssociatedDeclare(before: pair.beginIdx, in: tokens)
+            let blockStart = declareIdx.map { tokens[$0].range.lowerBound }
+                           ?? tokens[pair.beginIdx].range.lowerBound
+            result.append(blockStart..<blockEnd)
+        }
+        return result
+    }
+}
+
+// MARK: - Token types (file-private)
+
+private enum BlockTokenKind {
+    case begin, end, endControl, declare
+}
+
+private struct BlockToken {
+    let kind: BlockTokenKind
+    let range: Range<String.Index>
+}
+
+// MARK: - Tokenizer
+
+/// Walks `text` and returns only the block-structuring keywords:
+/// BEGIN, DECLARE, END, END IF, END LOOP, END CASE.
+/// Strings, comments, and quoted identifiers are skipped.
+private func collectBlockTokens(in text: String) -> [BlockToken] {
+    var tokens: [BlockToken] = []
+    var i = text.startIndex
+
+    while i < text.endIndex {
+        let c = text[i]
+
+        // Line comment: -- … \n
+        if c == "-" {
+            let next = text.index(after: i)
+            if next < text.endIndex, text[next] == "-" {
+                while i < text.endIndex, text[i] != "\n" { i = text.index(after: i) }
+                continue
+            }
+        }
+
+        // Block comment: /* … */
+        if c == "/" {
+            let next = text.index(after: i)
+            if next < text.endIndex, text[next] == "*" {
+                i = text.index(i, offsetBy: 2, limitedBy: text.endIndex) ?? text.endIndex
+                while i < text.endIndex {
+                    if text[i] == "*" {
+                        let n = text.index(after: i)
+                        if n < text.endIndex, text[n] == "/" {
+                            i = text.index(i, offsetBy: 2, limitedBy: text.endIndex) ?? text.endIndex
+                            break
+                        }
+                    }
+                    i = text.index(after: i)
+                }
+                continue
+            }
+        }
+
+        // Single-quoted string: '…' with '' escapes
+        if c == "'" {
+            i = text.index(after: i)
+            while i < text.endIndex {
+                if text[i] == "'" {
+                    i = text.index(after: i)
+                    if i < text.endIndex, text[i] == "'" { i = text.index(after: i); continue }
+                    break
+                }
+                i = text.index(after: i)
+            }
+            continue
+        }
+
+        // Quoted identifier: "…"
+        if c == "\"" {
+            i = text.index(after: i)
+            while i < text.endIndex, text[i] != "\"" { i = text.index(after: i) }
+            if i < text.endIndex { i = text.index(after: i) }
+            continue
+        }
+
+        // Skip non-identifier-starting characters
+        if !c.isLetter, c != "_" { i = text.index(after: i); continue }
+
+        // Read identifier
+        let wordStart = i
+        while i < text.endIndex, text[i].isLetter || text[i].isNumber || text[i] == "_" {
+            i = text.index(after: i)
+        }
+        let wordRange = wordStart..<i
+        let word = text[wordRange].uppercased()
+
+        switch word {
+        case "BEGIN":
+            tokens.append(BlockToken(kind: .begin, range: wordRange))
+
+        case "DECLARE":
+            tokens.append(BlockToken(kind: .declare, range: wordRange))
+
+        case "END":
+            // Peek at next non-space word to distinguish END IF/LOOP/CASE
+            var j = i
+            while j < text.endIndex, text[j] == " " || text[j] == "\t" { j = text.index(after: j) }
+            let nwStart = j
+            while j < text.endIndex, text[j].isLetter { j = text.index(after: j) }
+            let nextWord = text[nwStart..<j].uppercased()
+            let isControl = nextWord == "IF" || nextWord == "LOOP" || nextWord == "CASE"
+            tokens.append(BlockToken(kind: isControl ? .endControl : .end, range: wordRange))
+
+        default:
+            break
+        }
+    }
+    return tokens
+}
+
+// MARK: - Helpers
+
+/// Scans forward from `start`, skipping whitespace and identifier characters
+/// (an optional block label after `END`), and returns the index of the first
+/// `;`. Returns `nil` if a non-matching character is encountered first.
+private func findSemicolon(after start: String.Index, in text: String) -> String.Index? {
+    var i = start
+    while i < text.endIndex {
+        let c = text[i]
+        if c == ";" { return i }
+        if c.isWhitespace || c.isLetter || c.isNumber || c == "_" {
+            i = text.index(after: i)
+        } else {
+            return nil
+        }
+    }
+    return nil
+}
+
+/// Scans backward from `beginIdx - 1` through `tokens`, looking for a
+/// `DECLARE` at nesting depth 0. Depth is maintained by counting:
+///   `END` → depth++,  `BEGIN` (at depth > 0) → depth--.
+/// If a `BEGIN` at depth 0 is encountered first, returns `nil` (no DECLARE).
+private func findAssociatedDeclare(before beginIdx: Int, in tokens: [BlockToken]) -> Int? {
+    var bwDepth = 0
+    var t = beginIdx - 1
+    while t >= 0 {
+        switch tokens[t].kind {
+        case .end:
+            bwDepth += 1
+        case .begin:
+            if bwDepth > 0 {
+                bwDepth -= 1
+            } else {
+                return nil
+            }
+        case .declare:
+            if bwDepth == 0 { return t }
+        case .endControl:
+            break
+        }
+        t -= 1
+    }
+    return nil
+}

--- a/Macintora/MainApp/MainDocumentVM.swift
+++ b/Macintora/MainApp/MainDocumentVM.swift
@@ -407,6 +407,15 @@ from dual;\n\n
         if editorSelectionRange.lowerBound != editorSelectionRange.upperBound {
             ret = String(model.text[editorSelectionRange]).trimmingCharacters(in: ["\n"])
         } else {
+            let cursor = editorSelectionRange.lowerBound
+
+            // PL/SQL anonymous block detection (issue #14):
+            // If the caret is inside BEGIN…END; (optionally preceded by DECLARE),
+            // return the whole block. The `/` terminator is excluded by the detector.
+            if let blockSQL = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: model.text) {
+                return blockSQL
+            }
+
             var firstIndex = model.text.startIndex
             var lastIndex = model.text.endIndex
             var currentIndex = editorSelectionRange.lowerBound

--- a/MacintoraTests/Editor/PlsqlBlockDetectorTests.swift
+++ b/MacintoraTests/Editor/PlsqlBlockDetectorTests.swift
@@ -1,0 +1,238 @@
+// PlsqlBlockDetectorTests.swift
+// Tests for PlsqlBlockDetector and the PL/SQL anonymous block path in
+// MainDocumentVM.getCurrentSql (issue #14).
+
+import XCTest
+@testable import Macintora
+
+// MARK: - PlsqlBlockDetector unit tests
+
+final class PlsqlBlockDetectorTests: XCTestCase {
+
+    // MARK: - Simple BEGIN...END;
+
+    func test_simpleBlock_cursorInside_returnsBlock() {
+        let sql = "begin\nnull;\nend;"
+        let cursor = sql.range(of: "null")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, "begin\nnull;\nend;")
+    }
+
+    func test_simpleBlock_cursorOnFirstLine_returnsBlock() {
+        let sql = "begin\nnull;\nend;"
+        let cursor = sql.startIndex  // on 'b' of begin
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, "begin\nnull;\nend;")
+    }
+
+    func test_simpleBlock_cursorOnLastLinBeforeEnd_returnsBlock() {
+        let sql = "begin\nnull;\nend;"
+        let cursor = sql.range(of: "end")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, "begin\nnull;\nend;")
+    }
+
+    // MARK: - DECLARE...BEGIN...END;
+
+    func test_declareBlock_cursorInside_returnsFullBlock() {
+        let sql = "declare\n  x number;\nbegin\n  null;\nend;"
+        let cursor = sql.range(of: "null")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    func test_declareBlock_cursorOnDeclareLine_returnsFullBlock() {
+        let sql = "declare\n  x number;\nbegin\n  null;\nend;"
+        let cursor = sql.startIndex
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    func test_declareBlock_cursorOnBeginLine_returnsFullBlock() {
+        let sql = "declare\n  x number;\nbegin\n  null;\nend;"
+        let cursor = sql.range(of: "begin")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    // MARK: - Trailing `/` terminator
+
+    func test_trailingSlash_isStripped() {
+        // The `/` line must NOT be included in the returned SQL.
+        let sql = "begin\nnull;\nend;\n/"
+        let cursor = sql.range(of: "null")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        // Range ends after `end;`, before `\n/`
+        XCTAssertEqual(result, "begin\nnull;\nend;")
+    }
+
+    func test_trailingSlashWithWhitespace_isStripped() {
+        let sql = "begin\nnull;\nend;\n /\n"
+        let cursor = sql.range(of: "null")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, "begin\nnull;\nend;")
+    }
+
+    func test_noTrailingSlash_returnsBlockAsIs() {
+        let sql = "begin\nnull;\nend;\n\nselect 1 from dual;"
+        let cursor = sql.range(of: "null")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, "begin\nnull;\nend;")
+    }
+
+    // MARK: - Nested BEGIN...END;
+
+    func test_nestedBlock_cursorInInner_returnsOuterBlock() {
+        let sql = "begin\n  begin\n    null;\n  end;\nend;"
+        let cursor = sql.range(of: "null")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    func test_nestedBlock_cursorInOuterBeforeInner_returnsOuterBlock() {
+        let sql = "begin\n  dbms_output.put_line('a');\n  begin\n    null;\n  end;\nend;"
+        let cursor = sql.range(of: "dbms")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    func test_nestedBlock_cursorInOuterAfterInner_returnsOuterBlock() {
+        let sql = "begin\n  begin\n    null;\n  end;\n  dbms_output.put_line('b');\nend;"
+        let cursor = sql.range(of: "dbms")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    // MARK: - Cursor on blank line inside block
+
+    func test_blankLineInsideBlock_returnsBlock() {
+        let sql = "begin\n\n  null;\n\nend;"
+        // Position cursor on the first blank line (after the first '\n')
+        let cursor = sql.index(after: sql.startIndex)  // '\n' after 'begin'
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    // MARK: - Cursor NOT inside any block → nil
+
+    func test_regularSQL_returnsNil() {
+        let sql = "select 1 from dual"
+        let cursor = sql.range(of: "from")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertNil(result)
+    }
+
+    func test_cursorAfterBlock_returnsNil() {
+        let sql = "begin\nnull;\nend;\nselect 1 from dual"
+        let cursor = sql.range(of: "select")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertNil(result)
+    }
+
+    func test_emptyText_returnsNil() {
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: "".startIndex, in: "")
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Block inside string or comment does not match
+
+    func test_beginInsideString_notRecognized() {
+        // 'begin' in a string literal must not be treated as a block keyword.
+        let sql = "select 'begin' from dual"
+        let cursor = sql.range(of: "select")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertNil(result)
+    }
+
+    func test_beginInsideLineComment_notRecognized() {
+        let sql = "-- begin\nselect 1 from dual"
+        let cursor = sql.range(of: "select")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Multiple blocks in file; cursor in second
+
+    func test_twoBlocks_cursorInSecond_returnsSecondBlock() {
+        let sql = "begin\n  null;\nend;\nbegin\n  null;\nend;"
+        // The second `null` occurrence
+        let firstNull = sql.range(of: "null")!
+        let secondNull = sql.range(of: "null", range: firstNull.upperBound..<sql.endIndex)!
+        let cursor = secondNull.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, "begin\n  null;\nend;")
+    }
+
+    // MARK: - END IF / END LOOP do not close a BEGIN
+
+    func test_ifInsideBlock_notMistakenForBlockEnd() {
+        let sql = "begin\n  if true then\n    null;\n  end if;\nend;"
+        let cursor = sql.range(of: "null")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+
+    func test_loopInsideBlock_notMistakenForBlockEnd() {
+        let sql = "begin\n  loop\n    exit;\n  end loop;\nend;"
+        let cursor = sql.range(of: "exit")!.lowerBound
+        let result = PlsqlBlockDetector.plsqlAnonBlockSQL(at: cursor, in: sql)
+        XCTAssertEqual(result, sql)
+    }
+}
+
+// MARK: - Integration: getCurrentSql PL/SQL path
+
+@MainActor
+final class GetCurrentSqlPlsqlTests: XCTestCase {
+
+    // MARK: - Basic anonymous block
+
+    func test_getCurrentSql_caretInAnonBlock_returnsFullBlock() {
+        let sql = "begin\nnull;\nend;\n"
+        let doc = MainDocumentVM(text: sql)
+        let cursor = sql.range(of: "null")!.lowerBound
+        XCTAssertEqual(doc.getCurrentSql(for: cursor..<cursor), "begin\nnull;\nend;")
+    }
+
+    func test_getCurrentSql_caretInDeclareBlock_returnsFullBlock() {
+        let sql = "declare\n  x number := 1;\nbegin\n  null;\nend;\n"
+        let doc = MainDocumentVM(text: sql)
+        let cursor = sql.range(of: "null")!.lowerBound
+        XCTAssertEqual(doc.getCurrentSql(for: cursor..<cursor),
+                       "declare\n  x number := 1;\nbegin\n  null;\nend;")
+    }
+
+    func test_getCurrentSql_anonBlockWithTrailingSlash_slashStripped() {
+        let sql = "begin\nnull;\nend;\n/\n"
+        let doc = MainDocumentVM(text: sql)
+        let cursor = sql.range(of: "null")!.lowerBound
+        XCTAssertEqual(doc.getCurrentSql(for: cursor..<cursor), "begin\nnull;\nend;")
+    }
+
+    // MARK: - Regression: regular SQL still works
+
+    func test_getCurrentSql_regularSQL_notBrokenByPlsqlCheck() {
+        let sql = "select 1 from dual;\n"
+        let doc = MainDocumentVM(text: sql)
+        let cursor = sql.range(of: "from")!.lowerBound
+        // Existing behaviour: trailing ; stripped
+        XCTAssertEqual(doc.getCurrentSql(for: cursor..<cursor), "select 1 from dual")
+    }
+
+    func test_getCurrentSql_twoStatements_caretInSecond_returnsSecond() {
+        let sql = "select 1 from dual;\nselect 2 from dual;\n"
+        let doc = MainDocumentVM(text: sql)
+        let cursor = sql.range(of: "select 2")!.lowerBound
+        XCTAssertEqual(doc.getCurrentSql(for: cursor..<cursor), "select 2 from dual")
+    }
+
+    // MARK: - Nested block
+
+    func test_getCurrentSql_nestedBlock_caretInInner_returnsOuterBlock() {
+        let sql = "begin\n  begin\n    null;\n  end;\nend;\n"
+        let doc = MainDocumentVM(text: sql)
+        let cursor = sql.range(of: "null")!.lowerBound
+        XCTAssertEqual(doc.getCurrentSql(for: cursor..<cursor),
+                       "begin\n  begin\n    null;\n  end;\nend;")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PlsqlBlockDetector` — a pure-Swift forward scanner (`Macintora/Editor/PlsqlBlockDetector.swift`) that locates the outermost `BEGIN…END;` anonymous block (optionally preceded by `DECLARE`) enclosing the cursor.
- Integrates the detector as the first check inside `MainDocumentVM.getCurrentSql(for:)`: when the caret is inside an anonymous PL/SQL block the whole block is returned, the trailing `/` terminator is automatically excluded, and the existing semicolon-based splitter is not reached.
- No forked dependencies were modified.

## How it works

`PlsqlBlockDetector.findAllPlsqlAnonBlocks(in:)` does two passes over a lightweight keyword-token list (skips strings, comments, quoted identifiers):

1. **Forward pass** — pairs every outermost `BEGIN` with its matching `END` using a depth stack (only `END` bare — not `END IF` / `END LOOP` / `END CASE` — decrements depth).
2. **Backward DECLARE search** — for each pair, scans backward through the token list to find a `DECLARE` at nesting depth 0, correctly skipping over any nested subprogram bodies in the declaration section.

The block range ends just after the `;` of `END;`, so the `/` line is never included.
`plsqlAnonBlockSQL(at:in:)` selects the outermost containing block (earliest start; in case of a tie, largest range).

## Test coverage

**`PlsqlBlockDetectorTests`** (unit, via `@testable import Macintora`):
- Simple `begin…end;` — cursor inside, on first line, on last line before `end`
- `declare…begin…end;` — cursor inside, on `declare` line, on `begin` line
- Trailing `/` stripped
- Trailing `/ ` (with whitespace) stripped
- No trailing `/` — works correctly
- Nested `begin…end;` — cursor in inner block returns outer block
- Cursor before inner block / after inner block (still in outer)
- Cursor on blank line inside block
- Regular SQL → `nil` (no false positive)
- Cursor after block → `nil`
- Empty text → `nil`
- `BEGIN` inside string literal → not recognized
- `BEGIN` inside line comment → not recognized
- Two consecutive blocks — cursor in second returns second block
- `END IF` / `END LOOP` inside block — not mistaken for block end

**`GetCurrentSqlPlsqlTests`** (integration through `MainDocumentVM.getCurrentSql`):
- Caret in anonymous block returns full block (no `;` stripped — correct for PL/SQL)
- Caret in `DECLARE` block returns full block
- Trailing `/` stripped
- **Regression**: plain `SELECT` still works as before
- **Regression**: two `SELECT` statements, caret in second
- Nested block, caret in inner → outer block returned

> **Note:** `xcodebuild` is not available in the build environment used for this PR. The tests were verified correct by manual code review and trace-through of all cases. Please run `xcodebuild test -scheme Macintora -destination 'platform=macOS'` locally to confirm green.

Closes #14

https://claude.ai/code/session_01NV1QKApvSZgf3DAQLbU8Db

---
_Generated by [Claude Code](https://claude.ai/code/session_01NV1QKApvSZgf3DAQLbU8Db)_