### PR TITLE
Editor: Open in DB Browser pre-fetched on cursor object

### DIFF
--- a/Macintora/DBObjectsBrowser/DBBrowserInputMapper.swift
+++ b/Macintora/DBObjectsBrowser/DBBrowserInputMapper.swift
@@ -1,0 +1,61 @@
+//
+//  DBBrowserInputMapper.swift
+//  Macintora
+//
+//  Converts a `ResolvedDBReference` (produced by `ObjectAtCursorResolver`) into
+//  a `DBCacheInputValue` suitable for opening the DB Browser pre-focused on the
+//  cursor object.
+//
+//  Mapping rules:
+//  - `.schemaObject`   → search for the named object, owner as owner filter
+//  - `.packageMember`  → open the parent package; Details tab (shows source)
+//  - `.column`         → open the parent table; Details tab (shows columns)
+//  - `.unresolved`     → no-op: returns a bare `DBCacheInputValue` with no
+//                         pre-selection so the browser still opens
+//
+
+import Foundation
+
+enum DBBrowserInputMapper {
+    /// Builds a `DBCacheInputValue` that pre-focuses the DB Browser on the
+    /// object described by `reference`, using `mainConnection` as the target.
+    static func inputValue(
+        from reference: ResolvedDBReference,
+        mainConnection: MainConnection
+    ) -> DBCacheInputValue {
+        switch reference {
+
+        case .schemaObject(let owner, let name):
+            return DBCacheInputValue(
+                mainConnection: mainConnection,
+                selectedOwner: owner,
+                selectedObjectName: name,
+                selectedObjectType: nil,
+                initialDetailTab: .details
+            )
+
+        case .packageMember(let pkgOwner, let pkgName, _):
+            // Navigate to the parent package, not the individual member.
+            return DBCacheInputValue(
+                mainConnection: mainConnection,
+                selectedOwner: pkgOwner,
+                selectedObjectName: pkgName,
+                selectedObjectType: OracleObjectType.package.rawValue,
+                initialDetailTab: .details
+            )
+
+        case .column(let tableOwner, let tableName, _):
+            // Navigate to the parent table; Details tab shows column list.
+            return DBCacheInputValue(
+                mainConnection: mainConnection,
+                selectedOwner: tableOwner,
+                selectedObjectName: tableName,
+                selectedObjectType: OracleObjectType.table.rawValue,
+                initialDetailTab: .details
+            )
+
+        case .unresolved:
+            return DBCacheInputValue(mainConnection: mainConnection)
+        }
+    }
+}

--- a/Macintora/DBObjectsBrowser/DBBrowserWindowRegistry.swift
+++ b/Macintora/DBObjectsBrowser/DBBrowserWindowRegistry.swift
@@ -1,0 +1,140 @@
+//
+//  DBBrowserWindowRegistry.swift
+//  Macintora
+//
+//  Maintains a per-connection live index of open DB Browser windows so that
+//  "Open in DB Browser" triggers can re-use an existing window instead of
+//  booting a new CoreData stack each time.
+//
+//  Usage:
+//   - `DBCacheMainView` registers itself via the `WindowObserver` background
+//     view and deregisters on `onDisappear`.
+//   - `openOrFocusDBBrowser(value:openWindow:)` checks the registry first;
+//     if a matching window is found it focuses it and mutates its VM, otherwise
+//     it calls `openWindow(value:)`.
+//
+
+import AppKit
+import SwiftUI
+
+// MARK: - Registry
+
+/// Process-global, main-actor registry: TNS alias → (DBCacheVM, NSWindow).
+@MainActor
+final class DBBrowserWindowRegistry {
+    static let shared = DBBrowserWindowRegistry()
+    /// Internal so `@testable import Macintora` test suites can create
+    /// isolated instances rather than sharing the process-global singleton.
+    init() {}
+
+    private struct Entry {
+        let tns: String
+        weak var vm: DBCacheVM?
+        weak var window: NSWindow?
+    }
+    private var entries: [Entry] = []
+
+    func register(vm: DBCacheVM, window: NSWindow) {
+        // Idempotent: skip if this exact (vm, window) pair is already present.
+        if entries.contains(where: { $0.vm === vm && $0.window === window }) { return }
+        entries.removeAll { $0.vm === vm }
+        entries.append(Entry(tns: vm.connDetails.tns, vm: vm, window: window))
+        purge()
+    }
+
+    func deregister(vm: DBCacheVM) {
+        entries.removeAll { $0.vm === vm }
+    }
+
+    /// Returns the first live (vm, window) pair whose TNS matches `tns`, or
+    /// nil when no such window is currently open.
+    func find(forTNS tns: String) -> (vm: DBCacheVM, window: NSWindow)? {
+        purge()
+        for entry in entries where entry.tns == tns {
+            if let vm = entry.vm, let window = entry.window {
+                return (vm, window)
+            }
+        }
+        return nil
+    }
+
+    private func purge() {
+        entries.removeAll { $0.vm == nil || $0.window == nil }
+    }
+}
+
+// MARK: - Dedup open helper
+
+/// Opens a DB Browser window pre-focused on the object described by `value`.
+///
+/// If a browser for the same connection (TNS) is already open, focuses that
+/// window and mutates its VM so the user doesn't pay the CoreData bootstrap
+/// cost of a fresh window. Falls back to `openWindow(value:)` when no match
+/// is found.
+@MainActor
+func openOrFocusDBBrowser(value: DBCacheInputValue, openWindow: OpenWindowAction) {
+    let tns = value.mainConnection.mainConnDetails.tns
+    if let (vm, window) = DBBrowserWindowRegistry.shared.find(forTNS: tns) {
+        // Update the existing VM's search criteria.
+        if let name = value.selectedObjectName {
+            vm.searchCriteria.searchText = name
+        }
+        if let owner = value.selectedOwner {
+            vm.searchCriteria.ownerString = owner
+        }
+        vm.searchCriteria.selectedTypeFilter = value.selectedObjectType
+        // Arm the auto-selection mechanism.
+        vm.pendingSelectionName  = value.selectedObjectName
+        vm.pendingSelectionOwner = value.selectedOwner
+        vm.pendingSelectionType  = value.selectedObjectType
+        vm.initialDetailTab      = value.initialDetailTab
+        window.makeKeyAndOrderFront(nil)
+    } else {
+        openWindow(value: value)
+    }
+}
+
+// MARK: - WindowObserver
+
+/// A zero-size `NSViewRepresentable` that calls `onWindowResolved` once the
+/// view has been placed in a window. Used by `DBCacheMainView` to register
+/// itself with `DBBrowserWindowRegistry`.
+struct WindowObserver: NSViewRepresentable {
+    let onWindowResolved: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> _WindowObserverView {
+        _WindowObserverView(onWindowResolved: onWindowResolved)
+    }
+
+    func updateNSView(_ view: _WindowObserverView, context: Context) {
+        if let window = view.window {
+            onWindowResolved(window)
+        }
+    }
+}
+
+/// Internal `NSView` subclass that fires the callback when it moves into a
+/// window hierarchy. Kept package-internal; callers use `WindowObserver`.
+final class _WindowObserverView: NSView {
+    private let onWindowResolved: (NSWindow) -> Void
+    private var hasReported = false
+
+    init(onWindowResolved: @escaping (NSWindow) -> Void) {
+        self.onWindowResolved = onWindowResolved
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let window, !hasReported {
+            hasReported = true
+            // Fire on the next run-loop turn so SwiftUI's layout pass has
+            // completed and the window hierarchy is stable.
+            MainActor.assumeIsolated {
+                onWindowResolved(window)
+            }
+        }
+    }
+}

