### PR TITLE
Surface worksheet shortcuts in the menu bar

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -138,6 +138,12 @@
 		49DB100A0000000A /* STDBObjectQuickViewPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000A0000000A /* STDBObjectQuickViewPlugin.swift */; };
 		49DB100B0000000B /* EditorQuickViewBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000B0000000B /* EditorQuickViewBox.swift */; };
 		49DB100F0000000F /* EditorOpenInBrowserBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000F0000000F /* EditorOpenInBrowserBox.swift */; };
+		49DB102000000020 /* WorksheetCommandsBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002000000020 /* WorksheetCommandsBox.swift */; };
+		49DB102100000021 /* EditorToggleCommentBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002100000021 /* EditorToggleCommentBox.swift */; };
+		49DB102200000022 /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002200000022 /* KeyboardShortcuts.swift */; };
+		49DB302300000023 /* WorksheetCommandsBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002300000023 /* WorksheetCommandsBoxTests.swift */; };
+		49DB302400000024 /* EditorToggleCommentBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002400000024 /* EditorToggleCommentBoxTests.swift */; };
+		49DB302500000025 /* KeyboardShortcutsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002500000025 /* KeyboardShortcutsTests.swift */; };
 		49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000C0000000C /* ObjectAtCursorResolverTests.swift */; };
 		49DB301000000010 /* QuickViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001000000010 /* QuickViewControllerTests.swift */; };
 		49DB301200000012 /* EditorQuickViewBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001200000012 /* EditorQuickViewBoxTests.swift */; };
@@ -246,6 +252,12 @@
 		4944594B28D51D31007AB2BF /* SBMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBMainView.swift; sourceTree = "<group>"; };
 		4944594D28D539D2007AB2BF /* SBVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBVM.swift; sourceTree = "<group>"; };
 		49DB001A0000001A /* SessionBrowserBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionBrowserBox.swift; sourceTree = "<group>"; };
+		49DB002000000020 /* WorksheetCommandsBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorksheetCommandsBox.swift; sourceTree = "<group>"; };
+		49DB002100000021 /* EditorToggleCommentBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorToggleCommentBox.swift; sourceTree = "<group>"; };
+		49DB002200000022 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
+		49DB002300000023 /* WorksheetCommandsBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorksheetCommandsBoxTests.swift; sourceTree = "<group>"; };
+		49DB002400000024 /* EditorToggleCommentBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorToggleCommentBoxTests.swift; sourceTree = "<group>"; };
+		49DB002500000025 /* KeyboardShortcutsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutsTests.swift; sourceTree = "<group>"; };
 		4944594F28D68EFE007AB2BF /* SessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionView.swift; sourceTree = "<group>"; };
 		4947FEA5286FA39D00AEBE60 /* TableViewWithPasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TableViewWithPasteboard.swift; path = Macintora/Results/TableViewWithPasteboard.swift; sourceTree = SOURCE_ROOT; };
 		4947FEA7286FA3E200AEBE60 /* ResultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsController.swift; sourceTree = "<group>"; };
@@ -518,6 +530,8 @@
 				AA0000410000000000000000 /* ConnectionDetailsCodableTests.swift */,
 				AA0000C10000000000000000 /* LegacyDocumentMigrationTests.swift */,
 				AA0000F10000000000000000 /* FullRefreshReproTests.swift */,
+				49DB002300000023 /* WorksheetCommandsBoxTests.swift */,
+				49DB002500000025 /* KeyboardShortcutsTests.swift */,
 				49B0C0DE0000000000000040 /* DBBrowser */,
 				49D0ECF22F9C1E070047540A /* Editor */,
 				49D0ED042F9C34410047540A /* Results */,
@@ -538,6 +552,8 @@
 				4982889628B1C41700A28B04 /* Formatter.swift */,
 				49C62C2327E010AE00DE69E4 /* ConnectionListView.swift */,
 				4982890C28B95BC100A28B04 /* SettingsView.swift */,
+				49DB002000000020 /* WorksheetCommandsBox.swift */,
+				49DB002200000022 /* KeyboardShortcuts.swift */,
 				AA0000200000000000000000 /* DB */,
 				AA0000B60000000000000000 /* Connections */,
 			);
@@ -702,6 +718,7 @@
 				49D0ECF02F9C1DBF0047540A /* MacintoraEditor+Coordinator.swift */,
 				49C0000700000007 /* MacintoraEditor+Completion.swift */,
 				49141400000000000000A001 /* PlsqlBlockDetector.swift */,
+				49DB002100000021 /* EditorToggleCommentBox.swift */,
 				49C0200000000000 /* Completion */,
 				49DB000D0000000D /* Plugins */,
 			);
@@ -715,6 +732,7 @@
 				49D0ECF52F9C1EB90047540A /* GetCurrentSqlTests.swift */,
 				49141400000000000000A003 /* PlsqlBlockDetectorTests.swift */,
 				49EE000100000001 /* MacintoraSTTextViewTests.swift */,
+				49DB002400000024 /* EditorToggleCommentBoxTests.swift */,
 				49C0300000000010 /* Completion */,
 				49DB001E0000001E /* Plugins */,
 			);
@@ -1004,6 +1022,9 @@
 				49B0C0DE0000000000000130 /* DBBrowserInputMapperTests.swift in Sources */,
 				49B0C0DE0000000000000131 /* DBBrowserWindowRegistryTests.swift in Sources */,
 				49B0C0DE0000000000000132 /* DBCacheVMInitTests.swift in Sources */,
+				49DB302300000023 /* WorksheetCommandsBoxTests.swift in Sources */,
+				49DB302400000024 /* EditorToggleCommentBoxTests.swift in Sources */,
+				49DB302500000025 /* KeyboardShortcutsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1142,6 +1163,9 @@
 				49DB100A0000000A /* STDBObjectQuickViewPlugin.swift in Sources */,
 				49DB100B0000000B /* EditorQuickViewBox.swift in Sources */,
 				49DB100F0000000F /* EditorOpenInBrowserBox.swift in Sources */,
+				49DB102000000020 /* WorksheetCommandsBox.swift in Sources */,
+				49DB102100000021 /* EditorToggleCommentBox.swift in Sources */,
+				49DB102200000022 /* KeyboardShortcuts.swift in Sources */,
 				49B0C0DE0000000000000120 /* DBBrowserInputMapper.swift in Sources */,
 				49B0C0DE0000000000000121 /* DBBrowserWindowRegistry.swift in Sources */,
 			);

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		49DB302300000023 /* WorksheetCommandsBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002300000023 /* WorksheetCommandsBoxTests.swift */; };
 		49DB302400000024 /* EditorToggleCommentBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002400000024 /* EditorToggleCommentBoxTests.swift */; };
 		49DB302500000025 /* KeyboardShortcutsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002500000025 /* KeyboardShortcutsTests.swift */; };
+		49DB102600000026 /* UITestInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002600000026 /* UITestInstrumentation.swift */; };
+		49DB402700000027 /* EditorShortcutsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB002700000027 /* EditorShortcutsUITests.swift */; };
 		49DB300C0000000C /* ObjectAtCursorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB000C0000000C /* ObjectAtCursorResolverTests.swift */; };
 		49DB301000000010 /* QuickViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001000000010 /* QuickViewControllerTests.swift */; };
 		49DB301200000012 /* EditorQuickViewBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB001200000012 /* EditorQuickViewBoxTests.swift */; };
@@ -258,6 +260,8 @@
 		49DB002300000023 /* WorksheetCommandsBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorksheetCommandsBoxTests.swift; sourceTree = "<group>"; };
 		49DB002400000024 /* EditorToggleCommentBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorToggleCommentBoxTests.swift; sourceTree = "<group>"; };
 		49DB002500000025 /* KeyboardShortcutsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutsTests.swift; sourceTree = "<group>"; };
+		49DB002600000026 /* UITestInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestInstrumentation.swift; sourceTree = "<group>"; };
+		49DB002700000027 /* EditorShortcutsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorShortcutsUITests.swift; sourceTree = "<group>"; };
 		4944594F28D68EFE007AB2BF /* SessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionView.swift; sourceTree = "<group>"; };
 		4947FEA5286FA39D00AEBE60 /* TableViewWithPasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TableViewWithPasteboard.swift; path = Macintora/Results/TableViewWithPasteboard.swift; sourceTree = SOURCE_ROOT; };
 		4947FEA7286FA3E200AEBE60 /* ResultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsController.swift; sourceTree = "<group>"; };
@@ -630,6 +634,7 @@
 				49CE5FEE27279F09009C2A94 /* Results */,
 				4944594A28D51CE5007AB2BF /* SessionBrowser */,
 				49B6D13227335FF400D9D788 /* Utils.swift */,
+				49DB002600000026 /* UITestInstrumentation.swift */,
 				49B55F37270ADD8D00CFB3C7 /* Assets.xcassets */,
 				49B55F3C270ADD8D00CFB3C7 /* Info.plist */,
 				49B55F3D270ADD8D00CFB3C7 /* Macintora.entitlements */,
@@ -835,6 +840,7 @@
 				490E96E92FA43C6300DDF37F /* ScriptRunnerUXTests.swift */,
 				49DB001B0000001B /* EditTransformationsKeyEquivalentTests.swift */,
 				49DB001400000014 /* QuickViewUITests.swift */,
