### PR TITLE
Fix #15: cancel actually breaks the in-flight statement

### DIFF
--- a/Macintora/Results/OracleScriptExecutor.swift
+++ b/Macintora/Results/OracleScriptExecutor.swift
@@ -58,8 +58,12 @@ struct OracleScriptExecutor: ConnectionExecutor, Sendable {
 
     @concurrent
     func cancel() async {
-        // No-op: cancellation propagates from the runner's parent Task into
-        // the in-flight `try await` on the row iterator.
+        // Issue #15: send a TNS BREAK so the server actually
+        // interrupts the in-flight statement. Task cancellation
+        // alone doesn't propagate to oracle-nio's awaited promise,
+        // so the next unit would otherwise queue behind a runaway
+        // statement until it finished naturally.
+        conn.cancel()
     }
 
     @concurrent

--- a/Macintora/Results/ResultViewModel.swift
+++ b/Macintora/Results/ResultViewModel.swift
@@ -166,6 +166,12 @@ public final class ResultViewModel: nonisolated ObservableObject {
     }
 
     func cancel() {
+        // Issue #15: send a server-side TNS BREAK so the in-flight
+        // statement actually stops. `Task.cancel()` alone doesn't
+        // propagate to oracle-nio's awaited promise, so the next
+        // execute would otherwise queue behind the runaway statement
+        // until it finished naturally.
+        resultsController.document?.conn?.cancel()
         currentTask?.cancel()
         currentTask = nil
         // Bug B: drop the iterator reference so oracle-nio's


### PR DESCRIPTION
## Summary
- Wire the cancel button to `OracleConnection.cancel()` so the server actually interrupts the in-flight statement instead of letting it run to completion.
- Touches `ResultViewModel.cancel()` and `OracleScriptExecutor.cancel()`.

## Context
Closes #15. Before this change, cancel only called `Task.cancel()` and dropped the row iterator — fine for mid-fetch, but oracle-nio's awaited promise didn't observe Task cancellation, so for any statement still parsing/executing/sleeping the cancel "succeeded" in the UI while the server-side session stayed busy and the next `execute(...)` waited until the runaway finished.

The fix relies on the new `OracleConnection.cancel()` added on the oracle-nio `macintora` branch (SHA `9293da5`), which sends a TNS INTERRUPT marker and lets the server raise `ORA-01013`. The next statement runs in milliseconds for CPU-bound queries / a few seconds for a kernel sleep.

## Test plan
- [x] `xcodebuild test -scheme Macintora -only-testing:MacintoraTests` — 490 unit tests pass
- [x] Live: connect with `local`, run `BEGIN dbms_session.sleep(10); END;`, hit cancel, run `select * from user_tables` — runs promptly
- [x] Live: cancel mid-fetch on a long-running SELECT — iterator throws `.statementCancelled`, follow-up runs immediately
- [x] Live: cancel on idle connection — no-op, follow-up unaffected