--- a/Macintora/DBObjectsBrowser/DBCacheMainView.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheMainView.swift
@@ -9,9 +9,39 @@ import SwiftUI
 
 struct DBCacheInputValue: Hashable, Codable, Equatable {
     let mainConnection: MainConnection
+    let selectedOwner: String?
     let selectedObjectName: String?
-    
-    static func preview() -> DBCacheInputValue { DBCacheInputValue(mainConnection: MainConnection.preview(), selectedObjectName: nil) }
+    let selectedObjectType: String?
+    let initialDetailTab: DBDetailTab?
+
+    init(
+        mainConnection: MainConnection,
+        selectedOwner: String? = nil,
+        selectedObjectName: String? = nil,
+        selectedObjectType: String? = nil,
+        initialDetailTab: DBDetailTab? = nil
+    ) {
+        self.mainConnection = mainConnection
+        self.selectedOwner = selectedOwner
+        self.selectedObjectName = selectedObjectName
+        self.selectedObjectType = selectedObjectType
+        self.initialDetailTab = initialDetailTab
+    }
+
+    /// Backward-compatible decoding: scenes persisted before this version lack
+    /// the new fields; treat absent keys as nil rather than throwing.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        mainConnection     = try  c.decode(MainConnection.self,   forKey: .mainConnection)
+        selectedOwner      = try? c.decodeIfPresent(String.self,   forKey: .selectedOwner)      ?? nil
+        selectedObjectName = try? c.decodeIfPresent(String.self,   forKey: .selectedObjectName) ?? nil
+        selectedObjectType = try? c.decodeIfPresent(String.self,   forKey: .selectedObjectType) ?? nil
+        initialDetailTab   = try? c.decodeIfPresent(DBDetailTab.self, forKey: .initialDetailTab) ?? nil
+    }
+
+    static func preview() -> DBCacheInputValue {
+        DBCacheInputValue(mainConnection: .preview())
+    }
 }
 
 struct DBCacheMainView: View {
@@ -21,13 +51,34 @@ struct DBCacheMainView: View {
     @Environment(\.keychainService) private var keychain
     @State private var reportDisplayed = false
     @State private var columnVisibility = NavigationSplitViewVisibility.all
-//    @State private var totalCountMatched: Int = 0
     @SectionedFetchRequest var items: SectionedFetchResults<String?, DBCacheObject>
     @State private var listSelection: SectionedFetchResults<String?, DBCacheObject>.Section.Element?
 
     init(cache: DBCacheVM) {
         self.cache = cache
-        _items = SectionedFetchRequest(fetchRequest: DBCacheObject.fetchRequest(limit: cache.searchLimit, predicate: cache.searchCriteria.predicate), sectionIdentifier: \DBCacheObject.owner_, animation: .default)
+        _items = SectionedFetchRequest(
+            fetchRequest: DBCacheObject.fetchRequest(limit: cache.searchLimit, predicate: cache.searchCriteria.predicate),
+            sectionIdentifier: \DBCacheObject.owner_,
+            animation: .default)
+    }
+
+    /// Selects the pending object once `items` has been populated.
+    private func performAutoSelect() {
+        guard let name = cache.pendingSelectionName else { return }
+        let owner = cache.pendingSelectionOwner
+        let type  = cache.pendingSelectionType
+        for section in items {
+            for item in section {
+                guard item.name == name else { continue }
+                guard owner == nil || item.owner == owner else { continue }
+                guard type  == nil || item.type  == type  else { continue }
+                listSelection = item
+                cache.pendingSelectionName  = nil
+                cache.pendingSelectionOwner = nil
+                cache.pendingSelectionType  = nil
+                return
+            }
+        }
     }
     
     var body: some View {
@@ -64,13 +115,23 @@ struct DBCacheMainView: View {
             }
         }
         .searchable(text: query, placement: .sidebar, prompt: "type something")
+        .background(WindowObserver { window in
+            DBBrowserWindowRegistry.shared.register(vm: cache, window: window)
+        })
         .onAppear {
             cache.store = injectedStore
             cache.keychain = keychain
+            performAutoSelect()
+        }
+        .onDisappear {
+            DBBrowserWindowRegistry.shared.deregister(vm: cache)
         }
         .onChange(of: cache.searchCriteria.predicate) { _, value in
             listSelection = nil
             items.nsPredicate = value
+        }
+        .onChange(of: items) { _, _ in
+            performAutoSelect()
         }
         .toolbar {
             ToolbarItemGroup(placement: .principal) {

--- a/Macintora/DBObjectsBrowser/DBCacheSearchCriteria.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheSearchCriteria.swift
@@ -13,7 +13,7 @@ struct DBCacheSearchCriteria: Equatable {
     static func == (lhs: DBCacheSearchCriteria, rhs: DBCacheSearchCriteria) -> Bool {
         lhs.predicate == rhs.predicate
     }
-    
+
     var searchText = ""
     @AppStorage("prefixList") var prefixList = ["preview": ""] // tns = key: value
     @AppStorage("ownerList") var ownerList = ["preview": ""] // tns = key: value
@@ -25,8 +25,13 @@ struct DBCacheSearchCriteria: Equatable {
     @AppStorage("showTriggers") var showTriggers = true
     @AppStorage("showProcedures") var showProcedures = true
     @AppStorage("showFunctions") var showFunctions = true
-//    var changed = false
-    
+
+    /// When non-nil, overrides the `showXXX` type toggles and filters to
+    /// only this Oracle object type (e.g. "TABLE"). Set by "Open in DB Browser"
+    /// triggers so the list starts focused on the referenced object's type.
+    /// Cleared when the user resets the type filter from `QuickFilterView`.
+    var selectedTypeFilter: String? = nil
+
     private let tns: String
     
     var ownerString: String { get { ownerList[tns] ?? "" } set { ownerList[tns] = newValue} }
@@ -46,26 +51,26 @@ struct DBCacheSearchCriteria: Equatable {
     
     var predicate: NSPredicate {
         var predicates = [NSPredicate]()
-        
-        var typeInclusionList = [String]()
-//        var ownerPrefixExclusionList = ["SYS", "CDR_W"]
 
-        
-        
-        if showTables { typeInclusionList.append("TABLE") }
-        if showTypes { typeInclusionList.append("TYPE") }
-        if showProcedures { typeInclusionList.append("PROCEDURE") }
-        if showFunctions { typeInclusionList.append("FUNCTION") }
-        if showViews { typeInclusionList.append("VIEW") }
-        if showIndexes { typeInclusionList.append("INDEX") }
-        if showPackages { typeInclusionList.append("PACKAGE") }
-        if showTriggers { typeInclusionList.append("TRIGGER") }
-        
-        if !ownerInclusionList.isEmpty {
-            predicates.append(NSPredicate.init(format: "owner_ IN %@", ownerInclusionList))
+        if let forced = selectedTypeFilter {
+            predicates.append(NSPredicate(format: "type_ = %@", forced))
+        } else {
+            var typeInclusionList = [String]()
+            if showTables { typeInclusionList.append("TABLE") }
+            if showTypes { typeInclusionList.append("TYPE") }
+            if showProcedures { typeInclusionList.append("PROCEDURE") }
+            if showFunctions { typeInclusionList.append("FUNCTION") }
+            if showViews { typeInclusionList.append("VIEW") }
+            if showIndexes { typeInclusionList.append("INDEX") }
+            if showPackages { typeInclusionList.append("PACKAGE") }
+            if showTriggers { typeInclusionList.append("TRIGGER") }
+            if !typeInclusionList.isEmpty {
+                predicates.append(NSPredicate(format: "type_ IN %@", typeInclusionList))
+            }
         }
-        if !typeInclusionList.isEmpty {
-            predicates.append(NSPredicate.init(format: "type_ IN %@", typeInclusionList))
+
+        if !ownerInclusionList.isEmpty {
+            predicates.append(NSPredicate(format: "owner_ IN %@", ownerInclusionList))
         }
 //
         if !searchText.isEmpty {

--- a/Macintora/DBObjectsBrowser/DBCacheVM.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheVM.swift
@@ -254,6 +254,18 @@ final class DBCacheVM: nonisolated ObservableObject {
     var cacheState = CacheState()
     @Published var searchCriteria: DBCacheSearchCriteria
 
+    /// Initial tab to open in `DBDetailView`. Consumed once on first appear,
+    /// then cleared to nil so navigating to other rows doesn't re-apply it.
+    var initialDetailTab: DBDetailTab?
+
+    /// Name of the object to auto-select once the list loads. Cleared after
+    /// selection so subsequent predicate changes don't re-apply it.
+    @Published var pendingSelectionName: String?
+    /// Owner constraint for the auto-selection. Nil means any owner matches.
+    @Published var pendingSelectionOwner: String?
+    /// Type constraint for the auto-selection (e.g. "TABLE"). Nil means any.
+    @Published var pendingSelectionType: String?
+
     private let oracleLogger: Logging.Logger = {
         var logger = Logging.Logger(label: "com.iliasazonov.macintora.oracle.cache")
         logger.logLevel = .notice
@@ -267,15 +279,30 @@ final class DBCacheVM: nonisolated ObservableObject {
         return dateFormatter.string(from: lst)
     }
 
-    init(connDetails: ConnectionDetails, selectedObjectName: String? = nil) {
+    init(connDetails: ConnectionDetails,
+         persistenceController: PersistenceController? = nil,
+         selectedOwner: String? = nil,
+         selectedObjectName: String? = nil,
+         selectedObjectType: String? = nil,
+         initialDetailTab: DBDetailTab? = nil) {
         self.connDetails = connDetails
         self.searchCriteria = DBCacheSearchCriteria(for: connDetails.tns)
-        persistenceController = PersistenceController(name: connDetails.tns)
+        self.persistenceController = persistenceController ?? PersistenceController(name: connDetails.tns)
         setConnDetailsFromCache()
         OracleObjectType.allCases.forEach { objectQueues[$0] = ObjectQueue() }
-        if let selected = selectedObjectName {
-            searchCriteria.searchText = selected
+        if let name = selectedObjectName {
+            searchCriteria.searchText = name
         }
+        if let owner = selectedOwner {
+            searchCriteria.ownerString = owner
+        }
+        if let type = selectedObjectType {
+            searchCriteria.selectedTypeFilter = type
+        }
+        self.initialDetailTab = initialDetailTab
+        self.pendingSelectionName  = selectedObjectName
+        self.pendingSelectionOwner = selectedOwner
+        self.pendingSelectionType  = selectedObjectType
     }
 
     init(preview: Bool = true) {

--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -8,6 +8,13 @@
 import SwiftUI
 import os
 
+/// Top-level tab selection for `DBDetailView`.
+/// Codable so it round-trips through `DBCacheInputValue` for scene restoration.
+enum DBDetailTab: String, Codable, Hashable, CaseIterable, Sendable {
+    case main
+    case details
+}
+
 struct DBDetailObjectMainView: View {
     @Binding var dbObject: DBCacheObject
 
@@ -68,8 +75,10 @@ struct DBDetailObjectDetailsView: View {
 
 struct DBDetailView: View {
     @Binding var dbObject: DBCacheObject
+    @EnvironmentObject private var cache: DBCacheVM
     @State private var selectedTab: String = "details"
-    
+    @State private var hasAppliedInitialTab = false
+
     var body: some View {
         VStack(alignment: .leading) {
             DBDetailViewHeader(dbObject: $dbObject)
@@ -88,6 +97,14 @@ struct DBDetailView: View {
                         Text("Details")
                     }
                     .tag("details")
+            }
+        }
+        .onAppear {
+            guard !hasAppliedInitialTab else { return }
+            hasAppliedInitialTab = true
+            if let tab = cache.initialDetailTab {
+                selectedTab = tab.rawValue
+                cache.initialDetailTab = nil
             }
         }
     }

--- a/Macintora/DBObjectsBrowser/QuickFilterView.swift
+++ b/Macintora/DBObjectsBrowser/QuickFilterView.swift
@@ -36,11 +36,18 @@ struct QuickFilterView: View {
                 }
                 .controlGroupStyle(GridControlGroupStyle())
                 
+                if quickFilters.selectedTypeFilter != nil {
+                    Button("Show all types") {
+                        quickFilters.selectedTypeFilter = nil
+                    }
+                    .controlSize(.small)
+                }
+
                 TextField("Schemas, ex. SYSTEM,SYS", text: $quickFilters.ownerString)
                     .lineLimit(3, reservesSpace: true)
                     .textFieldStyle(.roundedBorder)
                     .disableAutocorrection(true)
-                
+
                 TextField("Object Prefix, ex. DBMS,DBA", text: $quickFilters.prefixString)
                     .lineLimit(3, reservesSpace: true)
                     .textFieldStyle(.roundedBorder)

--- a/Macintora/Editor/MacintoraEditor+Coordinator.swift
+++ b/Macintora/Editor/MacintoraEditor+Coordinator.swift
@@ -56,6 +56,10 @@ extension MacintoraEditorRepresentable {
         /// detect identity changes (rebind on full document re-init).
         weak var quickViewBoxRef: EditorQuickViewBox?
 
+        /// Weak reference back to the SwiftUI-owned Open-in-Browser box so we
+        /// can detect identity changes and avoid double-binding.
+        weak var openInBrowserBoxRef: EditorOpenInBrowserBox?
+
         /// Last UTF-16 cursor location seen in the selection callback. Used to
         /// detect when the cursor moves outside the in-progress identifier so
         /// auto-trigger can be cancelled.
@@ -114,6 +118,43 @@ extension MacintoraEditorRepresentable {
             box.trigger = { [weak controller, weak textView] in
                 guard let controller, let textView else { return }
                 controller.triggerAtCursor(textView: textView)
+            }
+        }
+
+        /// Sets `quickViewController.openInBrowserHandler` to a closure that maps
+        /// the resolved reference to a `DBCacheInputValue` and routes through
+        /// `openOrFocusDBBrowser`. Clears the handler when `mainConnectionProvider`
+        /// is nil (read-only viewer has no connection).
+        @MainActor
+        func wireOpenInBrowserHandler(
+            openWindow: OpenWindowAction,
+            mainConnectionProvider: (@MainActor () -> MainConnection?)?
+        ) {
+            guard let controller = quickViewController else { return }
+            guard let mainConnectionProvider else {
+                controller.openInBrowserHandler = nil
+                return
+            }
+            controller.openInBrowserHandler = { [weak controller] reference in
+                guard controller != nil else { return }
+                guard let connection = mainConnectionProvider() else { return }
+                let value = DBBrowserInputMapper.inputValue(from: reference,
+                                                            mainConnection: connection)
+                openOrFocusDBBrowser(value: value, openWindow: openWindow)
+            }
+        }
+
+        /// Wires the SwiftUI-owned `EditorOpenInBrowserBox` to this editor's
+        /// Quick View controller. The box's `trigger` closure is the path
+        /// the ⌥⌘B menu command uses to open the browser at the cursor.
+        @MainActor
+        func bindOpenInBrowserBox(_ box: EditorOpenInBrowserBox?, textView: STTextView) {
+            openInBrowserBoxRef?.trigger = nil
+            openInBrowserBoxRef = box
+            guard let box, let controller = quickViewController else { return }
+            box.trigger = { [weak controller, weak textView] in
+                guard let controller, let textView else { return }
+                controller.openInBrowserAtCursor(textView: textView)
             }
         }
 

--- a/Macintora/Editor/MacintoraEditor.swift
+++ b/Macintora/Editor/MacintoraEditor.swift
@@ -27,11 +27,16 @@ struct EditorCompletionConfig {
     let persistenceController: PersistenceController
     /// Closure so the editor picks up reconnects without rebuilding the view.
     let defaultOwnerProvider: @MainActor () -> String
+    /// Provides the current `MainConnection` at trigger time for the
+    /// "Open in DB Browser" handler. Nil when the document has no connection.
+    let mainConnectionProvider: (@MainActor () -> MainConnection?)?
 
     init(persistenceController: PersistenceController,
-         defaultOwnerProvider: @escaping @MainActor () -> String) {
+         defaultOwnerProvider: @escaping @MainActor () -> String,
+         mainConnectionProvider: (@MainActor () -> MainConnection?)? = nil) {
         self.persistenceController = persistenceController
         self.defaultOwnerProvider = defaultOwnerProvider
+        self.mainConnectionProvider = mainConnectionProvider
     }
 }
 
@@ -47,6 +52,7 @@ struct MacintoraEditor: View {
     let accessibilityIdentifier: String
     let completionConfig: EditorCompletionConfig?
     let quickViewBox: EditorQuickViewBox?
+    let openInBrowserBox: EditorOpenInBrowserBox?
 
     @AppStorage("editorTheme") private var editorThemeRaw: String = EditorTheme.default.rawValue
 
@@ -61,7 +67,8 @@ struct MacintoraEditor: View {
         highlightsSelectedLine: Bool = true,
         accessibilityIdentifier: String = "editor.main",
         completionConfig: EditorCompletionConfig? = nil,
-        quickViewBox: EditorQuickViewBox? = nil
+        quickViewBox: EditorQuickViewBox? = nil,
+        openInBrowserBox: EditorOpenInBrowserBox? = nil
     ) {
         self._text = text
         self._selection = selection
@@ -74,6 +81,7 @@ struct MacintoraEditor: View {
         self.accessibilityIdentifier = accessibilityIdentifier
         self.completionConfig = completionConfig
         self.quickViewBox = quickViewBox
+        self.openInBrowserBox = openInBrowserBox
     }
 
     private var editorTheme: EditorTheme {
@@ -93,7 +101,8 @@ struct MacintoraEditor: View {
             accessibilityIdentifier: accessibilityIdentifier,
             theme: editorTheme,
             completionConfig: completionConfig,
-            quickViewBox: quickViewBox
+            quickViewBox: quickViewBox,
+            openInBrowserBox: openInBrowserBox
         )
         .id(editorTheme)
     }
@@ -112,6 +121,7 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
     let theme: EditorTheme
     let completionConfig: EditorCompletionConfig?
     let quickViewBox: EditorQuickViewBox?
+    let openInBrowserBox: EditorOpenInBrowserBox?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(text: $text, selection: $selection)
@@ -159,6 +169,10 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
             if let quickViewController = context.coordinator.quickViewController {
                 textView.addPlugin(STDBObjectQuickViewPlugin(controller: quickViewController))
             }
+            context.coordinator.wireOpenInBrowserHandler(
+                openWindow: context.environment.openWindow,
+                mainConnectionProvider: config.mainConnectionProvider)
+            context.coordinator.bindOpenInBrowserBox(openInBrowserBox, textView: textView)
         }
 
         // Install the Neon syntax-highlighting plugin before the first text
@@ -190,11 +204,19 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
             if let quickViewController = context.coordinator.quickViewController {
                 textView.addPlugin(STDBObjectQuickViewPlugin(controller: quickViewController))
             }
-        } else if context.coordinator.quickViewBoxRef !== quickViewBox {
-            // Box identity changed (rare but happens on full document
-            // re-init). Rebind so the menu command keeps working against the
-            // freshly-mounted editor.
-            context.coordinator.bindQuickViewBox(quickViewBox, textView: textView)
+            context.coordinator.wireOpenInBrowserHandler(
+                openWindow: context.environment.openWindow,
+                mainConnectionProvider: config.mainConnectionProvider)
+            context.coordinator.bindOpenInBrowserBox(openInBrowserBox, textView: textView)
+        } else {
+            // Box identity may change on full document re-init. Rebind so menu
+            // commands keep working against the freshly-mounted editor.
+            if context.coordinator.quickViewBoxRef !== quickViewBox {
+                context.coordinator.bindQuickViewBox(quickViewBox, textView: textView)
+            }
+            if context.coordinator.openInBrowserBoxRef !== openInBrowserBox {
+                context.coordinator.bindOpenInBrowserBox(openInBrowserBox, textView: textView)
+            }
         }
 
         if textView.isEditable != isEditable { textView.isEditable = isEditable }

--- a/Macintora/Editor/Plugins/QuickView/EditorOpenInBrowserBox.swift
+++ b/Macintora/Editor/Plugins/QuickView/EditorOpenInBrowserBox.swift
@@ -1,0 +1,39 @@
+//
+//  EditorOpenInBrowserBox.swift
+//  Macintora
+//
+//  Bridge object that lets the SwiftUI menu command (⌥⌘B) trigger
+//  "Open in DB Browser" on the focused editor without holding a direct
+//  reference to the AppKit text view.
+//
+//  Mirrors the `EditorQuickViewBox` pattern — intentionally **not**
+//  `@Observable` to avoid the menu-invalidation → constraint-loop crash
+//  described in `EditorQuickViewBox.swift`.
+//
+//  - `MainDocumentView` owns a single instance and publishes it via
+//    `.focusedSceneValue(\.editorOpenInBrowserBox, ...)`.
+//  - The editor's coordinator writes the `trigger` closure after wiring
+//    `QuickViewController.openInBrowserHandler`.
+//  - The menu command reads the focused box and invokes `trigger?()`.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class EditorOpenInBrowserBox {
+    var trigger: (() -> Void)?
+}
+
+// MARK: - FocusedValueKey
+
+struct EditorOpenInBrowserBoxKey: FocusedValueKey {
+    typealias Value = EditorOpenInBrowserBox
+}
+
+extension FocusedValues {
+    var editorOpenInBrowserBox: EditorOpenInBrowserBoxKey.Value? {
+        get { self[EditorOpenInBrowserBoxKey.self] }
+        set { self[EditorOpenInBrowserBoxKey.self] = newValue }
+    }
+}

--- a/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewController.swift
@@ -85,6 +85,33 @@ final class QuickViewController {
         presenter.close()
     }
 
+    // MARK: - Open in DB Browser triggers
+
+    /// Resolves the token at the editor's current keyboard cursor and dispatches
+    /// to `openInBrowserHandler`. Used by the ⌥⌘B hotkey path.
+    func openInBrowserAtCursor(textView: STTextView) {
+        let offset = textView.selectedRange().location
+        openInBrowser(textView: textView, utf16Offset: offset)
+    }
+
+    /// Resolves the token at `utf16Offset` and dispatches to
+    /// `openInBrowserHandler`. Used by the right-click menu and ⌥⌘+Click.
+    func openInBrowserAtTextLocation(textView: STTextView, utf16Offset: Int) {
+        openInBrowser(textView: textView, utf16Offset: utf16Offset)
+    }
+
+    private func openInBrowser(textView: STTextView, utf16Offset: Int) {
+        let source = textView.text ?? ""
+        let tree   = treeStore.tree
+        let reference = resolver.resolve(utf16Offset: utf16Offset, source: source, tree: tree)
+        guard reference != .unresolved else {
+            logger.debug("OpenInBrowser: cursor not on a resolvable token")
+            return
+        }
+        logger.info("OpenInBrowser trigger: \(String(describing: reference), privacy: .public)")
+        openInBrowserHandler?(reference)
+    }
+
     // MARK: - Pipeline
 
     private func trigger(textView: STTextView,

--- a/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
+++ b/Macintora/Editor/Plugins/QuickView/STDBObjectQuickViewPlugin.swift
@@ -46,30 +46,34 @@ struct STDBObjectQuickViewPlugin: STPlugin {
         context.events.onContextMenu { [coordinator] location, contentManager in
             _ = coordinator
             let menu = NSMenu()
-            let item = NSMenuItem(
-                title: "Quick View",
-                action: nil,
-                keyEquivalent: "")
-            // Use a local target object so we don't rely on the responder
-            // chain finding our action on STTextView.
-            let target = QuickViewMenuTarget { [weak controller, weak textView] in
+            let utf16Offset = contentManager.offset(
+                from: contentManager.documentRange.location,
+                to: location)
+
+            // "Quick View" item
+            let qvTarget = QuickViewMenuTarget { [weak controller, weak textView] in
                 guard let controller, let textView else { return }
-                let utf16Offset = contentManager.offset(
-                    from: contentManager.documentRange.location,
-                    to: location)
                 controller.triggerAtTextLocation(textView: textView,
                                                  utf16Offset: utf16Offset)
             }
-            item.target = target
-            item.action = #selector(QuickViewMenuTarget.invoke(_:))
-            // `NSMenuItem.target` is a weak reference, so we need a strong
-            // ref to keep the closure alive until the menu is dismissed.
-            // `representedObject` is the canonical strong-ref slot on
-            // NSMenuItem — using it avoids an `objc_setAssociatedObject`
-            // call that Swift 6's strict-memory-safety mode now flags as
-            // unsafe.
-            item.representedObject = target
-            menu.addItem(item)
+            let qvItem = NSMenuItem(title: "Quick View", action: nil, keyEquivalent: "")
+            qvItem.target = qvTarget
+            qvItem.action = #selector(QuickViewMenuTarget.invoke(_:))
+            qvItem.representedObject = qvTarget
+            menu.addItem(qvItem)
+
+            // "Show in DB Browser" item — sibling of Quick View
+            let browserTarget = QuickViewMenuTarget { [weak controller, weak textView] in
+                guard let controller, let textView else { return }
+                controller.openInBrowserAtTextLocation(textView: textView,
+                                                       utf16Offset: utf16Offset)
+            }
+            let browserItem = NSMenuItem(title: "Show in DB Browser", action: nil, keyEquivalent: "")
+            browserItem.target = browserTarget
+            browserItem.action = #selector(QuickViewMenuTarget.invoke(_:))
+            browserItem.representedObject = browserTarget
+            menu.addItem(browserItem)
+
             return menu
         }
     }
@@ -110,7 +114,10 @@ struct STDBObjectQuickViewPlugin: STPlugin {
             // hierarchy `@MainActor`. Local monitors fire on the main
             // thread, so the assumption is the documented contract.
             monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak textView, weak controller] event in
-                guard event.modifierFlags.contains(.command) else { return event }
+                let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                // ⌥⌘+click → Open in DB Browser; ⌘+click → Quick View.
+                // Require at least ⌘; otherwise the event is unrelated.
+                guard flags.contains(.command) else { return event }
                 MainActor.assumeIsolated {
                     guard let textView, let controller else { return }
                     // `unsafe` acknowledges SE-0458 — `NSEvent.window` and
@@ -124,7 +131,13 @@ struct STDBObjectQuickViewPlugin: STPlugin {
                     let screenPoint = window.convertPoint(toScreen: event.locationInWindow)
                     let offset = textView.characterIndex(for: screenPoint)
                     guard offset != NSNotFound else { return }
-                    controller.triggerAtTextLocation(textView: textView, utf16Offset: offset)
+                    if flags.contains(.option) {
+                        // ⌥⌘+click → Open in DB Browser
+                        controller.openInBrowserAtTextLocation(textView: textView, utf16Offset: offset)
+                    } else {
+                        // ⌘+click (no ⌥) → Quick View
+                        controller.triggerAtTextLocation(textView: textView, utf16Offset: offset)
+                    }
                 }
                 return event
             }

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -221,7 +221,12 @@ struct MacOraApp: App {
 
         WindowGroup(for: DBCacheInputValue.self) { $value in
             let v = value ?? .preview()
-            let cache = DBCacheVM(connDetails: v.mainConnection.mainConnDetails, selectedObjectName: v.selectedObjectName)
+            let cache = DBCacheVM(
+                connDetails: v.mainConnection.mainConnDetails,
+                selectedOwner: v.selectedOwner,
+                selectedObjectName: v.selectedObjectName,
+                selectedObjectType: v.selectedObjectType,
+                initialDetailTab: v.initialDetailTab)
             DBCacheMainView(cache: cache)
                 .environment(\.managedObjectContext, cache.persistenceController.container.viewContext)
                 .environment(\.connectionStore, connectionStore)
@@ -247,6 +252,7 @@ struct MainDocumentMenuCommands: Commands {
     @FocusedValue(\.selectedObjectName) var selectedObjectName: String?
     @FocusedValue(\.mainConnection) var mainConnection
     @FocusedValue(\.editorQuickViewBox) var quickViewBox
+    @FocusedValue(\.editorOpenInBrowserBox) var openInBrowserBox
     @Environment(\.openWindow) var openWindow
 
     @Environment(\.openSettings) private var openSettings
@@ -291,6 +297,12 @@ struct MainDocumentMenuCommands: Commands {
             }
             .disabled(quickViewBox == nil)
             .quickViewShortcut(quickViewHotkey)
+
+            Button("Open in DB Browser") {
+                openInBrowserBox?.trigger?()
+            }
+            .disabled(openInBrowserBox == nil)
+            .keyboardShortcut("b", modifiers: [.command, .option])
         }
     }
 }

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -40,6 +40,8 @@ struct MainDocumentView: View {
     /// editor without holding a direct reference to the AppKit text view.
     /// Populated by the editor's coordinator after Quick View is wired.
     @State private var quickViewBox = EditorQuickViewBox()
+    /// Bridge for the ⌥⌘B "Open in DB Browser" menu command.
+    @State private var openInBrowserBox = EditorOpenInBrowserBox()
 
     var selectedObject: String {
         if editorSelection.isEmpty { return "" }
@@ -91,7 +93,8 @@ struct MainDocumentView: View {
                         showsLineNumbers: true,
                         highlightsSelectedLine: true,
                         completionConfig: completionConfig,
-                        quickViewBox: quickViewBox
+                        quickViewBox: quickViewBox,
+                        openInBrowserBox: openInBrowserBox
                     )
                         .frame(maxWidth: .infinity, minHeight: 120, idealHeight: 320, maxHeight: .infinity)
                         .focused($focusedView, equals: .codeEditor)
@@ -122,6 +125,7 @@ struct MainDocumentView: View {
         .focusedSceneValue(\.mainConnection, document.mainConnection)
         .focusedSceneValue(\.selectedObjectName, selectedObject)
         .focusedSceneValue(\.editorQuickViewBox, quickViewBox)
+        .focusedSceneValue(\.editorOpenInBrowserBox, openInBrowserBox)
         .tnsImportPromptOnFirstLaunch()
         .onAppear {
             document.prepareOnAppear(store: injectedStore, keychain: keychain)
@@ -136,6 +140,9 @@ struct MainDocumentView: View {
                         persistenceController: controller,
                         defaultOwnerProvider: { [weak document] in
                             document?.mainConnection.mainConnDetails.username.uppercased() ?? ""
+                        },
+                        mainConnectionProvider: { [weak document] in
+                            document?.mainConnection
                         }
                     )
                 }

--- a/MacintoraTests/DBBrowser/DBBrowserInputMapperTests.swift
+++ b/MacintoraTests/DBBrowser/DBBrowserInputMapperTests.swift
@@ -1,0 +1,102 @@
+//
+//  DBBrowserInputMapperTests.swift
+//  MacintoraTests
+//
+//  Verifies `DBBrowserInputMapper.inputValue(from:mainConnection:)` produces the
+//  correct `DBCacheInputValue` for each `ResolvedDBReference` case.
+//
+
+import XCTest
+@testable import Macintora
+
+final class DBBrowserInputMapperTests: XCTestCase {
+
+    private let connection = MainConnection.preview()
+
+    // MARK: - .schemaObject
+
+    func test_schemaObject_withExplicitOwner() {
+        let ref = ResolvedDBReference.schemaObject(owner: "HR", name: "EMPLOYEES")
+        let value = DBBrowserInputMapper.inputValue(from: ref, mainConnection: connection)
+        XCTAssertEqual(value.selectedOwner, "HR")
+        XCTAssertEqual(value.selectedObjectName, "EMPLOYEES")
+        XCTAssertNil(value.selectedObjectType)
+        XCTAssertEqual(value.initialDetailTab, .details)
+    }
+
+    func test_schemaObject_nilOwner_passesNilOwner() {
+        let ref = ResolvedDBReference.schemaObject(owner: nil, name: "DUAL")
+        let value = DBBrowserInputMapper.inputValue(from: ref, mainConnection: connection)
+        XCTAssertNil(value.selectedOwner)
+        XCTAssertEqual(value.selectedObjectName, "DUAL")
+        XCTAssertNil(value.selectedObjectType)
+        XCTAssertEqual(value.initialDetailTab, .details)
+    }
+
+    // MARK: - .packageMember
+
+    func test_packageMember_navigatesToParentPackage() {
+        let ref = ResolvedDBReference.packageMember(
+            packageOwner: "HR",
+            packageName: "EMP_PKG",
+            memberName: "GET_SALARY")
+        let value = DBBrowserInputMapper.inputValue(from: ref, mainConnection: connection)
+        XCTAssertEqual(value.selectedOwner, "HR")
+        XCTAssertEqual(value.selectedObjectName, "EMP_PKG")
+        XCTAssertEqual(value.selectedObjectType, OracleObjectType.package.rawValue)
+        XCTAssertEqual(value.initialDetailTab, .details)
+    }
+
+    func test_packageMember_nilOwner_passesNil() {
+        let ref = ResolvedDBReference.packageMember(
+            packageOwner: nil,
+            packageName: "UTIL_PKG",
+            memberName: "HELPER")
+        let value = DBBrowserInputMapper.inputValue(from: ref, mainConnection: connection)
+        XCTAssertNil(value.selectedOwner)
+        XCTAssertEqual(value.selectedObjectName, "UTIL_PKG")
+        XCTAssertEqual(value.selectedObjectType, OracleObjectType.package.rawValue)
+    }
+
+    // MARK: - .column
+
+    func test_column_navigatesToParentTable() {
+        let ref = ResolvedDBReference.column(
+            tableOwner: "HR",
+            tableName: "EMPLOYEES",
+            columnName: "SALARY")
+        let value = DBBrowserInputMapper.inputValue(from: ref, mainConnection: connection)
+        XCTAssertEqual(value.selectedOwner, "HR")
+        XCTAssertEqual(value.selectedObjectName, "EMPLOYEES")
+        XCTAssertEqual(value.selectedObjectType, OracleObjectType.table.rawValue)
+        XCTAssertEqual(value.initialDetailTab, .details)
+    }
+
+    func test_column_nilOwner_passesNil() {
+        let ref = ResolvedDBReference.column(
+            tableOwner: nil,
+            tableName: "DEPT",
+            columnName: "DEPTNO")
+        let value = DBBrowserInputMapper.inputValue(from: ref, mainConnection: connection)
+        XCTAssertNil(value.selectedOwner)
+        XCTAssertEqual(value.selectedObjectName, "DEPT")
+    }
+
+    // MARK: - .unresolved
+
+    func test_unresolved_returnsBareBrowserValue() {
+        let value = DBBrowserInputMapper.inputValue(from: .unresolved, mainConnection: connection)
+        XCTAssertNil(value.selectedOwner)
+        XCTAssertNil(value.selectedObjectName)
+        XCTAssertNil(value.selectedObjectType)
+        XCTAssertNil(value.initialDetailTab)
+    }
+
+    // MARK: - Connection identity
+
+    func test_mainConnectionIsPreserved() {
+        let ref = ResolvedDBReference.schemaObject(owner: nil, name: "X")
+        let value = DBBrowserInputMapper.inputValue(from: ref, mainConnection: connection)
+        XCTAssertEqual(value.mainConnection, connection)
+    }
+}

--- a/MacintoraTests/DBBrowser/DBBrowserWindowRegistryTests.swift
+++ b/MacintoraTests/DBBrowser/DBBrowserWindowRegistryTests.swift
@@ -1,0 +1,101 @@
+//
+//  DBBrowserWindowRegistryTests.swift
+//  MacintoraTests
+//
+//  Verifies the window-deduplication registry: register, find, deregister,
+//  weak-ref purge, and same-TNS collision handling.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class DBBrowserWindowRegistryTests: XCTestCase {
+
+    private var registry: DBBrowserWindowRegistry!
+    private var connDetails: ConnectionDetails!
+    private var persistence: PersistenceController!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Use a fresh instance (not the shared singleton) to keep tests isolated.
+        registry = DBBrowserWindowRegistry()
+        connDetails = ConnectionDetails(username: "SCOTT", password: "", tns: "testdb", connectionRole: .regular)
+        persistence = PersistenceController(inMemory: true)
+    }
+
+    override func tearDown() async throws {
+        registry = nil
+        connDetails = nil
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    private func makeVM() -> DBCacheVM {
+        DBCacheVM(connDetails: connDetails, persistenceController: persistence)
+    }
+
+    private func makeWindow() -> NSWindow {
+        let w = NSWindow(contentRect: .zero,
+                        styleMask: .borderless,
+                        backing: .buffered,
+                        defer: true)
+        return w
+    }
+
+    // MARK: - register / find
+
+    func test_find_returnsNilBeforeRegistration() {
+        XCTAssertNil(registry.find(forTNS: "testdb"))
+    }
+
+    func test_find_returnsPairAfterRegistration() {
+        let vm = makeVM()
+        let window = makeWindow()
+        registry.register(vm: vm, window: window)
+        let result = registry.find(forTNS: "testdb")
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result?.vm === vm)
+        XCTAssertTrue(result?.window === window)
+    }
+
+    func test_find_returnsNilForDifferentTNS() {
+        let vm = makeVM()
+        let window = makeWindow()
+        registry.register(vm: vm, window: window)
+        XCTAssertNil(registry.find(forTNS: "other_db"))
+    }
+
+    // MARK: - deregister
+
+    func test_deregister_removesEntry() {
+        let vm = makeVM()
+        let window = makeWindow()
+        registry.register(vm: vm, window: window)
+        registry.deregister(vm: vm)
+        XCTAssertNil(registry.find(forTNS: "testdb"))
+    }
+
+    // MARK: - idempotency
+
+    func test_register_idempotent_sameVMAndWindow() {
+        let vm = makeVM()
+        let window = makeWindow()
+        registry.register(vm: vm, window: window)
+        registry.register(vm: vm, window: window)
+        // Should still be findable — no crash or duplicate entry.
+        XCTAssertNotNil(registry.find(forTNS: "testdb"))
+    }
+
+    // MARK: - same-TNS re-register
+
+    func test_register_replacesOldEntryForSameVM_newWindow() {
+        let vm = makeVM()
+        let window1 = makeWindow()
+        let window2 = makeWindow()
+        registry.register(vm: vm, window: window1)
+        registry.register(vm: vm, window: window2)
+        let result = registry.find(forTNS: "testdb")
+        XCTAssertTrue(result?.window === window2)
+    }
+}

--- a/MacintoraTests/DBBrowser/DBCacheVMInitTests.swift
+++ b/MacintoraTests/DBBrowser/DBCacheVMInitTests.swift
@@ -1,0 +1,86 @@
+//
+//  DBCacheVMInitTests.swift
+//  MacintoraTests
+//
+//  Verifies that `DBCacheVM.init` seeds `searchCriteria`, the pending-selection
+//  fields, and `initialDetailTab` from the values passed at construction time.
+//  Uses an in-memory `PersistenceController` so no disk I/O occurs.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class DBCacheVMInitTests: XCTestCase {
+
+    private var connDetails: ConnectionDetails!
+    private var persistence: PersistenceController!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        connDetails = ConnectionDetails(username: "SCOTT", password: "", tns: "orcl", connectionRole: .regular)
+        persistence = PersistenceController(inMemory: true)
+    }
+
+    override func tearDown() async throws {
+        connDetails = nil
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    func test_defaultInit_leavesSelectionFieldsNil() {
+        let vm = DBCacheVM(connDetails: connDetails,
+                          persistenceController: persistence)
+        XCTAssertNil(vm.pendingSelectionName)
+        XCTAssertNil(vm.pendingSelectionOwner)
+        XCTAssertNil(vm.pendingSelectionType)
+        XCTAssertNil(vm.initialDetailTab)
+    }
+
+    func test_selectedObjectName_seedsSearchTextAndPending() {
+        let vm = DBCacheVM(connDetails: connDetails,
+                          persistenceController: persistence,
+                          selectedObjectName: "EMPLOYEES")
+        XCTAssertEqual(vm.searchCriteria.searchText, "EMPLOYEES")
+        XCTAssertEqual(vm.pendingSelectionName, "EMPLOYEES")
+    }
+
+    func test_selectedOwner_seedsOwnerStringAndPending() {
+        let vm = DBCacheVM(connDetails: connDetails,
+                          persistenceController: persistence,
+                          selectedOwner: "HR")
+        XCTAssertEqual(vm.searchCriteria.ownerString, "HR")
+        XCTAssertEqual(vm.pendingSelectionOwner, "HR")
+    }
+
+    func test_selectedObjectType_seedsTypeFilterAndPending() {
+        let vm = DBCacheVM(connDetails: connDetails,
+                          persistenceController: persistence,
+                          selectedObjectType: "TABLE")
+        XCTAssertEqual(vm.searchCriteria.selectedTypeFilter, "TABLE")
+        XCTAssertEqual(vm.pendingSelectionType, "TABLE")
+    }
+
+    func test_initialDetailTab_isStoredAndNotClearedByInit() {
+        let vm = DBCacheVM(connDetails: connDetails,
+                          persistenceController: persistence,
+                          initialDetailTab: .details)
+        XCTAssertEqual(vm.initialDetailTab, .details)
+    }
+
+    func test_allFieldsTogether() {
+        let vm = DBCacheVM(connDetails: connDetails,
+                          persistenceController: persistence,
+                          selectedOwner: "HR",
+                          selectedObjectName: "EMPLOYEES",
+                          selectedObjectType: "TABLE",
+                          initialDetailTab: .main)
+        XCTAssertEqual(vm.searchCriteria.searchText, "EMPLOYEES")
+        XCTAssertEqual(vm.searchCriteria.ownerString, "HR")
+        XCTAssertEqual(vm.searchCriteria.selectedTypeFilter, "TABLE")
+        XCTAssertEqual(vm.pendingSelectionName, "EMPLOYEES")
+        XCTAssertEqual(vm.pendingSelectionOwner, "HR")
+        XCTAssertEqual(vm.pendingSelectionType, "TABLE")
+        XCTAssertEqual(vm.initialDetailTab, .main)
+    }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Three trigger paths** for "Open in DB Browser" from the editor: right-click context menu ("Show in DB Browser"), ⌥⌘B hotkey, and ⌥⌘+click — all resolve the token at that location before opening
- **Window deduplication** via `DBBrowserWindowRegistry`: reuses an existing browser window for the same TNS connection instead of opening a new CoreData stack each time
- **Pre-focused browser**: the opened/focused window pre-filters by owner, object name, and type, and lands on the Details tab — no manual searching required
- **Initial tab selection** driven by `DBCacheInputValue.initialDetailTab`; consumed once on first appear then cleared so normal navigation is unaffected
- **Transient type filter** (`DBCacheSearchCriteria.selectedTypeFilter`) overrides the global show/hide toggles without touching AppStorage; a "Show all types" button clears it

## Changes

### DB Browser
- `DBCacheInputValue` extended with `selectedOwner`, `selectedObjectType`, `initialDetailTab`; backward-compatible `Codable` decoder
- `DBCacheVM.init` seeds `searchCriteria` + `pendingSelection*` fields from new input-value fields; `PersistenceController` is injectable for unit tests
- `DBDetailView` reads `cache.initialDetailTab` once on first appear (via `hasAppliedInitialTab` guard) then clears it
- `DBCacheSearchCriteria.selectedTypeFilter` — non-AppStorage transient override; `QuickFilterView` shows a "Show all types" button when set
- `DBBrowserWindowRegistry` — `@MainActor` singleton mapping TNS → `(weak DBCacheVM, weak NSWindow)`; `WindowObserver` NSViewRepresentable triggers registration from SwiftUI
- `DBBrowserInputMapper` — pure static mapper from `ResolvedDBReference` → `DBCacheInputValue`

### Editor
- `QuickViewController` — `openInBrowserAtCursor/AtTextLocation`, `openInBrowserHandler` closure
- `STDBObjectQuickViewPlugin` — "Show in DB Browser" context menu item (sibling of "Quick View"); ⌥⌘+click routes to open-in-browser path in the existing NSEvent monitor
- `EditorOpenInBrowserBox` — non-`@Observable` bridge class + `FocusedValueKey`, mirrors `EditorQuickViewBox`
- `MacintoraEditor` + `Coordinator` — `openInBrowserBox` property; `wireOpenInBrowserHandler` and `bindOpenInBrowserBox` methods; `updateNSView` rebinds on box-identity changes
- `MacintoraApp` — `WindowGroup(for: DBCacheInputValue)` passes all new fields; "Open in DB Browser" (⌥⌘B) menu command
- `MainDocumentView` — `@State private var openInBrowserBox`; `.focusedSceneValue(\.editorOpenInBrowserBox, ...)`; `completionConfig` includes `mainConnectionProvider`

### Tests
- `DBCacheVMInitTests` — verifies init seeding of searchCriteria + pending-selection fields
- `DBBrowserInputMapperTests` — covers all four `ResolvedDBReference` cases
- `DBBrowserWindowRegistryTests` — register, find, deregister, idempotency, same-TNS replace

## Test plan

- [ ] Right-click on a table name → context menu shows "Show in DB Browser" → browser opens pre-filtered to that table on Details tab
- [ ] ⌥⌘+click on a package name → browser opens pre-filtered to that package
- [ ] ⌥⌘B with cursor on a column reference → browser opens on the parent table
- [ ] Second ⌥⌘B with a browser already open for the same connection → reuses the window (no new window)
- [ ] "Show all types" button appears in QuickFilterView when triggered from editor; clears on click
- [ ] ⌘+click still triggers Quick View (not browser)
- [ ] Read-only editors (DB Browser source viewer) with no `completionConfig` — no crash, no browser trigger
- [ ] Unit tests: `xcodebuild test -scheme Macintora -destination 'platform=macOS'`

Closes #13

https://claude.ai/code/session_01N9QQKAS25sZQGb9yqEcTQP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9QQKAS25sZQGb9yqEcTQP)_