+				49DB002700000027 /* EditorShortcutsUITests.swift */,
 			);
 			path = MacintoraUITests;
 			sourceTree = "<group>";
@@ -1080,6 +1086,7 @@
 				498288FC28B7DCB000A28B04 /* DBSourceDetailView.swift in Sources */,
 				498288CF28B7DC5700A28B04 /* DBCacheSource+CoreDataProperties.swift in Sources */,
 				49B6D13327335FF400D9D788 /* Utils.swift in Sources */,
+				49DB102600000026 /* UITestInstrumentation.swift in Sources */,
 				498288C028B7DC5700A28B04 /* DBCacheObject+CoreDataProperties.swift in Sources */,
 				498288F828B7DCB000A28B04 /* HostingView.swift in Sources */,
 				49CE5FF027279F3A009C2A94 /* ResultView.swift in Sources */,
@@ -1180,6 +1187,7 @@
 				490E96EA2FA43C6300DDF37F /* ScriptRunnerUXTests.swift in Sources */,
 				49DB401400000014 /* QuickViewUITests.swift in Sources */,
 				49DB401B0000001B /* EditTransformationsKeyEquivalentTests.swift in Sources */,
+				49DB402700000027 /* EditorShortcutsUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora/Editor/EditorToggleCommentBox.swift
+++ b/Macintora/Editor/EditorToggleCommentBox.swift
@@ -1,0 +1,33 @@
+//
+//  EditorToggleCommentBox.swift
+//  Macintora
+//
+//  Bridge object that lets the SwiftUI menu command (⌘/) trigger
+//  Toggle Line Comment on the focused editor without holding a direct
+//  reference to the AppKit text view.
+//
+//  Mirrors the `EditorQuickViewBox` pattern — intentionally **not**
+//  `@Observable` to avoid the menu-invalidation → constraint-loop crash
+//  described in `EditorQuickViewBox.swift`.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class EditorToggleCommentBox {
+    var trigger: (() -> Void)?
+}
+
+// MARK: - FocusedValueKey
+
+struct EditorToggleCommentBoxKey: FocusedValueKey {
+    typealias Value = EditorToggleCommentBox
+}
+
+extension FocusedValues {
+    var editorToggleCommentBox: EditorToggleCommentBoxKey.Value? {
+        get { self[EditorToggleCommentBoxKey.self] }
+        set { self[EditorToggleCommentBoxKey.self] = newValue }
+    }
+}

--- a/Macintora/Editor/MacintoraEditor+Coordinator.swift
+++ b/Macintora/Editor/MacintoraEditor+Coordinator.swift
@@ -60,6 +60,9 @@ extension MacintoraEditorRepresentable {
         /// can detect identity changes and avoid double-binding.
         weak var openInBrowserBoxRef: EditorOpenInBrowserBox?
 
+        /// Weak reference back to the SwiftUI-owned Toggle Line Comment box.
+        weak var toggleCommentBoxRef: EditorToggleCommentBox?
+
         /// Last UTF-16 cursor location seen in the selection callback. Used to
         /// detect when the cursor moves outside the in-progress identifier so
         /// auto-trigger can be cancelled.
@@ -155,6 +158,20 @@ extension MacintoraEditorRepresentable {
             box.trigger = { [weak controller, weak textView] in
                 guard let controller, let textView else { return }
                 controller.openInBrowserAtCursor(textView: textView)
+            }
+        }
+
+        /// Wires the SwiftUI-owned `EditorToggleCommentBox` to this editor's
+        /// text view. The box's `trigger` becomes the path the ⌘/ menu
+        /// command uses to call `MacintoraSTTextView.toggleLineComment`.
+        @MainActor
+        func bindToggleCommentBox(_ box: EditorToggleCommentBox?, textView: STTextView) {
+            toggleCommentBoxRef?.trigger = nil
+            toggleCommentBoxRef = box
+            guard let box else { return }
+            box.trigger = { [weak textView] in
+                guard let textView = textView as? MacintoraSTTextView else { return }
+                textView.toggleLineComment(nil)
             }
         }
 

--- a/Macintora/Editor/MacintoraEditor.swift
+++ b/Macintora/Editor/MacintoraEditor.swift
@@ -53,6 +53,7 @@ struct MacintoraEditor: View {
     let completionConfig: EditorCompletionConfig?
     let quickViewBox: EditorQuickViewBox?
     let openInBrowserBox: EditorOpenInBrowserBox?
+    let toggleCommentBox: EditorToggleCommentBox?
 
     @AppStorage("editorTheme") private var editorThemeRaw: String = EditorTheme.default.rawValue
 
@@ -68,7 +69,8 @@ struct MacintoraEditor: View {
         accessibilityIdentifier: String = "editor.main",
         completionConfig: EditorCompletionConfig? = nil,
         quickViewBox: EditorQuickViewBox? = nil,
-        openInBrowserBox: EditorOpenInBrowserBox? = nil
+        openInBrowserBox: EditorOpenInBrowserBox? = nil,
+        toggleCommentBox: EditorToggleCommentBox? = nil
     ) {
         self._text = text
         self._selection = selection
@@ -82,6 +84,7 @@ struct MacintoraEditor: View {
         self.completionConfig = completionConfig
         self.quickViewBox = quickViewBox
         self.openInBrowserBox = openInBrowserBox
+        self.toggleCommentBox = toggleCommentBox
     }
 
     private var editorTheme: EditorTheme {
@@ -102,7 +105,8 @@ struct MacintoraEditor: View {
             theme: editorTheme,
             completionConfig: completionConfig,
             quickViewBox: quickViewBox,
-            openInBrowserBox: openInBrowserBox
+            openInBrowserBox: openInBrowserBox,
+            toggleCommentBox: toggleCommentBox
         )
         .id(editorTheme)
     }
@@ -122,6 +126,7 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
     let completionConfig: EditorCompletionConfig?
     let quickViewBox: EditorQuickViewBox?
     let openInBrowserBox: EditorOpenInBrowserBox?
+    let toggleCommentBox: EditorToggleCommentBox?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(text: $text, selection: $selection)
@@ -165,6 +170,10 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
                 mainConnectionProvider: config.mainConnectionProvider)
             context.coordinator.bindOpenInBrowserBox(openInBrowserBox, textView: textView)
         }
+        // Toggle Line Comment doesn't depend on completion/Quick View, so wire
+        // it whether or not `completionConfig` is set — read-only viewers
+        // typically pass nil here.
+        context.coordinator.bindToggleCommentBox(toggleCommentBox, textView: textView)
 
         // Install the Neon syntax-highlighting plugin before the first text
         // assignment so the initial parse fires on the seeded content.
@@ -208,6 +217,9 @@ struct MacintoraEditorRepresentable: NSViewRepresentable {
             if context.coordinator.openInBrowserBoxRef !== openInBrowserBox {
                 context.coordinator.bindOpenInBrowserBox(openInBrowserBox, textView: textView)
             }
+        }
+        if context.coordinator.toggleCommentBoxRef !== toggleCommentBox {
+            context.coordinator.bindToggleCommentBox(toggleCommentBox, textView: textView)
         }
 
         if textView.isEditable != isEditable { textView.isEditable = isEditable }

--- a/Macintora/Editor/MacintoraSTTextView.swift
+++ b/Macintora/Editor/MacintoraSTTextView.swift
@@ -46,15 +46,6 @@ final class MacintoraSTTextView: STTextView {
         outdentLines(touching: textSelection)
     }
 
-    override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if mods == .command, event.charactersIgnoringModifiers == "/" {
-            toggleLineComment(nil)
-            return true
-        }
-        return super.performKeyEquivalent(with: event)
-    }
-
     /// Toggle SQL line comments (`-- `) on every line touched by the current
     /// selection. Behavior matches Xcode/VS Code: if every non-blank affected
     /// line is already commented, all are uncommented; otherwise every

--- a/Macintora/MainApp/KeyboardShortcuts.swift
+++ b/Macintora/MainApp/KeyboardShortcuts.swift
@@ -1,0 +1,101 @@
+//
+//  KeyboardShortcuts.swift
+//  Macintora
+//
+//  Source-of-truth list for the Macintora-specific keyboard shortcuts and
+//  the read-only cheatsheet window that surfaces them. Adding a new
+//  shortcut means updating `KeyboardShortcuts.groups` in one place — the
+//  cheatsheet view renders straight from the same data the menu items use.
+//
+//  Shortcut glyphs are rendered via `Text("⇧⌘R").monospaced()` rather than
+//  reconstructed from `EventModifiers`, matching the convention used by
+//  most macOS cheatsheet panels.
+//
+
+import SwiftUI
+
+struct KeyboardShortcutEntry: Identifiable, Hashable {
+    let label: String
+    let shortcut: String
+    var id: String { label }
+}
+
+struct KeyboardShortcutGroup: Identifiable, Hashable {
+    let title: String
+    let entries: [KeyboardShortcutEntry]
+    var id: String { title }
+}
+
+enum KeyboardShortcuts {
+    static let groups: [KeyboardShortcutGroup] = [
+        KeyboardShortcutGroup(title: "Database", entries: [
+            KeyboardShortcutEntry(label: "Manage Connections…", shortcut: "⇧⌘K"),
+            KeyboardShortcutEntry(label: "Database Browser", shortcut: "⇧⌘I"),
+            KeyboardShortcutEntry(label: "Session Browser", shortcut: "⌃⇧⌘S"),
+            KeyboardShortcutEntry(label: "Quick View", shortcut: "⌘I"),
+        ]),
+        KeyboardShortcutGroup(title: "Run", entries: [
+            KeyboardShortcutEntry(label: "Run", shortcut: "⌘R"),
+            KeyboardShortcutEntry(label: "Stop", shortcut: "⌘B"),
+            KeyboardShortcutEntry(label: "Run Script", shortcut: "⇧⌘R"),
+            KeyboardShortcutEntry(label: "Run From Cursor / Selection", shortcut: "⌥⌘R"),
+            KeyboardShortcutEntry(label: "Explain Plan", shortcut: "⌘E"),
+            KeyboardShortcutEntry(label: "Compile", shortcut: "⌥⌘C"),
+            KeyboardShortcutEntry(label: "Format", shortcut: "⌃⌘F"),
+        ]),
+        KeyboardShortcutGroup(title: "Editor", entries: [
+            KeyboardShortcutEntry(label: "Toggle Line Comment", shortcut: "⌘/"),
+            KeyboardShortcutEntry(label: "Make Upper Case", shortcut: "⌘U"),
+            KeyboardShortcutEntry(label: "Make Lower Case", shortcut: "⌘L"),
+        ]),
+        KeyboardShortcutGroup(title: "File", entries: [
+            KeyboardShortcutEntry(label: "New Tab", shortcut: "⇧⌘T"),
+        ]),
+    ]
+
+    /// Stable scene identifier used by `openWindow(id:)` and the matching
+    /// `Window` declaration in `MacintoraApp`.
+    static let windowID = "shortcuts"
+}
+
+struct KeyboardShortcutsView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                ForEach(KeyboardShortcuts.groups) { group in
+                    KeyboardShortcutGroupView(group: group)
+                }
+            }
+            .padding()
+            .frame(minWidth: 360, alignment: .leading)
+        }
+        .scrollIndicators(.hidden)
+        .accessibilityIdentifier("keyboard.shortcuts.window")
+    }
+}
+
+private struct KeyboardShortcutGroupView: View {
+    let group: KeyboardShortcutGroup
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(group.title)
+                .font(.headline)
+
+            Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 4) {
+                ForEach(group.entries) { entry in
+                    GridRow {
+                        Text(entry.label)
+                        Text(entry.shortcut)
+                            .monospaced()
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    KeyboardShortcutsView()
+}

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -263,11 +263,13 @@ struct MacOraApp: App {
             HelpMenuCommands()
             CommandGroup(after: .newItem) {
                 Button("New Tab") {
-                    let doc = try! NSDocumentController.shared.makeUntitledDocument(ofType: NSDocumentController.shared.defaultType!)
-                    NSDocumentController.shared.addDocument(doc)
-                    doc.makeWindowControllers()
-                    doc.windowControllers.first?.window?.tabbingMode = .preferred
-                    doc.showWindows()
+                    UITestProbe.shared.dispatch("New Tab") {
+                        let doc = try! NSDocumentController.shared.makeUntitledDocument(ofType: NSDocumentController.shared.defaultType!)
+                        NSDocumentController.shared.addDocument(doc)
+                        doc.makeWindowControllers()
+                        doc.windowControllers.first?.window?.tabbingMode = .preferred
+                        doc.showWindows()
+                    }
                 }
                     .keyboardShortcut("t", modifiers: [.command])
             }
@@ -332,7 +334,9 @@ struct MainDocumentMenuCommands: Commands {
     var body: some Commands {
         CommandMenu("Database") {
             Button("Manage Connections…") {
-                openSettings()
+                UITestProbe.shared.dispatch("Manage Connections") {
+                    openSettings()
+                }
             }
             .keyboardShortcut("k", modifiers: [.command, .shift])
 
@@ -344,7 +348,9 @@ struct MainDocumentMenuCommands: Commands {
             // closure captured in `wireOpenInBrowserHandler`, so the menu
             // doesn't need a `mainConnection` of its own.
             Button("Database Browser") {
-                openInBrowserBox?.trigger?()
+                UITestProbe.shared.dispatch("Database Browser") {
+                    openInBrowserBox?.trigger?()
+                }
             }
             .disabled(openInBrowserBox == nil)
             .keyboardShortcut("i", modifiers: [.command, .shift])
@@ -353,7 +359,9 @@ struct MainDocumentMenuCommands: Commands {
             // document + `OpenWindowAction` at install time, so this menu
             // doesn't need to know the focused connection.
             Button("Session Browser") {
-                sessionBrowserBox?.trigger?()
+                UITestProbe.shared.dispatch("Session Browser") {
+                    sessionBrowserBox?.trigger?()
+                }
             }
             .disabled(sessionBrowserBox == nil)
             .keyboardShortcut("s", modifiers: [.command, .control, .shift])
@@ -365,7 +373,9 @@ struct MainDocumentMenuCommands: Commands {
             // see the long comment in `EditorQuickViewBox` for the
             // constraint-loop crash that observable trigger reads caused.
             Button("Quick View") {
-                quickViewBox?.trigger?()
+                UITestProbe.shared.dispatch("Quick View") {
+                    quickViewBox?.trigger?()
+                }
             }
             .disabled(quickViewBox == nil)
             .keyboardShortcut("i", modifiers: [.command])
@@ -378,13 +388,17 @@ struct MainDocumentMenuCommands: Commands {
             // toolbar: connected + not executing for run-style commands;
             // executing only for Stop.
             Button("Run") {
-                worksheetCommandsBox?.runCurrent?()
+                UITestProbe.shared.dispatch("Run") {
+                    worksheetCommandsBox?.runCurrent?()
+                }
             }
             .disabled(!canRunStatement)
             .keyboardShortcut("r", modifiers: [.command])
 
             Button("Stop") {
-                worksheetCommandsBox?.stop?()
+                UITestProbe.shared.dispatch("Stop") {
+                    worksheetCommandsBox?.stop?()
+                }
             }
             .disabled(!canStop)
             .keyboardShortcut("b", modifiers: [.command])
@@ -392,13 +406,17 @@ struct MainDocumentMenuCommands: Commands {
             Divider()
 
             Button("Run Script") {
-                worksheetCommandsBox?.runScript?()
+                UITestProbe.shared.dispatch("Run Script") {
+                    worksheetCommandsBox?.runScript?()
+                }
             }
             .disabled(!canRunStatement)
             .keyboardShortcut("r", modifiers: [.command, .shift])
 
             Button("Run From Cursor / Selection") {
-                worksheetCommandsBox?.runFromCursorOrSelection?()
+                UITestProbe.shared.dispatch("Run From Cursor / Selection") {
+                    worksheetCommandsBox?.runFromCursorOrSelection?()
+                }
             }
             .disabled(!canRunStatement)
             .keyboardShortcut("r", modifiers: [.command, .option])
@@ -406,13 +424,17 @@ struct MainDocumentMenuCommands: Commands {
             Divider()
 
             Button("Explain Plan") {
-                worksheetCommandsBox?.explainPlan?()
+                UITestProbe.shared.dispatch("Explain Plan") {
+                    worksheetCommandsBox?.explainPlan?()
+                }
             }
             .disabled(!canRunStatement)
             .keyboardShortcut("e", modifiers: [.command])
 
             Button("Compile") {
-                worksheetCommandsBox?.compile?()
+                UITestProbe.shared.dispatch("Compile") {
+                    worksheetCommandsBox?.compile?()
+                }
             }
             .disabled(!canRunStatement)
             .keyboardShortcut("c", modifiers: [.command, .option])
@@ -421,7 +443,9 @@ struct MainDocumentMenuCommands: Commands {
 
             // Format works offline — only requires a focused worksheet.
             Button("Format") {
-                worksheetCommandsBox?.format?()
+                UITestProbe.shared.dispatch("Format") {
+                    worksheetCommandsBox?.format?()
+                }
             }
             .disabled(worksheetCommandsBox == nil)
             .keyboardShortcut("f", modifiers: [.command, .control])
@@ -437,7 +461,9 @@ struct EditorMenuCommands: Commands {
     var body: some Commands {
         CommandGroup(after: .textFormatting) {
             Button("Toggle Line Comment") {
-                toggleCommentBox?.trigger?()
+                UITestProbe.shared.dispatch("Toggle Line Comment") {
+                    toggleCommentBox?.trigger?()
+                }
             }
             .disabled(toggleCommentBox == nil)
             .keyboardShortcut("/", modifiers: [.command])

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -259,6 +259,8 @@ struct MacOraApp: App {
             SidebarCommands()
             ToolbarCommands()
             MainDocumentMenuCommands()
+            EditorMenuCommands()
+            HelpMenuCommands()
             CommandGroup(after: .newItem) {
                 Button("New Tab") {
                     let doc = try! NSDocumentController.shared.makeUntitledDocument(ofType: NSDocumentController.shared.defaultType!)
@@ -296,6 +298,15 @@ struct MacOraApp: App {
                 .environment(\.connectionStore, connectionStore)
                 .environment(\.keychainService, keychainService)
         }
+
+        // Read-only cheatsheet listing every Macintora-specific shortcut.
+        // Opened from `HelpMenuCommands` via `openWindow(id:)`. Content-sized
+        // so the window snaps to the layout's intrinsic size on first open
+        // and the user can't drag it down to a useless thumbnail.
+        Window("Keyboard Shortcuts", id: KeyboardShortcuts.windowID) {
+            KeyboardShortcutsView()
+        }
+        .windowResizability(.contentSize)
     }
 }
 
@@ -303,7 +314,20 @@ struct MainDocumentMenuCommands: Commands {
     @FocusedValue(\.editorQuickViewBox) var quickViewBox
     @FocusedValue(\.editorOpenInBrowserBox) var openInBrowserBox
     @FocusedValue(\.sessionBrowserBox) var sessionBrowserBox
+    @FocusedValue(\.worksheetCommandsBox) var worksheetCommandsBox
+    @FocusedValue(\.worksheetIsConnected) var worksheetIsConnected
+    @FocusedValue(\.worksheetIsExecuting) var worksheetIsExecuting
     @Environment(\.openSettings) private var openSettings
+
+    private var canRunStatement: Bool {
+        worksheetCommandsBox != nil
+            && worksheetIsConnected == .connected
+            && worksheetIsExecuting != true
+    }
+
+    private var canStop: Bool {
+        worksheetCommandsBox != nil && worksheetIsExecuting == true
+    }
 
     var body: some Commands {
         CommandMenu("Database") {
@@ -345,6 +369,94 @@ struct MainDocumentMenuCommands: Commands {
             }
             .disabled(quickViewBox == nil)
             .keyboardShortcut("i", modifiers: [.command])
+
+            Divider()
+
+            // Worksheet execution. The toolbar buttons remain the primary
+            // affordance — these menu items exist for HIG compliance and
+            // Help-menu search discoverability. Disabled state mirrors the
+            // toolbar: connected + not executing for run-style commands;
+            // executing only for Stop.
+            Button("Run") {
+                worksheetCommandsBox?.runCurrent?()
+            }
+            .disabled(!canRunStatement)
+            .keyboardShortcut("r", modifiers: [.command])
+
+            Button("Stop") {
+                worksheetCommandsBox?.stop?()
+            }
+            .disabled(!canStop)
+            .keyboardShortcut("b", modifiers: [.command])
+
+            Divider()
+
+            Button("Run Script") {
+                worksheetCommandsBox?.runScript?()
+            }
+            .disabled(!canRunStatement)
+            .keyboardShortcut("r", modifiers: [.command, .shift])
+
+            Button("Run From Cursor / Selection") {
+                worksheetCommandsBox?.runFromCursorOrSelection?()
+            }
+            .disabled(!canRunStatement)
+            .keyboardShortcut("r", modifiers: [.command, .option])
+
+            Divider()
+
+            Button("Explain Plan") {
+                worksheetCommandsBox?.explainPlan?()
+            }
+            .disabled(!canRunStatement)
+            .keyboardShortcut("e", modifiers: [.command])
+
+            Button("Compile") {
+                worksheetCommandsBox?.compile?()
+            }
+            .disabled(!canRunStatement)
+            .keyboardShortcut("c", modifiers: [.command, .option])
+
+            Divider()
+
+            // Format works offline — only requires a focused worksheet.
+            Button("Format") {
+                worksheetCommandsBox?.format?()
+            }
+            .disabled(worksheetCommandsBox == nil)
+            .keyboardShortcut("f", modifiers: [.command, .control])
+        }
+    }
+}
+
+/// Editor-affordance commands that aren't database-driven. Lives next to
+/// the system's Edit > Transformations entries via `after: .textFormatting`.
+struct EditorMenuCommands: Commands {
+    @FocusedValue(\.editorToggleCommentBox) var toggleCommentBox
+
+    var body: some Commands {
+        CommandGroup(after: .textFormatting) {
+            Button("Toggle Line Comment") {
+                toggleCommentBox?.trigger?()
+            }
+            .disabled(toggleCommentBox == nil)
+            .keyboardShortcut("/", modifiers: [.command])
+        }
+    }
+}
+
+/// Help menu entry that opens the cheatsheet window listing every
+/// Macintora-specific shortcut. The window itself is defined as a `Window`
+/// scene in `MacOraApp.body` so it gets state restoration and a fixed,
+/// content-sized layout.
+struct HelpMenuCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(after: .help) {
+            Button("Keyboard Shortcuts…") {
+                openWindow(id: KeyboardShortcuts.windowID)
+            }
         }
     }
 }

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -48,6 +48,16 @@ struct MainDocumentView: View {
     /// `[weak document]` reference so the menu command can stay free of
     /// `@FocusedValue(\.mainConnection)` reads.
     @State private var sessionBrowserBox = SessionBrowserBox()
+    /// Bridge for the Database menu's worksheet commands (Run, Stop, Run
+    /// Script, Run From Cursor / Selection, Explain Plan, Compile, Format).
+    /// Triggers are installed in `.onAppear` and read live state via
+    /// captured bindings so menu invocations always see the current
+    /// document selection.
+    @State private var worksheetCommandsBox = WorksheetCommandsBox()
+    /// Bridge for the ⌘/ "Toggle Line Comment" menu command. The trigger
+    /// is installed by the editor coordinator once the AppKit text view is
+    /// available.
+    @State private var toggleCommentBox = EditorToggleCommentBox()
 
     var selectedObject: String {
         if editorSelection.isEmpty { return "" }
@@ -99,7 +109,8 @@ struct MainDocumentView: View {
                     highlightsSelectedLine: true,
                     completionConfig: completionConfig,
                     quickViewBox: quickViewBox,
-                    openInBrowserBox: openInBrowserBox
+                    openInBrowserBox: openInBrowserBox,
+                    toggleCommentBox: toggleCommentBox
                 )
                     .frame(maxWidth: .infinity, minHeight: 120, idealHeight: 320, maxHeight: .infinity)
                     .focused($focusedView, equals: .codeEditor)
@@ -123,6 +134,10 @@ struct MainDocumentView: View {
         .focusedSceneValue(\.editorQuickViewBox, quickViewBox)
         .focusedSceneValue(\.editorOpenInBrowserBox, openInBrowserBox)
         .focusedSceneValue(\.sessionBrowserBox, sessionBrowserBox)
+        .focusedSceneValue(\.worksheetCommandsBox, worksheetCommandsBox)
+        .focusedSceneValue(\.editorToggleCommentBox, toggleCommentBox)
+        .focusedSceneValue(\.worksheetIsConnected, document.isConnected)
+        .focusedSceneValue(\.worksheetIsExecuting, document.resultsController?.isExecuting ?? false)
         .tnsImportPromptOnFirstLaunch()
         .onAppear {
             document.prepareOnAppear(store: injectedStore, keychain: keychain)
@@ -133,6 +148,39 @@ struct MainDocumentView: View {
             sessionBrowserBox.trigger = { [weak document] in
                 guard let document else { return }
                 openWindow(value: SBInputValue(mainConnection: document.mainConnection))
+            }
+            // Worksheet commands. The closures capture `$editorSelection` so
+            // each menu invocation reads the current selection rather than
+            // a snapshot taken at install time. The toolbar buttons remain
+            // the primary affordance — these triggers exist so the menu
+            // items in `MainDocumentMenuCommands` route to the same VM
+            // methods without needing a reference to the document.
+            let selectionBinding = $editorSelection
+            worksheetCommandsBox.runCurrent = { [weak document] in
+                document?.runCurrentSQL(for: selectionBinding.wrappedValue)
+            }
+            worksheetCommandsBox.stop = { [weak document] in
+                document?.stopRunningSQL()
+            }
+            worksheetCommandsBox.runScript = { [weak document] in
+                document?.runScript()
+            }
+            worksheetCommandsBox.runFromCursorOrSelection = { [weak document] in
+                let selection = selectionBinding.wrappedValue
+                if selection.isEmpty {
+                    document?.runScriptFromCursor(selection.lowerBound)
+                } else {
+                    document?.runScriptSelection(selection)
+                }
+            }
+            worksheetCommandsBox.explainPlan = { [weak document] in
+                document?.explainPlan(for: selectionBinding.wrappedValue)
+            }
+            worksheetCommandsBox.compile = { [weak document] in
+                document?.compileSource(for: selectionBinding.wrappedValue)
+            }
+            worksheetCommandsBox.format = { [weak document] in
+                document?.format(of: selectionBinding)
             }
             if completionConfig == nil {
                 let tns = document.mainConnection.mainConnDetails.tns
@@ -193,8 +241,7 @@ struct MainDocumentView: View {
                     }
                 }
                 .disabled(document.isConnected != .connected)
-                .keyboardShortcut(document.resultsController?.isExecuting ?? false ? "b" : "r", modifiers: .command)
-                .help("Execute current statement")
+                .help(document.resultsController?.isExecuting ?? false ? "Stop (⌘B)" : "Run Statement (⌘R)")
                 .accessibilityIdentifier("toolbar.run")
                 .accessibilityLabel("Run")
 
@@ -208,8 +255,7 @@ struct MainDocumentView: View {
                     focusedView = .codeEditor
                 } label: { Image(systemName: "play.square") }
                     .disabled(document.isConnected != .connected)
-                    .keyboardShortcut("r", modifiers: [.command, .shift])
-                    .help("Run entire script")
+                    .help("Run Script (⇧⌘R)")
                     .accessibilityIdentifier("toolbar.runScript")
                     .accessibilityLabel("Run Script")
 
@@ -225,8 +271,7 @@ struct MainDocumentView: View {
                     focusedView = .codeEditor
                 } label: { Image(systemName: "play.square.stack") }
                     .disabled(document.isConnected != .connected)
-                    .keyboardShortcut("r", modifiers: [.command, .option])
-                    .help(editorSelection.isEmpty ? "Run script from cursor" : "Run selection as script")
+                    .help(editorSelection.isEmpty ? "Run From Cursor (⌥⌘R)" : "Run Selection as Script (⌥⌘R)")
                     .accessibilityIdentifier("toolbar.runScriptFromCursor")
                     .accessibilityLabel("Run From Cursor")
 
@@ -240,9 +285,8 @@ struct MainDocumentView: View {
                     Image(systemName: "list.number")
                 }
                 .disabled(document.isConnected != .connected || document.resultsController?.isExecuting ?? false)
-                .keyboardShortcut("e", modifiers: .command)
-                .help("Explain plan of current statement")
-                
+                .help("Explain Plan (⌘E)")
+
                 // copy current sql into a new tab
                 Button {
                     Task {
@@ -256,24 +300,22 @@ struct MainDocumentView: View {
                     }
                 } label: { Image(systemName: "doc.on.doc") }
                     .keyboardShortcut("t", modifiers: [.command, .shift])
-                    .help("New Tab")
-                
+                    .help("New Tab (⇧⌘T)")
+
                 // format sql
                 Button {
                     document.format(of: $editorSelection)
                     focusedView = .codeEditor
                 } label: { Image(systemName: "wand.and.stars") }
-                    .keyboardShortcut("f", modifiers: [.command, .control])
-                    .help("Format")
-                
+                    .help("Format (⌃⌘F)")
+
                 // compile source
                 Button {
                     document.compileSource(for: editorSelection)
                     focusedView = .codeEditor
                 } label: { Image(systemName: "ellipsis.curlybraces") }
                     .disabled(document.isConnected != .connected || document.resultsController?.isExecuting ?? false)
-                    .keyboardShortcut("c", modifiers: [.command, .option])
-                    .help("Compile")
+                    .help("Compile (⌥⌘C)")
                 
                 Spacer()
 

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -66,6 +66,22 @@ struct MainDocumentView: View {
         return s
     }
 
+    /// Published `worksheetIsConnected` value. Returns the real document
+    /// state, except when `UITestProbe` is forcing `.connected` so the UI
+    /// tests for ⌘R / ⌘E / ⌘C / ⇧⌘R / ⌥⌘R / ⌃⌘F can hit menu items that
+    /// gate on a live connection without actually opening one.
+    private var probedIsConnected: ConnectionStatus {
+        UITestProbe.shared.forceConnected ? .connected : document.isConnected
+    }
+
+    /// Published `worksheetIsExecuting` value with the same probe-override
+    /// pattern. `-uiTestForceExecuting` flips it to `true` so the Stop menu
+    /// item enables for that test.
+    private var probedIsExecuting: Bool {
+        UITestProbe.shared.forceExecuting
+            || (document.resultsController?.isExecuting ?? false)
+    }
+
     init(document: MainDocumentVM) {
         self.document = document
         // `MainDocumentVM`'s init is nonisolated (to satisfy the
@@ -136,8 +152,9 @@ struct MainDocumentView: View {
         .focusedSceneValue(\.sessionBrowserBox, sessionBrowserBox)
         .focusedSceneValue(\.worksheetCommandsBox, worksheetCommandsBox)
         .focusedSceneValue(\.editorToggleCommentBox, toggleCommentBox)
-        .focusedSceneValue(\.worksheetIsConnected, document.isConnected)
-        .focusedSceneValue(\.worksheetIsExecuting, document.resultsController?.isExecuting ?? false)
+        .focusedSceneValue(\.worksheetIsConnected, probedIsConnected)
+        .focusedSceneValue(\.worksheetIsExecuting, probedIsExecuting)
+        .overlay(alignment: .topLeading) { UITestProbeView() }
         .tnsImportPromptOnFirstLaunch()
         .onAppear {
             document.prepareOnAppear(store: injectedStore, keychain: keychain)
@@ -223,12 +240,25 @@ struct MainDocumentView: View {
                 .accessibilityIdentifier(document.isConnected == .connected ? "toolbar.disconnect" : "toolbar.connect")
                 .accessibilityLabel(document.isConnected == .connected ? "Disconnect" : "Connect")
 
-                // execute/stop sql
+                // execute/stop sql. The toolbar Button keeps the keyboard
+                // shortcut alongside the equivalent menu item: SwiftUI
+                // toolbar bindings dispatch ahead of NSTextView's responder
+                // chain, which is the only reliable path for shortcuts that
+                // collide with a system action (notably ⌘E, claimed by
+                // NSTextView's `useSelectionForFind:`). The menu items
+                // remain for HIG menu-bar discoverability + Help search.
                 Button {
-                    if document.resultsController?.isExecuting ?? false {
-                        document.stopRunningSQL()
-                    } else {
-                        document.runCurrentSQL(for: editorSelection)
+                    // Use the probed flag so the recorded command name agrees
+                    // with the keyboardShortcut binding (which is also driven
+                    // by `probedIsExecuting`). In production `probedIsExecuting`
+                    // is just `document.resultsController?.isExecuting`.
+                    let isExecuting = probedIsExecuting
+                    UITestProbe.shared.dispatch(isExecuting ? "Stop" : "Run") {
+                        if isExecuting {
+                            document.stopRunningSQL()
+                        } else {
+                            document.runCurrentSQL(for: editorSelection)
+                        }
                     }
                     focusedView = .codeEditor
                 } label: {
@@ -240,62 +270,74 @@ struct MainDocumentView: View {
                         Image(systemName: "play")
                     }
                 }
-                .disabled(document.isConnected != .connected)
+                .disabled(probedIsConnected != .connected)
+                .keyboardShortcut(probedIsExecuting ? "b" : "r", modifiers: .command)
                 .help(document.resultsController?.isExecuting ?? false ? "Stop (⌘B)" : "Run Statement (⌘R)")
                 .accessibilityIdentifier("toolbar.run")
                 .accessibilityLabel("Run")
 
                 // run script (whole file)
                 Button {
-                    if document.resultsController?.isExecuting ?? false {
-                        document.stopRunningSQL()
-                    } else {
-                        document.runScript()
+                    UITestProbe.shared.dispatch("Run Script") {
+                        if document.resultsController?.isExecuting ?? false {
+                            document.stopRunningSQL()
+                        } else {
+                            document.runScript()
+                        }
                     }
                     focusedView = .codeEditor
                 } label: { Image(systemName: "play.square") }
-                    .disabled(document.isConnected != .connected)
+                    .disabled(probedIsConnected != .connected)
+                    .keyboardShortcut("r", modifiers: [.command, .shift])
                     .help("Run Script (⇧⌘R)")
                     .accessibilityIdentifier("toolbar.runScript")
                     .accessibilityLabel("Run Script")
 
                 // run from cursor / run selection
                 Button {
-                    if document.resultsController?.isExecuting ?? false {
-                        document.stopRunningSQL()
-                    } else if !editorSelection.isEmpty {
-                        document.runScriptSelection(editorSelection)
-                    } else {
-                        document.runScriptFromCursor(editorSelection.lowerBound)
+                    UITestProbe.shared.dispatch("Run From Cursor / Selection") {
+                        if document.resultsController?.isExecuting ?? false {
+                            document.stopRunningSQL()
+                        } else if !editorSelection.isEmpty {
+                            document.runScriptSelection(editorSelection)
+                        } else {
+                            document.runScriptFromCursor(editorSelection.lowerBound)
+                        }
                     }
                     focusedView = .codeEditor
                 } label: { Image(systemName: "play.square.stack") }
-                    .disabled(document.isConnected != .connected)
+                    .disabled(probedIsConnected != .connected)
+                    .keyboardShortcut("r", modifiers: [.command, .option])
                     .help(editorSelection.isEmpty ? "Run From Cursor (⌥⌘R)" : "Run Selection as Script (⌥⌘R)")
                     .accessibilityIdentifier("toolbar.runScriptFromCursor")
                     .accessibilityLabel("Run From Cursor")
 
                 // explain plan
                 Button {
-                    if !(document.resultsController?.isExecuting ?? false) {
-                        document.explainPlan(for: editorSelection)
+                    UITestProbe.shared.dispatch("Explain Plan") {
+                        if !(document.resultsController?.isExecuting ?? false) {
+                            document.explainPlan(for: editorSelection)
+                        }
                     }
                     focusedView = .codeEditor
                 } label: {
                     Image(systemName: "list.number")
                 }
-                .disabled(document.isConnected != .connected || document.resultsController?.isExecuting ?? false)
+                .disabled(probedIsConnected != .connected || probedIsExecuting)
+                .keyboardShortcut("e", modifiers: .command)
                 .help("Explain Plan (⌘E)")
 
                 // copy current sql into a new tab
                 Button {
-                    Task {
-                        if let url = document.newDocument(from: editorSelection) {
-                            let (doc,_): (NSDocument, Bool) = try await NSDocumentController.shared.openDocument(withContentsOf: url, display: false)
-                            NSDocumentController.shared.addDocument(doc)
-                            doc.makeWindowControllers()
-                            doc.windowControllers.first?.window?.tabbingMode = .preferred
-                            doc.showWindows()
+                    UITestProbe.shared.dispatch("New Tab from Selection") {
+                        Task {
+                            if let url = document.newDocument(from: editorSelection) {
+                                let (doc,_): (NSDocument, Bool) = try await NSDocumentController.shared.openDocument(withContentsOf: url, display: false)
+                                NSDocumentController.shared.addDocument(doc)
+                                doc.makeWindowControllers()
+                                doc.windowControllers.first?.window?.tabbingMode = .preferred
+                                doc.showWindows()
+                            }
                         }
                     }
                 } label: { Image(systemName: "doc.on.doc") }
@@ -304,17 +346,23 @@ struct MainDocumentView: View {
 
                 // format sql
                 Button {
-                    document.format(of: $editorSelection)
+                    UITestProbe.shared.dispatch("Format") {
+                        document.format(of: $editorSelection)
+                    }
                     focusedView = .codeEditor
                 } label: { Image(systemName: "wand.and.stars") }
+                    .keyboardShortcut("f", modifiers: [.command, .control])
                     .help("Format (⌃⌘F)")
 
                 // compile source
                 Button {
-                    document.compileSource(for: editorSelection)
+                    UITestProbe.shared.dispatch("Compile") {
+                        document.compileSource(for: editorSelection)
+                    }
                     focusedView = .codeEditor
                 } label: { Image(systemName: "ellipsis.curlybraces") }
-                    .disabled(document.isConnected != .connected || document.resultsController?.isExecuting ?? false)
+                    .disabled(probedIsConnected != .connected || probedIsExecuting)
+                    .keyboardShortcut("c", modifiers: [.command, .option])
                     .help("Compile (⌥⌘C)")
                 
                 Spacer()

--- a/Macintora/MainApp/WorksheetCommandsBox.swift
+++ b/Macintora/MainApp/WorksheetCommandsBox.swift
@@ -1,0 +1,63 @@
+//
+//  WorksheetCommandsBox.swift
+//  Macintora
+//
+//  Bridge object that lets SwiftUI menu commands (Database menu) trigger
+//  worksheet actions on the focused document — Run, Stop, Run Script,
+//  Run From Cursor / Selection, Explain Plan, Compile, Format — without
+//  the menu commands holding a direct reference to the document VM.
+//
+//  Mirrors the `EditorQuickViewBox` pattern: intentionally **not**
+//  `@Observable` so trigger reassignment doesn't cascade menu redraws into
+//  the constraint-loop crash described in `EditorQuickViewBox.swift`.
+//
+//  The companion `worksheetIsConnected` / `worksheetIsExecuting` focused
+//  scene values carry the state the menu needs for `.disabled(...)`. They
+//  are plain values (not boxes) so SwiftUI republishes them on each
+//  document body redraw and the menu item enable state stays in sync.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class WorksheetCommandsBox {
+    var runCurrent: (() -> Void)?
+    var stop: (() -> Void)?
+    var runScript: (() -> Void)?
+    var runFromCursorOrSelection: (() -> Void)?
+    var explainPlan: (() -> Void)?
+    var compile: (() -> Void)?
+    var format: (() -> Void)?
+}
+
+// MARK: - FocusedValueKeys
+
+struct WorksheetCommandsBoxKey: FocusedValueKey {
+    typealias Value = WorksheetCommandsBox
+}
+
+struct WorksheetIsConnectedKey: FocusedValueKey {
+    typealias Value = ConnectionStatus
+}
+
+struct WorksheetIsExecutingKey: FocusedValueKey {
+    typealias Value = Bool
+}
+
+extension FocusedValues {
+    var worksheetCommandsBox: WorksheetCommandsBoxKey.Value? {
+        get { self[WorksheetCommandsBoxKey.self] }
+        set { self[WorksheetCommandsBoxKey.self] = newValue }
+    }
+
+    var worksheetIsConnected: WorksheetIsConnectedKey.Value? {
+        get { self[WorksheetIsConnectedKey.self] }
+        set { self[WorksheetIsConnectedKey.self] = newValue }
+    }
+
+    var worksheetIsExecuting: WorksheetIsExecutingKey.Value? {
+        get { self[WorksheetIsExecutingKey.self] }
+        set { self[WorksheetIsExecutingKey.self] = newValue }
+    }
+}

--- a/Macintora/UITestInstrumentation.swift
+++ b/Macintora/UITestInstrumentation.swift
@@ -1,0 +1,90 @@
+//
+//  UITestInstrumentation.swift
+//  Macintora
+//
+//  Tiny probe used by `MacintoraUITests/EditorShortcutsUITests` to verify
+//  that menu items and toolbar shortcuts dispatch the right action. The
+//  whole instrument is dormant unless the app was launched with the
+//  `-uiTestProbe` argument, so production runs pay no runtime cost beyond
+//  one Boolean read per wrapped action.
+//
+//  Launch arguments (set via `XCUIApplication.launchArguments`):
+//  - `-uiTestProbe`           — turn instrumentation on, suppress real
+//                               side effects, and force-publish
+//                               `worksheetIsConnected = .connected` so
+//                               menu items that gate on the connection
+//                               state are enabled.
+//  - `-uiTestForceExecuting`  — additionally force-publish
+//                               `worksheetIsExecuting = true` so the
+//                               Stop menu item is enabled.
+//
+//  A SwiftUI `UITestProbeView` renders `lastCommand` as a hidden `Text`
+//  with `accessibilityIdentifier("ui_test_probe.last_command")`. Tests
+//  read its `value` to assert the right command name fired.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+@Observable
+final class UITestProbe {
+    static let shared = UITestProbe()
+
+    let isEnabled: Bool
+    let suppressActions: Bool
+    let forceConnected: Bool
+    let forceExecuting: Bool
+
+    /// Name of the most-recently invoked probed action. Empty string until
+    /// the first call. SwiftUI's `@Observable` tracking republishes this to
+    /// the probe view so XCUITest can poll for the expected value.
+    private(set) var lastCommand: String = ""
+
+    private init() {
+        let args = ProcessInfo.processInfo.arguments
+        let enabled = args.contains("-uiTestProbe")
+        isEnabled = enabled
+        suppressActions = enabled
+        forceConnected = enabled
+        forceExecuting = args.contains("-uiTestForceExecuting")
+    }
+
+    /// Wrap a menu/toolbar action with the probe. In production
+    /// (`isEnabled == false`) the wrapper is a single Boolean read and a
+    /// closure call — measurably free. In test mode it records the name
+    /// and skips the real side effect.
+    func dispatch(_ command: String, _ action: () -> Void) {
+        if isEnabled {
+            lastCommand = command
+            guard !suppressActions else { return }
+        }
+        action()
+    }
+}
+
+/// Small visible `Text` chip carrying `UITestProbe.lastCommand`. Embedded
+/// as an overlay on `MainDocumentView` so XCUITest can read its
+/// accessibility value. The chip is intentionally rendered (not hidden):
+/// invisible SwiftUI views drop out of the accessibility tree, and being
+/// able to eyeball the recorded command while watching a failing test run
+/// is a useful diagnosability bonus. Renders nothing when the probe is
+/// dormant, so production runs see no UI change.
+struct UITestProbeView: View {
+    private let probe = UITestProbe.shared
+
+    var body: some View {
+        if probe.isEnabled {
+            Text(probe.lastCommand.isEmpty ? "(idle)" : probe.lastCommand)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.regularMaterial, in: .capsule)
+                .padding(4)
+                .accessibilityIdentifier("ui_test_probe.last_command")
+                .accessibilityValue(probe.lastCommand)
+                .allowsHitTesting(false)
+        }
+    }
+}

--- a/MacintoraTests/Editor/EditorToggleCommentBoxTests.swift
+++ b/MacintoraTests/Editor/EditorToggleCommentBoxTests.swift
@@ -1,0 +1,51 @@
+//
+//  EditorToggleCommentBoxTests.swift
+//  MacintoraTests
+//
+//  Verifies the bridge object that lets the ⌘/ menu command call into the
+//  focused editor's `toggleLineComment(_:)` without the menu holding a
+//  direct text-view reference.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class EditorToggleCommentBoxTests: XCTestCase {
+
+    func test_freshBox_hasNilTrigger() {
+        let box = EditorToggleCommentBox()
+        XCTAssertNil(box.trigger,
+                     "A box with no editor wired must report nil so the menu can disable")
+    }
+
+    func test_setTrigger_invokesClosureWhenCalled() {
+        let box = EditorToggleCommentBox()
+        var calls = 0
+        box.trigger = { calls += 1 }
+        box.trigger?()
+        XCTAssertEqual(calls, 1)
+        box.trigger?()
+        XCTAssertEqual(calls, 2)
+    }
+
+    func test_overwriteTrigger_replacesPreviousClosure() {
+        let box = EditorToggleCommentBox()
+        var firstCalls = 0
+        var secondCalls = 0
+        box.trigger = { firstCalls += 1 }
+        box.trigger = { secondCalls += 1 }
+        box.trigger?()
+        XCTAssertEqual(firstCalls, 0)
+        XCTAssertEqual(secondCalls, 1)
+    }
+
+    func test_clearTrigger_disablesInvocation() {
+        let box = EditorToggleCommentBox()
+        var calls = 0
+        box.trigger = { calls += 1 }
+        box.trigger = nil
+        box.trigger?()
+        XCTAssertEqual(calls, 0)
+    }
+}

--- a/MacintoraTests/KeyboardShortcutsTests.swift
+++ b/MacintoraTests/KeyboardShortcutsTests.swift
@@ -1,0 +1,91 @@
+//
+//  KeyboardShortcutsTests.swift
+//  MacintoraTests
+//
+//  Sanity checks for the cheatsheet's source-of-truth list. The list
+//  drives both the Help-menu cheatsheet window and (by convention) what
+//  the menu items in `MainDocumentMenuCommands` / `EditorMenuCommands`
+//  bind. Tests here lock in the entries so a typo or accidental drop
+//  fails CI rather than only showing up in QA.
+//
+
+import XCTest
+@testable import Macintora
+
+final class KeyboardShortcutsTests: XCTestCase {
+
+    func test_groupsAreNonEmpty() {
+        XCTAssertFalse(KeyboardShortcuts.groups.isEmpty)
+        for group in KeyboardShortcuts.groups {
+            XCTAssertFalse(group.entries.isEmpty,
+                           "group \(group.title) must have at least one entry")
+        }
+    }
+
+    func test_groupTitlesAreUnique() {
+        let titles = KeyboardShortcuts.groups.map(\.title)
+        XCTAssertEqual(titles.count, Set(titles).count,
+                       "duplicate group title in cheatsheet")
+    }
+
+    func test_entryLabelsAreUniqueWithinGroup() {
+        for group in KeyboardShortcuts.groups {
+            let labels = group.entries.map(\.label)
+            XCTAssertEqual(labels.count, Set(labels).count,
+                           "duplicate label in group \(group.title)")
+        }
+    }
+
+    func test_shortcutsAreNonEmpty() {
+        for group in KeyboardShortcuts.groups {
+            for entry in group.entries {
+                XCTAssertFalse(entry.shortcut.isEmpty,
+                               "entry \(entry.label) must have a shortcut glyph")
+            }
+        }
+    }
+
+    func test_runGroup_containsExpectedCommands() {
+        let runGroup = KeyboardShortcuts.groups.first { $0.title == "Run" }
+        XCTAssertNotNil(runGroup)
+        let labels = runGroup?.entries.map(\.label) ?? []
+        XCTAssertTrue(labels.contains("Run"))
+        XCTAssertTrue(labels.contains("Stop"))
+        XCTAssertTrue(labels.contains("Run Script"))
+        XCTAssertTrue(labels.contains("Run From Cursor / Selection"))
+        XCTAssertTrue(labels.contains("Explain Plan"))
+        XCTAssertTrue(labels.contains("Compile"))
+        XCTAssertTrue(labels.contains("Format"))
+    }
+
+    func test_editorGroup_containsToggleLineComment() {
+        let editor = KeyboardShortcuts.groups.first { $0.title == "Editor" }
+        XCTAssertNotNil(editor)
+        let toggle = editor?.entries.first { $0.label == "Toggle Line Comment" }
+        XCTAssertEqual(toggle?.shortcut, "⌘/")
+    }
+
+    func test_runShortcuts_matchExpectedGlyphs() {
+        let expected: [String: String] = [
+            "Run": "⌘R",
+            "Stop": "⌘B",
+            "Run Script": "⇧⌘R",
+            "Run From Cursor / Selection": "⌥⌘R",
+            "Explain Plan": "⌘E",
+            "Compile": "⌥⌘C",
+            "Format": "⌃⌘F",
+        ]
+        let runGroup = KeyboardShortcuts.groups.first { $0.title == "Run" }
+        for entry in runGroup?.entries ?? [] {
+            XCTAssertEqual(entry.shortcut, expected[entry.label],
+                           "unexpected shortcut for \(entry.label)")
+        }
+    }
+
+    func test_windowID_isStable() {
+        // The Help menu uses `openWindow(id:)` with this constant; the
+        // matching `Window` scene declares the same id. Asserting it here
+        // stops a silent typo from breaking the cheatsheet.
+        XCTAssertEqual(KeyboardShortcuts.windowID, "shortcuts")
+    }
+}

--- a/MacintoraTests/WorksheetCommandsBoxTests.swift
+++ b/MacintoraTests/WorksheetCommandsBoxTests.swift
@@ -1,0 +1,80 @@
+//
+//  WorksheetCommandsBoxTests.swift
+//  MacintoraTests
+//
+//  Verifies the bridge box that lets the Database CommandMenu reach the
+//  focused worksheet without holding a direct VM reference. The contract
+//  is small: each trigger is an optional closure; setting it then calling
+//  it must invoke the closure once; reassigning replaces the previous
+//  closure exactly as `bind...Box` does on document re-mount.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class WorksheetCommandsBoxTests: XCTestCase {
+
+    func test_freshBox_allTriggersAreNil() {
+        let box = WorksheetCommandsBox()
+        XCTAssertNil(box.runCurrent)
+        XCTAssertNil(box.stop)
+        XCTAssertNil(box.runScript)
+        XCTAssertNil(box.runFromCursorOrSelection)
+        XCTAssertNil(box.explainPlan)
+        XCTAssertNil(box.compile)
+        XCTAssertNil(box.format)
+    }
+
+    func test_eachTrigger_invokesClosure() {
+        let box = WorksheetCommandsBox()
+        var calls: [String] = []
+        box.runCurrent = { calls.append("runCurrent") }
+        box.stop = { calls.append("stop") }
+        box.runScript = { calls.append("runScript") }
+        box.runFromCursorOrSelection = { calls.append("runFromCursorOrSelection") }
+        box.explainPlan = { calls.append("explainPlan") }
+        box.compile = { calls.append("compile") }
+        box.format = { calls.append("format") }
+
+        box.runCurrent?()
+        box.stop?()
+        box.runScript?()
+        box.runFromCursorOrSelection?()
+        box.explainPlan?()
+        box.compile?()
+        box.format?()
+
+        XCTAssertEqual(calls, [
+            "runCurrent",
+            "stop",
+            "runScript",
+            "runFromCursorOrSelection",
+            "explainPlan",
+            "compile",
+            "format",
+        ])
+    }
+
+    func test_overwriteTrigger_replacesPreviousClosure() {
+        // Mirrors what document re-mount does: the previous closure must be
+        // dropped so a stale, dismantled VM isn't called into.
+        let box = WorksheetCommandsBox()
+        var firstCalls = 0
+        var secondCalls = 0
+        box.runCurrent = { firstCalls += 1 }
+        box.runCurrent = { secondCalls += 1 }
+        box.runCurrent?()
+        XCTAssertEqual(firstCalls, 0)
+        XCTAssertEqual(secondCalls, 1)
+    }
+
+    func test_clearTrigger_disablesInvocation() {
+        let box = WorksheetCommandsBox()
+        var calls = 0
+        box.runCurrent = { calls += 1 }
+        box.runCurrent = nil
+        box.runCurrent?()
+        XCTAssertEqual(calls, 0)
+    }
+}

--- a/MacintoraUITests/EditorShortcutsUITests.swift
+++ b/MacintoraUITests/EditorShortcutsUITests.swift
@@ -1,0 +1,208 @@
+//
+//  EditorShortcutsUITests.swift
+//  MacintoraUITests
+//
+//  Verifies every Macintora-specific keyboard shortcut wired by the
+//  menu bar (issue #24) actually reaches its action site when pressed.
+//  We don't need to run the real `runScript`, open Settings, or toggle
+//  comments here — that's covered by unit tests and the standalone
+//  `EditTransformationsKeyEquivalentTests` / `QuickViewUITests`. The job
+//  of this suite is to catch dispatch regressions in the menu wiring.
+//
+//  Mechanism: the app, when launched with `-uiTestProbe`, records the
+//  fired command name on `UITestProbe.shared.lastCommand` and suppresses
+//  the real side effect. A hidden SwiftUI `Text` with accessibility
+//  identifier `"ui_test_probe.last_command"` carries the recorded value
+//  back to XCUITest. The Stop test additionally passes
+//  `-uiTestForceExecuting` to flip the menu's executing gate on.
+//
+//  Skips when the local fixture document is missing — same convention as
+//  the existing UI tests so this suite stays runnable on machines without
+//  test fixtures provisioned.
+//
+
+import XCTest
+
+final class EditorShortcutsUITests: XCTestCase {
+
+    private static let fixtureURL = URL(fileURLWithPath:
+        "/Users/ilia/Documents/macintora/local.macintora")
+    private static let probeIdentifier = "ui_test_probe.last_command"
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        let path = Self.fixtureURL.path
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: path),
+            "Fixture document \(path) does not exist — required for UI tests."
+        )
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func launchAppWithProbe(forceExecuting: Bool = false) -> XCUIApplication {
+        let app = XCUIApplication()
+        var args = [Self.fixtureURL.path, "-uiTestProbe"]
+        if forceExecuting { args.append("-uiTestForceExecuting") }
+        app.launchArguments = args
+        app.launchEnvironment["OS_ACTIVITY_MODE"] = "disable"
+        app.launch()
+        return app
+    }
+
+    /// Press the shortcut at the document window and wait for the probe's
+    /// `accessibilityValue` to equal `expected`. The probe is a hidden
+    /// SwiftUI `Text` whose `.value` reflects `UITestProbe.lastCommand`.
+    @MainActor
+    private func assertShortcutFires(
+        _ expected: String,
+        on app: XCUIApplication,
+        key: String,
+        modifiers: XCUIElement.KeyModifierFlags,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let window = app.windows.firstMatch
+        XCTAssertTrue(
+            window.waitForExistence(timeout: 10),
+            "document window did not appear",
+            file: file, line: line
+        )
+
+        // The editor needs focus so the document scene's menu dispatch
+        // sees the right `@FocusedSceneValue` cohort.
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(
+            textView.waitForExistence(timeout: 5),
+            "editor text view not found",
+            file: file, line: line
+        )
+        textView.click()
+
+        let probe = app.descendants(matching: .any).matching(identifier: Self.probeIdentifier).firstMatch
+        XCTAssertTrue(
+            probe.waitForExistence(timeout: 5),
+            "UI test probe not found — was the app launched with -uiTestProbe?",
+            file: file, line: line
+        )
+
+        window.typeKey(key, modifierFlags: modifiers)
+
+        // Poll the probe's accessibility value rather than reading once — the
+        // menu dispatch is asynchronous and the `@Observable` republish takes
+        // a tick or two to propagate through SwiftUI.
+        let predicate = NSPredicate(format: "value == %@", expected)
+        let probed = XCTNSPredicateExpectation(predicate: predicate, object: probe)
+        let result = XCTWaiter().wait(for: [probed], timeout: 4)
+        XCTAssertEqual(
+            result, .completed,
+            "expected the probe to record \"\(expected)\" within 4s after pressing the shortcut; got \"\(String(describing: probe.value))\"",
+            file: file, line: line
+        )
+    }
+
+    // MARK: - Run group
+
+    @MainActor
+    func test_cmd_R_fires_run() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires("Run", on: app, key: "r", modifiers: .command)
+    }
+
+    @MainActor
+    func test_cmd_B_fires_stop() throws {
+        // Stop is enabled only when `worksheetIsExecuting == true`. The
+        // probe synthesises that state without a live DB connection.
+        let app = launchAppWithProbe(forceExecuting: true)
+        assertShortcutFires("Stop", on: app, key: "b", modifiers: .command)
+    }
+
+    @MainActor
+    func test_shiftCmd_R_fires_run_script() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires("Run Script", on: app, key: "r", modifiers: [.command, .shift])
+    }
+
+    @MainActor
+    func test_optCmd_R_fires_run_from_cursor_or_selection() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires(
+            "Run From Cursor / Selection",
+            on: app, key: "r", modifiers: [.command, .option]
+        )
+    }
+
+    @MainActor
+    func test_cmd_E_fires_explain_plan() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires("Explain Plan", on: app, key: "e", modifiers: .command)
+    }
+
+    @MainActor
+    func test_optCmd_C_fires_compile() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires("Compile", on: app, key: "c", modifiers: [.command, .option])
+    }
+
+    @MainActor
+    func test_ctrlCmd_F_fires_format() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires("Format", on: app, key: "f", modifiers: [.command, .control])
+    }
+
+    // MARK: - Editor
+
+    @MainActor
+    func test_cmd_slash_fires_toggle_line_comment() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires(
+            "Toggle Line Comment",
+            on: app, key: "/", modifiers: .command
+        )
+    }
+
+    // MARK: - Database
+
+    @MainActor
+    func test_shiftCmd_K_fires_manage_connections() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires(
+            "Manage Connections",
+            on: app, key: "k", modifiers: [.command, .shift]
+        )
+    }
+
+    @MainActor
+    func test_shiftCmd_I_fires_database_browser() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires(
+            "Database Browser",
+            on: app, key: "i", modifiers: [.command, .shift]
+        )
+    }
+
+    @MainActor
+    func test_ctrlShiftCmd_S_fires_session_browser() throws {
+        let app = launchAppWithProbe()
+        assertShortcutFires(
+            "Session Browser",
+            on: app, key: "s", modifiers: [.command, .control, .shift]
+        )
+    }
+
+    // MARK: - File / Toolbar
+
+    @MainActor
+    func test_shiftCmd_T_fires_new_tab_from_selection() throws {
+        // ⇧⌘T lives on the toolbar button (copy current SQL into a new tab),
+        // not the ⌘T `CommandGroup(after: .newItem)` blank-tab entry. The
+        // probe label distinguishes the two so this test can't accidentally
+        // pass against the wrong source.
+        let app = launchAppWithProbe()
+        assertShortcutFires(
+            "New Tab from Selection",
+            on: app, key: "t", modifiers: [.command, .shift]
+        )
+    }
+}

--- a/MacintoraUITests/MacintoraUITests.swift
+++ b/MacintoraUITests/MacintoraUITests.swift
@@ -207,7 +207,7 @@ final class MacintoraUITests: XCTestCase {
     /// and the wrapper's re-entrancy guard must keep the binding and view in
     /// sync while typing.
     ///
-    /// The timing budget is generous (30 s for 20 statements, ~840 chars): the
+    /// The timing budget is generous (30 s for the fixture, ~200 chars): the
     /// XCUITest keystroke path itself costs ~25 ms per character. The point
     /// is to catch *severe* regressions (main-thread-blocking full re-parse),
     /// not to benchmark the highlighter. The storage check below is the real
@@ -225,16 +225,22 @@ final class MacintoraUITests: XCTestCase {
         textView.typeKey("a", modifierFlags: .command)
         textView.typeKey(.delete, modifierFlags: [])
 
-        let stmts = (0..<6)
+        let statementCount = 6
+        let stmts = (0..<statementCount)
             .map { "SELECT \($0) FROM dual WHERE x = \($0);\n" }
             .joined()
         let start = Date()
         textView.typeText(stmts)
         let elapsed = Date().timeIntervalSince(start)
 
+        // Assert the first and last statements survived. Driving the needles
+        // off `statementCount` so trimming the fixture in the future can't
+        // silently desync the assertion from the typed payload again.
+        let firstNeedle = "SELECT 0 FROM dual"
+        let lastNeedle = "SELECT \(statementCount - 1) FROM dual"
         let contents = (textView.value as? String) ?? ""
         XCTAssertTrue(
-            contents.contains("SELECT 0 FROM dual") && contents.contains("SELECT 19 FROM dual"),
+            contents.contains(firstNeedle) && contents.contains(lastNeedle),
             "first and/or last statement missing from storage — keystrokes were dropped. value tail=\"\(contents.suffix(180))\""
         )
         XCTAssertLessThan(


### PR DESCRIPTION
## Summary

Closes #24. Macintora's worksheet commands and editor shortcuts now appear in the menu bar — discoverable via tooltips, ⌘⇧/ Help search, and a Help-menu cheatsheet.

- **Database** CommandMenu picks up a new section: Run (⌘R), Stop (⌘B), Run Script (⇧⌘R), Run From Cursor / Selection (⌥⌘R), Explain Plan (⌘E), Compile (⌥⌘C), Format (⌃⌘F). Disabled state mirrors the toolbar (Run gated on connected + not-executing; Stop gated on executing; Format only requires a focused worksheet).
- **Edit** menu gains Toggle Line Comment (⌘/) via `CommandGroup(after: .textFormatting)`. The previous local `performKeyEquivalent` handler in `MacintoraSTTextView` is removed in favor of menu-driven dispatch through a new `EditorToggleCommentBox`.
- **Help** menu gains "Keyboard Shortcuts…", which opens a content-sized `Window` rendering a single source-of-truth list (`KeyboardShortcuts.groups`) with monospaced glyphs. No keyboard shortcut bound, per the issue's recommendation to leave ⌘⇧/ for system Help search.
- Toolbar tooltips now include the shortcut in parentheses (e.g. `Run Statement (⌘R)`); redundant `.keyboardShortcut` modifiers on those buttons are dropped so the menu owns dispatch.

## Implementation notes

- Followed the existing `EditorQuickViewBox` / `SessionBrowserBox` pattern: a non-`@Observable` reference holder published via `@FocusedSceneValue`, with closures installed in the document view's `.onAppear`. `WorksheetCommandsBox` carries seven trigger closures; selection state is read at trigger time via a captured `Binding<Range<String.Index>>` so the closures always see the current selection rather than a snapshot.
- Run/Stop disabled state and the toolbar's label-flip read newly published `@FocusedSceneValue`s `worksheetIsConnected` and `worksheetIsExecuting`, which republish on each `MainDocumentView` body redraw.
- Single source-of-truth in `KeyboardShortcuts.groups` powers both the cheatsheet view and the unit tests that lock in the shortcut glyphs.

## Test plan

- [ ] `WorksheetCommandsBoxTests`, `EditorToggleCommentBoxTests`, `KeyboardShortcutsTests` pass.
- [ ] Existing `MacintoraSTTextViewTests` (toggle-line-comment behavior) still pass after removing `performKeyEquivalent`.
- [ ] Manually verify in-app: Database menu shows the new section with correct enable/disable states across connect/disconnect and during execution.
- [ ] ⌘R, ⌘B, ⇧⌘R, ⌥⌘R, ⌘E, ⌥⌘C, ⌃⌘F all dispatch the same VM methods as the toolbar buttons.
- [ ] ⌘/ toggles line comments on the focused editor.
- [ ] ⌘⇧/ Help search finds Run, Stop, Run Script, Run From Cursor / Selection, Explain Plan, Compile, Format, Toggle Line Comment, Keyboard Shortcuts… by name.
- [ ] Help → Keyboard Shortcuts… opens the cheatsheet window with all groups rendered.
- [ ] Toolbar tooltips show the parenthesised shortcut.

https://claude.ai/code/session_01Q41B4qPeQPRbGzEBS63TxS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q41B4qPeQPRbGzEBS63TxS)_