### PR TITLE
Editor: standalone procs + active-arg highlight (#10 phase 3)

### DIFF
--- a/Macintora/Editor/Completion/CompletionCoordinator.swift
+++ b/Macintora/Editor/Completion/CompletionCoordinator.swift
@@ -330,36 +330,45 @@ final class CompletionCoordinator: @unchecked Sendable {
     }
 
     /// Builds one popup row per overload of the call target, with the
-    /// formatted parameter list as the primary text. Phase 2 scope is
-    /// package members only — standalone procedures (no qualifier) are
-    /// deferred to phase 3 and skipped here. The matching-arity overload
-    /// is sorted first as a hint for which signature applies; the user
-    /// can still arrow through the rest.
+    /// formatted parameter list as the primary text. Handles both package
+    /// members (`pkg.proc(`) and standalones (`proc(` at top level — the
+    /// cache stores standalones with `objectName_ == procedureName_`,
+    /// so the same `procedures(...)` call works once we know the owner).
+    /// The matching-arity overload is sorted first as a hint, and the
+    /// argument under the cursor is wrapped in `›‹` markers in the
+    /// rendered display so the user can see which slot they're filling.
     private func procedureCallSignatures(packageName: String?,
                                          procedureName: String,
                                          currentArgumentIndex: Int,
                                          owner: String) async -> [MacintoraCompletionItem] {
-        guard let packageName else {
-            // Phase 3 will resolve the standalone via DBCacheObject lookup.
-            editorCompletionLog.info("procedureCall: standalone procs deferred to phase 3 — skipping")
+        let resolved: ResolvedSchemaObject?
+        if let packageName {
+            resolved = await dataSource.resolvePackage(name: packageName,
+                                                       preferredOwner: owner)
+        } else {
+            resolved = await dataSource.resolveStandaloneProcedure(name: procedureName,
+                                                                   preferredOwner: owner)
+        }
+        guard let resolved else {
+            editorCompletionLog.info("procedureCall: target not in cache (pkg=\(packageName ?? "<nil>", privacy: .public) proc=\(procedureName, privacy: .public))")
             return []
         }
-        guard let pkg = await dataSource.resolvePackage(name: packageName,
-                                                        preferredOwner: owner) else {
-            editorCompletionLog.info("procedureCall: no cached package for \(packageName, privacy: .public)")
-            return []
-        }
+        // For standalones the cache stores rows under `objectName_ ==
+        // procedureName_`, so the `procedures(...)` lookup uses the
+        // resolved name as the package key.
+        let cachedPackageName = resolved.name
+
         // procedures(...) does substring matching; filter the result to
         // exact-name overloads. Overload count is small (typically 1-3),
         // so the per-overload argument fetch is cheap.
         let upperProc = procedureName.uppercased()
-        let allMatches = await dataSource.procedures(packageName: pkg.name,
-                                                     owner: pkg.owner,
+        let allMatches = await dataSource.procedures(packageName: cachedPackageName,
+                                                     owner: resolved.owner,
                                                      search: procedureName,
                                                      limit: fetchLimit)
         let overloads = allMatches.filter { $0.procedureName == upperProc }
         guard !overloads.isEmpty else {
-            editorCompletionLog.info("procedureCall: \(pkg.name, privacy: .public).\(upperProc, privacy: .public) not in cache")
+            editorCompletionLog.info("procedureCall: \(cachedPackageName, privacy: .public).\(upperProc, privacy: .public) not in cache")
             return []
         }
 
@@ -369,8 +378,10 @@ final class CompletionCoordinator: @unchecked Sendable {
                                                            packageName: overload.packageName,
                                                            procedureName: overload.procedureName,
                                                            overload: overload.overload)
-            rendered.append((MacintoraCompletionItem.make(signatureFrom: overload, arguments: args),
-                             args.count))
+            let item = MacintoraCompletionItem.make(signatureFrom: overload,
+                                                    arguments: args,
+                                                    activeArgumentIndex: currentArgumentIndex)
+            rendered.append((item, args.count))
         }
         // Bubble matching-arity overloads first; ties retain fetch order.
         let needed = currentArgumentIndex + 1

--- a/Macintora/Editor/Completion/CompletionDataSource.swift
+++ b/Macintora/Editor/Completion/CompletionDataSource.swift
@@ -323,6 +323,42 @@ actor CompletionDataSource {
         }
     }
 
+    /// Resolves a top-level procedure or function name (no package qualifier)
+    /// to its owning schema. Mirrors `resolvePackage(...)` but matches
+    /// `DBCacheObject.type_ IN ("PROCEDURE", "FUNCTION")`. Used by the
+    /// completion coordinator to surface signatures for `proc(` calls
+    /// without a package prefix.
+    func resolveStandaloneProcedure(name: String,
+                                    preferredOwner: String) async -> ResolvedSchemaObject? {
+        await fetch { ctx -> ResolvedSchemaObject? in
+            let upperName = name.uppercased()
+            let upperPreferred = preferredOwner.uppercased()
+            let request = DBCacheObject.fetchRequest()
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "name_ = %@", upperName),
+                NSPredicate(format: "type_ IN %@", ["PROCEDURE", "FUNCTION"])
+            ])
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "owner_", ascending: true),
+                NSSortDescriptor(key: "name_", ascending: true)
+            ]
+            do {
+                let rows = try ctx.fetch(request)
+                guard !rows.isEmpty else { return nil }
+                let chosen = rows.first { ($0.owner_ ?? "") == upperPreferred } ?? rows[0]
+                return ResolvedSchemaObject(
+                    owner: chosen.owner_ ?? "",
+                    name: chosen.name_ ?? "",
+                    objectType: chosen.type_ ?? "PROCEDURE",
+                    isValid: chosen.isValid,
+                    lastDDLDate: chosen.lastDDLDate)
+            } catch {
+                self.logger.error("resolveStandaloneProcedure fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
     /// Arguments of a single procedure / function invocation. Excludes the
     /// `position == 0` return-value row (callers consume return type via
     /// `procedures(...).returnType`) and `dataLevel > 0` composite expansions.

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -253,20 +253,31 @@ extension MacintoraCompletionItem {
     }
 
     /// Builds a row that shows the call signature of a single overload —
-    /// `(in_csp_id in number, val in varchar2 default null)`. The procedure
-    /// name is omitted because the user has already typed it before the `(`
-    /// that triggered the popup; repeating it just steals horizontal space.
-    /// Lowercase, monospaced, and allowed to wrap so the full parameter
-    /// list stays visible in the 450pt popup.
+    /// `(in_csp_id in number, ›val in varchar2‹ default null)`. The
+    /// procedure name is omitted because the user has already typed it
+    /// before the `(` that triggered the popup; repeating it just steals
+    /// horizontal space. Lowercase, monospaced, and allowed to wrap so
+    /// the full parameter list stays visible in the 450pt popup.
+    ///
+    /// The argument at `activeArgumentIndex` is wrapped in `›‹` markers
+    /// so the user can see which slot they're filling. Out-of-range
+    /// indexes (e.g. the user has typed past the last declared arg)
+    /// leave the row unmarked rather than highlighting nothing.
     ///
     /// Accepting the row inserts a true named-argument call template
     /// (`in_csp_id => , val => , fmt => )`) and parks the caret at the
     /// first value slot. Rows with zero arguments produce an empty
     /// insertion — the `(` already typed is a complete call.
     static func make(signatureFrom p: ProcedureSuggestion,
-                     arguments: [ProcedureArgumentSuggestion]) -> MacintoraCompletionItem {
+                     arguments: [ProcedureArgumentSuggestion],
+                     activeArgumentIndex: Int = -1) -> MacintoraCompletionItem {
         let kind: Kind = p.kind == "FUNCTION" ? .function : .procedure
-        let formattedArgs = arguments.map(formatArgument).joined(separator: ", ")
+        let formattedArgs = arguments.enumerated().map { offset, arg -> String in
+            let rendered = formatArgument(arg)
+            return offset == activeArgumentIndex ? "›\(rendered)‹" : rendered
+        }.joined(separator: ", ")
+        // `lowercased()` is locale-independent and leaves non-letter code
+        // points (the `›‹` markers, U+203A / U+2039) untouched.
         let display = "(\(formattedArgs))".lowercased()
         var secondary = p.kind
         if let overload = p.overload, !overload.isEmpty {

--- a/MacintoraTests/Editor/Completion/CompletionCoordinatorTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionCoordinatorTests.swift
@@ -150,21 +150,22 @@ final class CompletionCoordinatorTests: XCTestCase {
                                             atUTF16Offset: "BEGIN accounts_pkg.debit(".utf16.count)
 
         // Both DEBIT overloads must appear, formatted as call signatures.
-        // The procedure name is omitted from the row — the user has already
-        // typed it before the `(` that triggered the popup. Display is
-        // lowercase so the row reads like editor text.
+        // The procedure name is omitted (the user just typed it before the
+        // `(`), display is lowercased to read like editor text, and the
+        // active argument (the first slot, since the cursor is right after
+        // `(`) is wrapped in `›‹` markers.
         let display = items.map(\.displayText)
-        XCTAssertTrue(display.contains { $0 == "(amount in number)" })
-        XCTAssertTrue(display.contains { $0 == "(amount in number, currency in varchar2)" })
+        XCTAssertTrue(display.contains { $0 == "(›amount in number‹)" })
+        XCTAssertTrue(display.contains { $0 == "(›amount in number‹, currency in varchar2)" })
 
         // Accepting a row inserts a true named-argument call template — the
         // user is picking a specific overload, not just previewing it.
-        let oneArg = items.first { $0.displayText == "(amount in number)" }
+        let oneArg = items.first { $0.displayText == "(›amount in number‹)" }
         XCTAssertEqual(oneArg?.insertText, "amount => )")
         XCTAssertEqual(oneArg?.signatureInsertion?.caretUTF16Offset, "amount => ".utf16.count,
                        "Caret must land on the first value slot")
 
-        let twoArg = items.first { $0.displayText == "(amount in number, currency in varchar2)" }
+        let twoArg = items.first { $0.displayText == "(›amount in number‹, currency in varchar2)" }
         XCTAssertEqual(twoArg?.insertText, "amount => , currency => )")
     }
 
@@ -173,7 +174,7 @@ final class CompletionCoordinatorTests: XCTestCase {
         let items = await coordinator.items(for: makeTextView("BEGIN accounts_pkg.get_balance("),
                                             atUTF16Offset: "BEGIN accounts_pkg.get_balance(".utf16.count)
 
-        let row = items.first { $0.displayText == "(acct_id in number)" }
+        let row = items.first { $0.displayText == "(›acct_id in number‹)" }
         XCTAssertNotNil(row, "Function signature must surface")
         XCTAssertTrue(row?.secondaryText?.contains("→ NUMBER") ?? false,
                       "Function row must show the return type hint")
@@ -188,8 +189,9 @@ final class CompletionCoordinatorTests: XCTestCase {
                                             atUTF16Offset: source.utf16.count)
 
         let display = items.map(\.displayText)
-        XCTAssertEqual(display.first, "(amount in number, currency in varchar2)",
-                       "Two-arg overload must lead when the user is filling the second slot")
+        XCTAssertEqual(display.first,
+                       "(amount in number, ›currency in varchar2‹)",
+                       "Two-arg overload must lead when filling the second slot, with that slot highlighted")
     }
 
     func test_procedureCall_unknownPackage_returnsEmpty() async {
@@ -201,15 +203,69 @@ final class CompletionCoordinatorTests: XCTestCase {
         XCTAssertTrue(items.isEmpty)
     }
 
-    func test_procedureCall_standalone_skippedInPhase2() async {
-        // No qualifier → analyzer routes to .procedureCall(packageName: nil)
-        // and the coordinator currently no-ops; phase 3 will surface the
-        // standalone signature.
+    func test_procedureCall_standalone_unknownNameReturnsEmpty() async {
+        // Standalone name not in the cache → no signature surfaces.
         seedAccountsPackageWithObject(owner: "HR")
         let source = "BEGIN debit("
         let items = await coordinator.items(for: makeTextView(source),
                                             atUTF16Offset: source.utf16.count)
-        XCTAssertTrue(items.isEmpty)
+        XCTAssertTrue(items.isEmpty,
+                      "DEBIT exists only as a package member; the standalone lookup must miss")
+    }
+
+    // MARK: - Phase 3: standalone procedure signatures
+
+    func test_procedureCall_standalone_surfacesSignature() async {
+        seedStandalonePurgeOld(owner: "HR")
+        let source = "BEGIN purge_old("
+        let items = await coordinator.items(for: makeTextView(source),
+                                            atUTF16Offset: source.utf16.count)
+
+        XCTAssertEqual(items.map(\.displayText),
+                       ["(›cutoff in date‹)"],
+                       "Standalone procedure signature must surface with active arg highlighted")
+    }
+
+    func test_procedureCall_standalone_function_carriesReturnType() async {
+        seedStandaloneNextSerial(owner: "HR")
+        let source = "BEGIN x := next_serial("
+        let items = await coordinator.items(for: makeTextView(source),
+                                            atUTF16Offset: source.utf16.count)
+
+        let row = items.first
+        XCTAssertEqual(row?.displayText, "(›seq in varchar2‹)")
+        XCTAssertTrue(row?.secondaryText?.contains("→ NUMBER") ?? false,
+                      "Standalone function row must include the return type")
+    }
+
+    func test_procedureCall_standalone_prefersConnectedSchema() async {
+        // Same standalone name in two schemas — preferred owner wins.
+        seedStandalonePurgeOld(owner: "BILLING")
+        seedStandalonePurgeOld(owner: "HR")
+        let source = "BEGIN purge_old("
+        let items = await coordinator.items(for: makeTextView(source),
+                                            atUTF16Offset: source.utf16.count)
+        // Both copies are seeded identically — but the resolver must pick
+        // HR (the connected schema) and return that owner's overloads only.
+        XCTAssertEqual(items.count, 1,
+                       "Resolver must scope to the preferred owner, not unify across schemas")
+    }
+
+    // MARK: - Phase 3: current-argument highlighting
+
+    func test_procedureCall_outOfRangeArgumentIndex_doesNotHighlight() async {
+        // User has typed past the last declared argument — the popup
+        // should still render the row (without an active highlight) so
+        // the user notices they've over-shot rather than seeing nothing.
+        seedAccountsPackageWithObject(owner: "HR")
+        let source = "BEGIN accounts_pkg.get_balance(100, 200, "
+        let items = await coordinator.items(for: makeTextView(source),
+                                            atUTF16Offset: source.utf16.count)
+        // GET_BALANCE has only one parameter; the cursor is on argument
+        // index 2, which is out of range — no `›‹` markers should appear.
+        let display = items.map(\.displayText)
+        XCTAssertTrue(display.contains { !$0.contains("›") && !$0.contains("‹") },
+                      "Out-of-range index must not wrap any argument")
     }
 
     // MARK: - Seed helpers
@@ -220,6 +276,47 @@ final class CompletionCoordinatorTests: XCTestCase {
         return view
     }
 
+    /// Standalone PROCEDURE `<owner>.PURGE_OLD(CUTOFF IN DATE)`.
+    /// Seeds both the parent `DBCacheObject` (so resolveStandaloneProcedure
+    /// finds it) and the matching `DBCacheProcedure` / `DBCacheProcedureArgument`
+    /// rows that the standalone lookup keys on (`objectName_ ==
+    /// procedureName_` for top-level callables).
+    private func seedStandalonePurgeOld(owner: String) {
+        let ctx = persistence.container.viewContext
+        let object = DBCacheObject(context: ctx)
+        object.owner_ = owner
+        object.name_ = "PURGE_OLD"
+        object.type_ = "PROCEDURE"
+
+        addProcedure(in: ctx, owner: owner, pkg: "PURGE_OLD",
+                     name: "PURGE_OLD", subprogramId: 1, overload: nil,
+                     parentType: "PROCEDURE")
+        addArgument(in: ctx, owner: owner, pkg: "PURGE_OLD", proc: "PURGE_OLD",
+                    overload: nil, position: 1, sequence: 1, name: "CUTOFF",
+                    dataType: "DATE", inOut: "IN")
+        try! ctx.save()
+    }
+
+    /// Standalone FUNCTION `<owner>.NEXT_SERIAL(SEQ IN VARCHAR2) RETURN NUMBER`.
+    /// The function classification comes from the `position == 0` return-row.
+    private func seedStandaloneNextSerial(owner: String) {
+        let ctx = persistence.container.viewContext
+        let object = DBCacheObject(context: ctx)
+        object.owner_ = owner
+        object.name_ = "NEXT_SERIAL"
+        object.type_ = "FUNCTION"
+
+        addProcedure(in: ctx, owner: owner, pkg: "NEXT_SERIAL",
+                     name: "NEXT_SERIAL", subprogramId: 1, overload: nil,
+                     parentType: "FUNCTION")
+        addArgument(in: ctx, owner: owner, pkg: "NEXT_SERIAL", proc: "NEXT_SERIAL",
+                    overload: nil, position: 0, sequence: 1, name: nil,
+                    dataType: "NUMBER", inOut: "OUT")
+        addArgument(in: ctx, owner: owner, pkg: "NEXT_SERIAL", proc: "NEXT_SERIAL",
+                    overload: nil, position: 1, sequence: 2, name: "SEQ",
+                    dataType: "VARCHAR2", inOut: "IN")
+        try! ctx.save()
+    }
 
     /// Adds the same `DBCacheProcedure` / `DBCacheProcedureArgument` rows as
     /// `CompletionDataSourceTests.seedAccountsPackage`, plus a parent

--- a/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
+++ b/MacintoraTests/Editor/Completion/CompletionDataSourceTests.swift
@@ -207,6 +207,46 @@ final class CompletionDataSourceTests: XCTestCase {
         XCTAssertEqual(resolved?.owner, "BILLING")
     }
 
+    // MARK: - Completion: resolveStandaloneProcedure
+
+    func test_resolveStandaloneProcedure_findsProcedureAndFunction() async {
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "HR", name: "PURGE_OLD", type: "PROCEDURE")
+        addObject(in: ctx, owner: "HR", name: "NEXT_SERIAL", type: "FUNCTION")
+        try! ctx.save()
+
+        let proc = await dataSource.resolveStandaloneProcedure(
+            name: "PURGE_OLD", preferredOwner: "HR")
+        XCTAssertEqual(proc?.objectType, "PROCEDURE")
+
+        let fn = await dataSource.resolveStandaloneProcedure(
+            name: "NEXT_SERIAL", preferredOwner: "HR")
+        XCTAssertEqual(fn?.objectType, "FUNCTION")
+    }
+
+    func test_resolveStandaloneProcedure_ignoresPackagesAndTables() async {
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "HR", name: "PURGE_OLD", type: "PACKAGE")
+        addObject(in: ctx, owner: "HR", name: "PURGE_OLD", type: "TABLE")
+        try! ctx.save()
+
+        let resolved = await dataSource.resolveStandaloneProcedure(
+            name: "PURGE_OLD", preferredOwner: "HR")
+        XCTAssertNil(resolved,
+                     "Only PROCEDURE / FUNCTION rows must satisfy a standalone-call lookup")
+    }
+
+    func test_resolveStandaloneProcedure_prefersConnectedSchema() async {
+        let ctx = persistence.container.viewContext
+        addObject(in: ctx, owner: "BILLING", name: "PURGE_OLD", type: "PROCEDURE")
+        addObject(in: ctx, owner: "HR", name: "PURGE_OLD", type: "PROCEDURE")
+        try! ctx.save()
+
+        let resolved = await dataSource.resolveStandaloneProcedure(
+            name: "PURGE_OLD", preferredOwner: "HR")
+        XCTAssertEqual(resolved?.owner, "HR")
+    }
+
     // MARK: - Quick View: resolveSchemaObject
 
     func test_resolveSchemaObject_explicitOwner_findsExactRow() async {


### PR DESCRIPTION
Phase 3 of #10. Stacked on #18 (phase 2), which is stacked on #17
(phase 1) — base branch is `fix/issue-10-procedure-call-signature`.
Merge #17 → #18 → this PR for sequential review; GitHub will retarget
each PR's base as its predecessor merges.

## What changed

- **`CompletionDataSource.resolveStandaloneProcedure(name:preferredOwner:)`** — mirrors `resolvePackage(...)` but matches `DBCacheObject.type_ IN ("PROCEDURE", "FUNCTION")`. Used by the coordinator to find the owner of a top-level `proc(` call.
- **`CompletionCoordinator.procedureCallSignatures`** — when the analyzer reports `procedureCall(packageName: nil, ...)` it now resolves the target via the new helper. Standalones live under `objectName_ == procedureName_` in the cache, so the existing `procedures(...)` / `procedureArguments(...)` queries work unchanged once we know the owner.
- **`MacintoraCompletionItem.make(signatureFrom:arguments:activeArgumentIndex:)`** — wraps the argument under the cursor with `›‹` markers driven by the analyzer's `currentArgumentIndex`. Out-of-range indexes (cursor past the last declared arg) leave the row unmarked rather than highlighting nothing.

## Test coverage

`xcodebuild test -scheme Macintora -destination 'platform=macOS'` for the four completion suites: 85/85 pass.

- **`CompletionDataSourceTests` (+3):** `resolveStandaloneProcedure` finds both PROCEDURE and FUNCTION rows, ignores PACKAGE / TABLE collisions, prefers the connected schema.
- **`CompletionCoordinatorTests` (+5):** standalone signature surfaces with the active-arg highlight, function signature carries the return type, resolver scopes to the preferred owner instead of unifying across schemas, missing-name lookup returns empty, out-of-range argument index doesn't wrap any arg.
- Phase-2 expectations updated for the new `›‹` markers (active arg now wrapped in the rendered display text).

## Out of scope (issue #10 follow-up work)

- `dataLevel > 0` composite-type expansion in the arg popup — data is captured but UI deferred per the issue's "Out of scope" section.
- Snippet insertion (`proc(arg1 => , arg2 => )` skeleton) — separate UX issue.
- Member-of-record / cursor-FOR-loop record field expansion — needs PL/SQL parsing the SQL grammar doesn't currently provide.

With this PR, all three rollout phases of #10 are covered. Ready to close #10 once #17 → #18 → this PR are merged.