### PR TITLE
DB Browser UX audit: filter refresh, list cap, shortcuts, progress, detail forms

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -97,6 +97,10 @@
 		49B0C0DE0000000000000130 /* DBBrowserInputMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000030 /* DBBrowserInputMapperTests.swift */; };
 		49B0C0DE0000000000000131 /* DBBrowserWindowRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000031 /* DBBrowserWindowRegistryTests.swift */; };
 		49B0C0DE0000000000000132 /* DBCacheVMInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000032 /* DBCacheVMInitTests.swift */; };
+		49B0C0DE0000000000000133 /* DBBrowserCommandsBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000033 /* DBBrowserCommandsBoxTests.swift */; };
+		49B0C0DE0000000000000134 /* DBCacheSearchCriteriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000034 /* DBCacheSearchCriteriaTests.swift */; };
+		49B0C0DE0000000000000135 /* DBCacheObjectFetchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000035 /* DBCacheObjectFetchRequestTests.swift */; };
+		49B0C0DE0000000000000136 /* DBBrowserMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000036 /* DBBrowserMenuUITests.swift */; };
 		49B55F32270ADD8B00CFB3C7 /* MacintoraApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B55F31270ADD8B00CFB3C7 /* MacintoraApp.swift */; };
 		49B55F36270ADD8B00CFB3C7 /* MainDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B55F35270ADD8B00CFB3C7 /* MainDocumentView.swift */; };
 		49B55F38270ADD8D00CFB3C7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49B55F37270ADD8D00CFB3C7 /* Assets.xcassets */; };
@@ -320,6 +324,10 @@
 		49B0C0DE0000000000000030 /* DBBrowserInputMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserInputMapperTests.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000031 /* DBBrowserWindowRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserWindowRegistryTests.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000032 /* DBCacheVMInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBCacheVMInitTests.swift; sourceTree = "<group>"; };
+		49B0C0DE0000000000000033 /* DBBrowserCommandsBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserCommandsBoxTests.swift; sourceTree = "<group>"; };
+		49B0C0DE0000000000000034 /* DBCacheSearchCriteriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBCacheSearchCriteriaTests.swift; sourceTree = "<group>"; };
+		49B0C0DE0000000000000035 /* DBCacheObjectFetchRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBCacheObjectFetchRequestTests.swift; sourceTree = "<group>"; };
+		49B0C0DE0000000000000036 /* DBBrowserMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserMenuUITests.swift; sourceTree = "<group>"; };
 		49B55F2E270ADD8B00CFB3C7 /* Macintora.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Macintora.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		49B55F31270ADD8B00CFB3C7 /* MacintoraApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MacintoraApp.swift; sourceTree = "<group>"; };
 		49B55F35270ADD8B00CFB3C7 /* MainDocumentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentView.swift; sourceTree = "<group>"; };
@@ -604,6 +612,9 @@
 				49B0C0DE0000000000000030 /* DBBrowserInputMapperTests.swift */,
 				49B0C0DE0000000000000031 /* DBBrowserWindowRegistryTests.swift */,
 				49B0C0DE0000000000000032 /* DBCacheVMInitTests.swift */,
+				49B0C0DE0000000000000033 /* DBBrowserCommandsBoxTests.swift */,
+				49B0C0DE0000000000000034 /* DBCacheSearchCriteriaTests.swift */,
+				49B0C0DE0000000000000035 /* DBCacheObjectFetchRequestTests.swift */,
 			);
 			path = DBBrowser;
 			sourceTree = "<group>";
@@ -844,6 +855,7 @@
 				49DB001B0000001B /* EditTransformationsKeyEquivalentTests.swift */,
 				49DB001400000014 /* QuickViewUITests.swift */,
 				49DB002700000027 /* EditorShortcutsUITests.swift */,
+				49B0C0DE0000000000000036 /* DBBrowserMenuUITests.swift */,
 			);
 			path = MacintoraUITests;
 			sourceTree = "<group>";
@@ -1031,6 +1043,9 @@
 				49B0C0DE0000000000000130 /* DBBrowserInputMapperTests.swift in Sources */,
 				49B0C0DE0000000000000131 /* DBBrowserWindowRegistryTests.swift in Sources */,
 				49B0C0DE0000000000000132 /* DBCacheVMInitTests.swift in Sources */,
+				49B0C0DE0000000000000133 /* DBBrowserCommandsBoxTests.swift in Sources */,
+				49B0C0DE0000000000000134 /* DBCacheSearchCriteriaTests.swift in Sources */,
+				49B0C0DE0000000000000135 /* DBCacheObjectFetchRequestTests.swift in Sources */,
 				49DB302300000023 /* WorksheetCommandsBoxTests.swift in Sources */,
 				49DB302400000024 /* EditorToggleCommentBoxTests.swift in Sources */,
 				49DB302500000025 /* KeyboardShortcutsTests.swift in Sources */,
@@ -1192,6 +1207,7 @@
 				49DB401400000014 /* QuickViewUITests.swift in Sources */,
 				49DB401B0000001B /* EditTransformationsKeyEquivalentTests.swift in Sources */,
 				49DB402700000027 /* EditorShortcutsUITests.swift in Sources */,
+				49B0C0DE0000000000000136 /* DBBrowserMenuUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		49B0C0DE0000000000000015 /* PackageProceduresListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000005 /* PackageProceduresListView.swift */; };
 		49B0C0DE0000000000000120 /* DBBrowserInputMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000020 /* DBBrowserInputMapper.swift */; };
 		49B0C0DE0000000000000121 /* DBBrowserWindowRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000021 /* DBBrowserWindowRegistry.swift */; };
+		49B0C0DE0000000000000122 /* DBBrowserCommandsBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000022 /* DBBrowserCommandsBox.swift */; };
 		49B0C0DE0000000000000130 /* DBBrowserInputMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000030 /* DBBrowserInputMapperTests.swift */; };
 		49B0C0DE0000000000000131 /* DBBrowserWindowRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000031 /* DBBrowserWindowRegistryTests.swift */; };
 		49B0C0DE0000000000000132 /* DBCacheVMInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000032 /* DBCacheVMInitTests.swift */; };
@@ -315,6 +316,7 @@
 		49B0C0DE0000000000000005 /* PackageProceduresListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageProceduresListView.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000020 /* DBBrowserInputMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserInputMapper.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000021 /* DBBrowserWindowRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserWindowRegistry.swift; sourceTree = "<group>"; };
+		49B0C0DE0000000000000022 /* DBBrowserCommandsBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserCommandsBox.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000030 /* DBBrowserInputMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserInputMapperTests.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000031 /* DBBrowserWindowRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserWindowRegistryTests.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000032 /* DBCacheVMInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBCacheVMInitTests.swift; sourceTree = "<group>"; };
@@ -511,6 +513,7 @@
 				49B0C0DE0000000000000005 /* PackageProceduresListView.swift */,
 				49B0C0DE0000000000000020 /* DBBrowserInputMapper.swift */,
 				49B0C0DE0000000000000021 /* DBBrowserWindowRegistry.swift */,
+				49B0C0DE0000000000000022 /* DBBrowserCommandsBox.swift */,
 				498288AD28B7DC5700A28B04 /* CoreData */,
 			);
 			path = DBObjectsBrowser;
@@ -1175,6 +1178,7 @@
 				49DB102200000022 /* KeyboardShortcuts.swift in Sources */,
 				49B0C0DE0000000000000120 /* DBBrowserInputMapper.swift in Sources */,
 				49B0C0DE0000000000000121 /* DBBrowserWindowRegistry.swift in Sources */,
+				49B0C0DE0000000000000122 /* DBBrowserCommandsBox.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macintora/DBObjectsBrowser/CoreData/DBCacheObject+CoreDataProperties.swift
+++ b/Macintora/DBObjectsBrowser/CoreData/DBCacheObject+CoreDataProperties.swift
@@ -47,10 +47,15 @@ extension DBCacheObject {
         set { self.owner_ = newValue }
     }
     
-    public class func fetchRequest(limit: Int, predicate: NSPredicate? = nil) -> NSFetchRequest<DBCacheObject> {
+    /// Builds the list-pane fetch request. `limit == 0` means no cap (rely on
+    /// Core Data faulting + `List`'s lazy row materialisation for effectively
+    /// infinite scroll); any positive value caps the result set.
+    public class func fetchRequest(limit: Int = 0, predicate: NSPredicate? = nil) -> NSFetchRequest<DBCacheObject> {
         let request = DBCacheObject.fetchRequest()
         request.sortDescriptors = [NSSortDescriptor(key: "owner_", ascending: true), NSSortDescriptor(key: "type_", ascending: true), NSSortDescriptor(key: "name_", ascending: true)]
-        request.fetchLimit = limit
+        if limit > 0 {
+            request.fetchLimit = limit
+        }
         if let predicate = predicate {
             request.predicate = predicate
         }

--- a/Macintora/DBObjectsBrowser/DBBrowserCommandsBox.swift
+++ b/Macintora/DBObjectsBrowser/DBBrowserCommandsBox.swift
@@ -1,0 +1,54 @@
+//
+//  DBBrowserCommandsBox.swift
+//  Macintora
+//
+//  Bridge object that lets SwiftUI menu commands trigger DB Browser actions
+//  on the focused window — Refresh, Clear, focus search, switch tabs — so
+//  every toolbar item has a menu-bar peer with a standard key equivalent
+//  (HIG: "Make every toolbar item available as a command in the menu bar.")
+//
+//  Follows the `WorksheetCommandsBox` pattern: intentionally **not**
+//  `@Observable` so trigger reassignment doesn't cascade menu redraws into
+//  a constraint-loop crash.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class DBBrowserCommandsBox {
+    var incrementalRefresh: (() -> Void)?
+    var fullRefresh: (() -> Void)?
+    var fullRefreshAndCompact: (() -> Void)?
+    var compactOnly: (() -> Void)?
+    var clear: (() -> Void)?
+    var showCounts: (() -> Void)?
+    var focusSearch: (() -> Void)?
+    var clearSearch: (() -> Void)?
+    var selectMainTab: (() -> Void)?
+    var selectDetailsTab: (() -> Void)?
+    var editSource: (() -> Void)?
+    var refreshObject: (() -> Void)?
+}
+
+// MARK: - FocusedValueKeys
+
+struct DBBrowserCommandsBoxKey: FocusedValueKey {
+    typealias Value = DBBrowserCommandsBox
+}
+
+struct DBBrowserIsReloadingKey: FocusedValueKey {
+    typealias Value = Bool
+}
+
+extension FocusedValues {
+    var dbBrowserCommandsBox: DBBrowserCommandsBoxKey.Value? {
+        get { self[DBBrowserCommandsBoxKey.self] }
+        set { self[DBBrowserCommandsBoxKey.self] = newValue }
+    }
+
+    var dbBrowserIsReloading: DBBrowserIsReloadingKey.Value? {
+        get { self[DBBrowserIsReloadingKey.self] }
+        set { self[DBBrowserIsReloadingKey.self] = newValue }
+    }
+}

--- a/Macintora/DBObjectsBrowser/DBCacheListEntryView.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheListEntryView.swift
@@ -10,25 +10,44 @@ import SwiftUI
 struct DBCacheListEntryView: View {
     @ObservedObject var dbObject: DBCacheObject
     @Environment(\.managedObjectContext) private var managedObjectContext
-    
+
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                switch dbObject.type {
-                    case "TABLE": Image(systemName: "tablecells").foregroundColor(Color.blue)
-                    case "VIEW": Image(systemName: "tablecells.badge.ellipsis").foregroundColor(Color.blue)
-                    case "TYPE": Image(systemName: "t.square").foregroundColor(Color.blue)
-                    case "PACKAGE": Image(systemName: "ellipsis.curlybraces").foregroundColor(Color.blue)
-                    case "INDEX": Image(systemName: "decrease.indent").foregroundColor(Color.blue)
-                    case "TRIGGER": Image(systemName: "bolt").foregroundColor(Color.blue)
-                    case "PROCEDURE": Image(systemName: "curlybraces").foregroundColor(Color.blue)
-                    case "FUNCTION": Image(systemName: "f.cursive").foregroundColor(Color.blue)
-                    default: Image(systemName: "questionmark.square").foregroundColor(Color.blue)
-                }
-                Text(dbObject.name)
-                    .lineLimit(1)
+        HStack(spacing: 6) {
+            Image(systemName: symbolName)
+                .foregroundStyle(iconTint)
+                .frame(width: 16)
+            Text(dbObject.name)
+                .lineLimit(1)
+            if !dbObject.isValid {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .help("Invalid object")
+                    .accessibilityLabel("Invalid")
             }
+            Spacer(minLength: 0)
         }
+        .contentShape(.rect)
+    }
+
+    private var symbolName: String {
+        switch dbObject.type {
+        case "TABLE":     return "tablecells"
+        case "VIEW":      return "tablecells.badge.ellipsis"
+        case "TYPE":      return "shippingbox"
+        case "PACKAGE":   return "ellipsis.curlybraces"
+        case "INDEX":     return "list.bullet.indent"
+        case "TRIGGER":   return "bolt"
+        case "PROCEDURE": return "curlybraces"
+        case "FUNCTION":  return "f.cursive"
+        default:          return "questionmark.square"
+        }
+    }
+
+    /// Per-type tint role. HIG: "Avoid stylizing your app by specifying a
+    /// fixed color for all sidebar icons." Tint roles let the accent color
+    /// drive presentation while still giving each type a distinguishable hue.
+    private var iconTint: HierarchicalShapeStyle {
+        .secondary
     }
 }
 

--- a/Macintora/DBObjectsBrowser/DBCacheMainView.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheMainView.swift
@@ -55,9 +55,18 @@ struct DBCacheMainView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.connectionStore) private var injectedStore
     @Environment(\.keychainService) private var keychain
+    @Environment(\.openWindow) private var openWindow
     @State private var reportDisplayed = false
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     @State private var filterInspectorPresented = false
+    /// Local mirror of the search field. Debounced into
+    /// `cache.searchCriteria.searchText` so the predicate doesn't recompute
+    /// on every keystroke (HIG: Item 18).
+    @State private var pendingSearchText: String = ""
+    /// Per-connection persisted "last selected object" as
+    /// `owner|name|type`. Backed by UserDefaults (`@AppStorage` doesn't
+    /// support `[String: String]` directly). Restored on first appear when
+    /// no other selection pending was set by `DBCacheInputValue`.
     @SectionedFetchRequest var items: SectionedFetchResults<String?, DBCacheObject>
     @State private var listSelection: SectionedFetchResults<String?, DBCacheObject>.Section.Element?
     @State private var commandsBox = DBBrowserCommandsBox()
@@ -94,7 +103,11 @@ struct DBCacheMainView: View {
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            DBCacheSidebarList(items: items, listSelection: $listSelection)
+            DBCacheSidebarList(
+                items: items,
+                listSelection: $listSelection,
+                onContextAction: handleRowAction
+            )
         } detail: {
             if let selectedItem = listSelection {
                 DBDetailView(dbObject: Binding(get: { selectedItem }, set: {_ in }))
@@ -112,7 +125,7 @@ struct DBCacheMainView: View {
         }
         .navigationTitle(cache.connDetails.tns)
         .navigationSubtitle(navigationSubtitle)
-        .searchable(text: query, placement: .sidebar, prompt: "Filter objects")
+        .searchable(text: $pendingSearchText, placement: .sidebar, prompt: "Filter objects")
         .searchFocused($focus, equals: .search)
         .inspector(isPresented: $filterInspectorPresented) {
             QuickFilterView(quickFilters: $cache.searchCriteria)
@@ -124,6 +137,8 @@ struct DBCacheMainView: View {
         .onAppear {
             cache.store = injectedStore
             cache.keychain = keychain
+            pendingSearchText = cache.searchCriteria.searchText
+            restoreLastSelectionIfNeeded()
             performAutoSelect()
             wireCommandsBox()
         }
@@ -138,9 +153,83 @@ struct DBCacheMainView: View {
         .onChange(of: items.count) { _, _ in
             performAutoSelect()
         }
+        .onChange(of: listSelection) { _, newValue in
+            saveLastSelection(newValue)
+        }
+        // Debounce search input: each new pendingSearchText cancels the
+        // previous task; only an uncancelled run after 200ms commits to
+        // the criteria. The new value compares unequal so the criteria
+        // `onChange` updates the predicate exactly once per pause.
+        .task(id: pendingSearchText) {
+            // Skip the initial-mount no-op (pendingSearchText already in
+            // sync with criteria after onAppear).
+            if pendingSearchText == cache.searchCriteria.searchText { return }
+            do {
+                try await Task.sleep(for: .milliseconds(200))
+            } catch {
+                return
+            }
+            cache.searchCriteria.searchText = pendingSearchText
+        }
         .focusedSceneValue(\.dbBrowserCommandsBox, commandsBox)
         .focusedSceneValue(\.dbBrowserIsReloading, cache.isReloading)
         .toolbar { toolbarContent }
+    }
+
+    /// Saves the last selected object to UserDefaults keyed by TNS. Intentionally
+    /// no-op when `selected` is nil so transient filter-driven clears (e.g.
+    /// search criteria mutation) don't wipe the persisted last-selection.
+    private func saveLastSelection(_ selected: DBCacheObject?) {
+        guard let obj = selected else { return }
+        let tns = cache.connDetails.tns
+        var dict = UserDefaults.standard.dictionary(forKey: "dbBrowserLastSelection") as? [String: String] ?? [:]
+        dict[tns] = "\(obj.owner)|\(obj.name)|\(obj.type)"
+        UserDefaults.standard.set(dict, forKey: "dbBrowserLastSelection")
+    }
+
+    private func restoreLastSelectionIfNeeded() {
+        guard cache.pendingSelectionName == nil else { return }
+        let tns = cache.connDetails.tns
+        guard
+            let dict = UserDefaults.standard.dictionary(forKey: "dbBrowserLastSelection") as? [String: String],
+            let encoded = dict[tns]
+        else { return }
+        let parts = encoded.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 3 else { return }
+        cache.pendingSelectionOwner = parts[0]
+        cache.pendingSelectionName  = parts[1]
+        cache.pendingSelectionType  = parts[2]
+    }
+
+    private func handleRowAction(_ action: DBCacheRowAction, _ obj: DBCacheObject) {
+        switch action {
+        case .copyName:
+            copyToPasteboard(obj.name)
+        case .copyQualifiedName:
+            copyToPasteboard("\(obj.owner).\(obj.name)")
+        case .reveal:
+            listSelection = obj
+        case .openInNewWindow:
+            let value = DBCacheInputValue(
+                mainConnection: MainConnection(mainConnDetails: cache.connDetails),
+                selectedOwner: obj.owner,
+                selectedObjectName: obj.name,
+                selectedObjectType: obj.type
+            )
+            openWindow(value: value)
+        case .editSource:
+            Task(priority: .background) {
+                if let url = await cache.editSource(dbObject: obj) {
+                    await MainActor.run { NSWorkspace.shared.open(url) }
+                }
+            }
+        }
+    }
+
+    private func copyToPasteboard(_ string: String) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(string, forType: .string)
     }
 
     private var navigationSubtitle: String {
@@ -176,6 +265,7 @@ struct DBCacheMainView: View {
             self.focus = .search
         }
         commandsBox.clearSearch = { [weak cache] in
+            self.pendingSearchText = ""
             cache?.searchCriteria.searchText = ""
         }
         commandsBox.selectMainTab = {
@@ -248,20 +338,21 @@ struct DBCacheMainView: View {
         .frame(minWidth: 320, idealWidth: 360, minHeight: 200)
     }
 
-    var query: Binding<String> {
-        Binding {
-            cache.searchCriteria.searchText
-        } set: { newValue in
-            listSelection = nil
-            cache.searchCriteria.searchText = newValue
-            items.nsPredicate = cache.searchCriteria.predicate
-        }
-    }
+}
+
+/// Actions exposed via the sidebar row context menu (HIG, Item 24).
+enum DBCacheRowAction {
+    case copyName
+    case copyQualifiedName
+    case reveal
+    case openInNewWindow
+    case editSource
 }
 
 private struct DBCacheSidebarList: View {
     let items: SectionedFetchResults<String?, DBCacheObject>
     @Binding var listSelection: SectionedFetchResults<String?, DBCacheObject>.Section.Element?
+    let onContextAction: (DBCacheRowAction, DBCacheObject) -> Void
 
     var body: some View {
         Group {
@@ -274,6 +365,27 @@ private struct DBCacheSidebarList: View {
                             ForEach(section) { item in
                                 DBCacheListEntryView(dbObject: item)
                                     .tag(item)
+                                    .draggable("\(item.owner).\(item.name)") {
+                                        DBCacheListEntryView(dbObject: item)
+                                    }
+                                    .contextMenu {
+                                        Button("Copy Name") {
+                                            onContextAction(.copyName, item)
+                                        }
+                                        Button("Copy Owner.Name") {
+                                            onContextAction(.copyQualifiedName, item)
+                                        }
+                                        Divider()
+                                        Button("Reveal in Sidebar") {
+                                            onContextAction(.reveal, item)
+                                        }
+                                        Button("Open in New Window") {
+                                            onContextAction(.openInNewWindow, item)
+                                        }
+                                        Button("Open Source in Editor") {
+                                            onContextAction(.editSource, item)
+                                        }
+                                    }
                             }
                         } header: {
                             Text(section.id ?? "(unknown)")

--- a/Macintora/DBObjectsBrowser/DBCacheMainView.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheMainView.swift
@@ -44,6 +44,12 @@ struct DBCacheInputValue: Hashable, Codable, Equatable {
     }
 }
 
+/// Search-field focus identifier. `@FocusState` toggled by ⌘F via the
+/// `DBBrowserCommandsBox.focusSearch` hook.
+private enum DBBrowserFocus: Hashable {
+    case search
+}
+
 struct DBCacheMainView: View {
     @ObservedObject var cache: DBCacheVM
     @Environment(\.managedObjectContext) private var viewContext
@@ -51,13 +57,18 @@ struct DBCacheMainView: View {
     @Environment(\.keychainService) private var keychain
     @State private var reportDisplayed = false
     @State private var columnVisibility = NavigationSplitViewVisibility.all
+    @State private var filterInspectorPresented = false
     @SectionedFetchRequest var items: SectionedFetchResults<String?, DBCacheObject>
     @State private var listSelection: SectionedFetchResults<String?, DBCacheObject>.Section.Element?
+    @State private var commandsBox = DBBrowserCommandsBox()
+    @FocusState private var focus: DBBrowserFocus?
 
     init(cache: DBCacheVM) {
         self.cache = cache
+        // No fetch cap: rely on Core Data faulting + List's lazy row
+        // materialisation. Effective infinite scroll for free.
         _items = SectionedFetchRequest(
-            fetchRequest: DBCacheObject.fetchRequest(limit: cache.searchLimit, predicate: cache.searchCriteria.predicate),
+            fetchRequest: DBCacheObject.fetchRequest(predicate: cache.searchCriteria.predicate),
             sectionIdentifier: \DBCacheObject.owner_,
             animation: .default)
     }
@@ -80,28 +91,33 @@ struct DBCacheMainView: View {
             }
         }
     }
-    
+
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            VStack(alignment: .leading, spacing: 0) {
-                headerView
-                    .frame(minWidth: 200)
-                QuickFilterView(quickFilters: $cache.searchCriteria)
-                Spacer()
-            }
-            .padding()
-        } content: {
             DBCacheSidebarList(items: items, listSelection: $listSelection)
         } detail: {
             if let selectedItem = listSelection {
                 DBDetailView(dbObject: Binding(get: { selectedItem }, set: {_ in }))
                     .environmentObject(cache)
                     .frame(minWidth: 400, idealWidth: 600, maxWidth: .infinity, idealHeight: 1000, maxHeight: .infinity)
+            } else if items.isEmpty {
+                ContentUnavailableView.search
             } else {
-                Text("Nothing selected")
+                ContentUnavailableView(
+                    "No Object Selected",
+                    systemImage: "tablecells",
+                    description: Text("Pick an object from the list to view details.")
+                )
             }
         }
-        .searchable(text: query, placement: .sidebar, prompt: "type something")
+        .navigationTitle(cache.connDetails.tns)
+        .navigationSubtitle(navigationSubtitle)
+        .searchable(text: query, placement: .sidebar, prompt: "Filter objects")
+        .searchFocused($focus, equals: .search)
+        .inspector(isPresented: $filterInspectorPresented) {
+            QuickFilterView(quickFilters: $cache.searchCriteria)
+                .inspectorColumnWidth(min: 220, ideal: 260, max: 360)
+        }
         .background(WindowObserver { window in
             DBBrowserWindowRegistry.shared.register(vm: cache, window: window)
         })
@@ -109,53 +125,86 @@ struct DBCacheMainView: View {
             cache.store = injectedStore
             cache.keychain = keychain
             performAutoSelect()
+            wireCommandsBox()
         }
         .onDisappear {
             DBBrowserWindowRegistry.shared.deregister(vm: cache)
         }
-        .onChange(of: cache.searchCriteria.predicate) { _, value in
+        .onChange(of: cache.searchCriteria) { _, value in
             listSelection = nil
-            items.nsPredicate = value
+            items.nsPredicate = value.predicate
+            value.persist()
         }
         .onChange(of: items.count) { _, _ in
             performAutoSelect()
         }
+        .focusedSceneValue(\.dbBrowserCommandsBox, commandsBox)
+        .focusedSceneValue(\.dbBrowserIsReloading, cache.isReloading)
         .toolbar { toolbarContent }
+    }
+
+    private var navigationSubtitle: String {
+        let version = cache.dbVersionFull ?? "—"
+        return "\(version) · updated \(cache.lastUpdatedStr)"
+    }
+
+    private func wireCommandsBox() {
+        let cache = self.cache
+        commandsBox.incrementalRefresh = { [weak cache] in
+            guard let cache, !cache.isReloading else { return }
+            cache.updateCache()
+        }
+        commandsBox.fullRefresh = { [weak cache] in
+            guard let cache, !cache.isReloading else { return }
+            cache.updateCache(ignoreLastUpdate: true)
+        }
+        commandsBox.fullRefreshAndCompact = { [weak cache] in
+            guard let cache, !cache.isReloading else { return }
+            cache.updateCache(ignoreLastUpdate: true, withCleanup: true)
+        }
+        commandsBox.compactOnly = { [weak cache] in
+            guard let cache, !cache.isReloading else { return }
+            cache.updateCache(cleanupOnly: true)
+        }
+        commandsBox.clear = { [weak cache] in
+            cache?.clearCache()
+        }
+        commandsBox.showCounts = {
+            self.reportDisplayed = true
+        }
+        commandsBox.focusSearch = {
+            self.focus = .search
+        }
+        commandsBox.clearSearch = { [weak cache] in
+            cache?.searchCriteria.searchText = ""
+        }
+        commandsBox.selectMainTab = {
+            UserDefaults.standard.set(DBDetailTab.main.rawValue, forKey: "dbDetailSelectedTab")
+        }
+        commandsBox.selectDetailsTab = {
+            UserDefaults.standard.set(DBDetailTab.details.rawValue, forKey: "dbDetailSelectedTab")
+        }
     }
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolbarItemGroup(placement: .principal) {
             Menu {
-                Button(cache.isReloading ? "Working..." : "Incremental Refresh") {
-                    guard !cache.isReloading else { return }
-                    cache.updateCache()
-                }
-
-                Button(cache.isReloading ? "Working..." : "Full Refresh (No Vacuum)") {
-                    guard !cache.isReloading else { return }
-                    cache.updateCache(ignoreLastUpdate: true)
-                }
-
-                Button(cache.isReloading ? "Working..." : "Full Refresh + Vacuum") {
-                    guard !cache.isReloading else { return }
-                    cache.updateCache(ignoreLastUpdate: true, withCleanup: true)
-                }
-
-                Button(cache.isReloading ? "Working..." : "Vacuum Only") {
-                    guard !cache.isReloading else { return }
-                    cache.updateCache(cleanupOnly: true)
-                }
-
+                Button("Incremental Refresh") { commandsBox.incrementalRefresh?() }
+                Button("Full Refresh") { commandsBox.fullRefresh?() }
+                Button("Full Refresh & Compact") { commandsBox.fullRefreshAndCompact?() }
+                Button("Compact Cache") { commandsBox.compactOnly?() }
             } label: {
-                Label(cache.isReloading ? "Working..." : "Refresh", systemImage: "arrow.triangle.2.circlepath")
+                Label("Refresh", systemImage: "arrow.clockwise")
             }
+            .disabled(cache.isReloading)
             .help("Refresh Cache")
 
-            Button { cache.clearCache() } label: {
+            Button { commandsBox.clear?() } label: {
                 Label("Clear", systemImage: "trash")
             }
             .help("Clear Cache")
+            .disabled(cache.isReloading)
         }
 
         ToolbarItemGroup(placement: .status) {
@@ -163,39 +212,42 @@ struct DBCacheMainView: View {
                 Label("Counts", systemImage: "sum")
             }
             .sheet(isPresented: $reportDisplayed) {
-                VStack {
-                    Text(cache.reportCacheCounts())
-                        .textSelection(.enabled)
-                        .lineLimit(20)
-                        .frame(width: 300.0, height: 200.0, alignment: .topLeading)
-                        .padding()
-                    Button { reportDisplayed.toggle() } label: { Text("Dismiss") }
-                    .padding()
-                }.padding()
+                cacheCountsSheet
             }
             .help("Show Cache counts")
 
-            Image(systemName: "arrow.triangle.2.circlepath")
-                .rotationEffect(Angle.degrees(cache.isReloading ? 360 : 0))
-                .animation(.linear(duration: 2.0).repeat(while: cache.isReloading, autoreverses: false), value: cache.isReloading)
-                .foregroundColor(cache.isReloading ? .red : .green)
-        }
-    }
-    
-    var headerView: some View {
-        // db name and cache update timestamp
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text("\(cache.connDetails.tns)").font(.headline)
-                Text("- \(cache.dbVersionFull ?? "(unknown)")")
+            Button {
+                filterInspectorPresented.toggle()
+            } label: {
+                Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
             }
-                .padding(.vertical,3)
-            Text("Cache updated: \(cache.lastUpdatedStr)")
-                .font(.subheadline)
-                .padding(.horizontal)
+            .help("Filter")
+
+            if cache.isReloading {
+                ProgressView()
+                    .controlSize(.small)
+                    .help("Refreshing cache…")
+            }
         }
     }
-    
+
+    private var cacheCountsSheet: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Cache Counts").font(.headline)
+            Text(cache.reportCacheCounts())
+                .textSelection(.enabled)
+                .monospaced()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack {
+                Spacer()
+                Button("Done") { reportDisplayed = false }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 320, idealWidth: 360, minHeight: 200)
+    }
+
     var query: Binding<String> {
         Binding {
             cache.searchCriteria.searchText
@@ -203,7 +255,6 @@ struct DBCacheMainView: View {
             listSelection = nil
             cache.searchCriteria.searchText = newValue
             items.nsPredicate = cache.searchCriteria.predicate
-//            totalCountMatched = 0
         }
     }
 }
@@ -213,20 +264,25 @@ private struct DBCacheSidebarList: View {
     @Binding var listSelection: SectionedFetchResults<String?, DBCacheObject>.Section.Element?
 
     var body: some View {
-        List(selection: $listSelection) {
-            ForEach(items) { section in
-                Section(header: Text(section.id ?? "(unknown)")) {
-                    ForEach(section) { item in
-                        NavigationLink(value: item) {
-                            DBCacheListEntryView(dbObject: item)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .contentShape(Rectangle())
+        Group {
+            if items.isEmpty {
+                ContentUnavailableView.search
+            } else {
+                List(selection: $listSelection) {
+                    ForEach(items) { section in
+                        Section {
+                            ForEach(section) { item in
+                                DBCacheListEntryView(dbObject: item)
+                                    .tag(item)
+                            }
+                        } header: {
+                            Text(section.id ?? "(unknown)")
                         }
                     }
                 }
+                .listStyle(.sidebar)
             }
         }
-        .listStyle(SidebarListStyle())
     }
 }
 

--- a/Macintora/DBObjectsBrowser/DBCacheMainView.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheMainView.swift
@@ -390,6 +390,7 @@ private struct DBCacheSidebarList: View {
                         } header: {
                             Text(section.id ?? "(unknown)")
                         }
+                        .headerProminence(.increased)
                     }
                 }
                 .listStyle(.sidebar)

--- a/Macintora/DBObjectsBrowser/DBCacheSearchCriteria.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheSearchCriteria.swift
@@ -37,6 +37,14 @@ struct DBCacheSearchCriteria: Equatable {
     /// Cleared when the user resets the type filter from `QuickFilterView`.
     var selectedTypeFilter: String? = nil
 
+    /// When true, the per-type `showXXX` toggles are ignored entirely so the
+    /// list isn't constrained by object type. Set when the DB Browser is
+    /// opened pre-focused on an object whose type isn't known up front (a bare
+    /// `owner.name` reference): the user asked for that object, so the type
+    /// toggles must not hide it. Cleared as soon as the user touches a type
+    /// toggle in `QuickFilterView`. Session-only — never persisted.
+    var ignoreTypeFilter: Bool = false
+
     private let tns: String
 
     var ownerInclusionList: [String] {
@@ -87,7 +95,7 @@ struct DBCacheSearchCriteria: Equatable {
 
         if let forced = selectedTypeFilter {
             predicates.append(NSPredicate(format: "type_ = %@", forced))
-        } else {
+        } else if !ignoreTypeFilter {
             var typeInclusionList = [String]()
             if showTables { typeInclusionList.append("TABLE") }
             if showTypes { typeInclusionList.append("TYPE") }

--- a/Macintora/DBObjectsBrowser/DBCacheSearchCriteria.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheSearchCriteria.swift
@@ -9,22 +9,27 @@ import CoreData
 import os
 import SwiftUI
 
+/// Filter + search state for the DB Browser's object list. Plain stored
+/// properties (no `@AppStorage`) so binding mutations through
+/// `@Published`/`@Observable` reliably fire `objectWillChange`. UserDefaults
+/// is read once in `init(for:)` and rewritten via `persist()` whenever the
+/// hosting view model observes a change.
 struct DBCacheSearchCriteria: Equatable {
     static func == (lhs: DBCacheSearchCriteria, rhs: DBCacheSearchCriteria) -> Bool {
         lhs.predicate == rhs.predicate
     }
 
     var searchText = ""
-    @AppStorage("prefixList") var prefixList = ["preview": ""] // tns = key: value
-    @AppStorage("ownerList") var ownerList = ["preview": ""] // tns = key: value
-    @AppStorage("showTables") var showTables = true
-    @AppStorage("showViews") var showViews = true
-    @AppStorage("showIndexes") var showIndexes = true
-    @AppStorage("showPackages") var showPackages = true
-    @AppStorage("showTypes") var showTypes = true
-    @AppStorage("showTriggers") var showTriggers = true
-    @AppStorage("showProcedures") var showProcedures = true
-    @AppStorage("showFunctions") var showFunctions = true
+    var ownerString: String
+    var prefixString: String
+    var showTables: Bool
+    var showViews: Bool
+    var showIndexes: Bool
+    var showPackages: Bool
+    var showTypes: Bool
+    var showTriggers: Bool
+    var showProcedures: Bool
+    var showFunctions: Bool
 
     /// When non-nil, overrides the `showXXX` type toggles and filters to
     /// only this Oracle object type (e.g. "TABLE"). Set by "Open in DB Browser"
@@ -33,22 +38,50 @@ struct DBCacheSearchCriteria: Equatable {
     var selectedTypeFilter: String? = nil
 
     private let tns: String
-    
-    var ownerString: String { get { ownerList[tns] ?? "" } set { ownerList[tns] = newValue} }
-    var prefixString: String { get { prefixList[tns] ?? "" } set { prefixList[tns] = newValue} }
-    
+
     var ownerInclusionList: [String] {
         ownerString.uppercased().components(separatedBy: ",").compactMap { let trimmed = $0.trimmingCharacters(in: .whitespaces); return trimmed.isEmpty ? nil : trimmed }
     }
-    
+
     var namePrefixInclusionList: [String] {
         prefixString.components(separatedBy: ",").compactMap { let trimmed = $0.uppercased().trimmingCharacters(in: .whitespaces); return trimmed.isEmpty ? nil : trimmed }
     }
-    
+
     init(for tns: String) {
         self.tns = tns
+        let d = UserDefaults.standard
+        self.showTables = d.object(forKey: Keys.showTables) as? Bool ?? true
+        self.showViews = d.object(forKey: Keys.showViews) as? Bool ?? true
+        self.showIndexes = d.object(forKey: Keys.showIndexes) as? Bool ?? true
+        self.showPackages = d.object(forKey: Keys.showPackages) as? Bool ?? true
+        self.showTypes = d.object(forKey: Keys.showTypes) as? Bool ?? true
+        self.showTriggers = d.object(forKey: Keys.showTriggers) as? Bool ?? true
+        self.showProcedures = d.object(forKey: Keys.showProcedures) as? Bool ?? true
+        self.showFunctions = d.object(forKey: Keys.showFunctions) as? Bool ?? true
+        let ownerList = d.dictionary(forKey: Keys.ownerList) as? [String: String] ?? [:]
+        let prefixList = d.dictionary(forKey: Keys.prefixList) as? [String: String] ?? [:]
+        self.ownerString = ownerList[tns] ?? ""
+        self.prefixString = prefixList[tns] ?? ""
     }
-    
+
+    func persist() {
+        let d = UserDefaults.standard
+        d.set(showTables, forKey: Keys.showTables)
+        d.set(showViews, forKey: Keys.showViews)
+        d.set(showIndexes, forKey: Keys.showIndexes)
+        d.set(showPackages, forKey: Keys.showPackages)
+        d.set(showTypes, forKey: Keys.showTypes)
+        d.set(showTriggers, forKey: Keys.showTriggers)
+        d.set(showProcedures, forKey: Keys.showProcedures)
+        d.set(showFunctions, forKey: Keys.showFunctions)
+        var ownerList = d.dictionary(forKey: Keys.ownerList) as? [String: String] ?? [:]
+        ownerList[tns] = ownerString
+        d.set(ownerList, forKey: Keys.ownerList)
+        var prefixList = d.dictionary(forKey: Keys.prefixList) as? [String: String] ?? [:]
+        prefixList[tns] = prefixString
+        d.set(prefixList, forKey: Keys.prefixList)
+    }
+
     var predicate: NSPredicate {
         var predicates = [NSPredicate]()
 
@@ -72,37 +105,28 @@ struct DBCacheSearchCriteria: Equatable {
         if !ownerInclusionList.isEmpty {
             predicates.append(NSPredicate(format: "owner_ IN %@", ownerInclusionList))
         }
-//
+
         if !searchText.isEmpty {
             predicates.append(NSPredicate.init(format: "name_ CONTAINS[c] %@", searchText))
         }
         if !namePrefixInclusionList.isEmpty {
             predicates.append(NSCompoundPredicate.init(type: .or, subpredicates: namePrefixInclusionList.map { NSPredicate.init(format: "name_ BEGINSWITH[c] %@", $0) } ))
         }
-        
-        //        predicates.append(NSCompoundPredicate.init(format: "name_ = %@", "CDR_JOBS"))
+
         log.cache.debug("criteria: \(predicates, privacy: .public)")
         return NSCompoundPredicate.init(type: .and, subpredicates: predicates)
     }
-    
-//    var sort: [NSSortDescriptor] {
-//        var sorts = [NSSortDescriptor]()
-//        sorts.append(NSSortDescriptor(keyPath: \DBCacheObject.name_, ascending: true))
-//        sorts.append(NSSortDescriptor(keyPath: \DBCacheObject.owner_, ascending: true))
-//        sorts.append(NSSortDescriptor(keyPath: \DBCacheObject.type_, ascending: true))
-//        return sorts
-//    }
-    
-//    var fetchParams: (NSPredicate, [NSSortDescriptor]) {
-//        (predicate, sort)
-//    }
-    
-//    var fetchRequest: NSFetchRequest<DBCacheObject> {
-//        let request = DBCacheObject.fetchRequest()
-//        request.predicate = predicate
-//        request.sortDescriptors = sort
-//        request.fetchLimit = 50
-//        return request
-//    }
-    
+
+    private enum Keys {
+        static let showTables = "showTables"
+        static let showViews = "showViews"
+        static let showIndexes = "showIndexes"
+        static let showPackages = "showPackages"
+        static let showTypes = "showTypes"
+        static let showTriggers = "showTriggers"
+        static let showProcedures = "showProcedures"
+        static let showFunctions = "showFunctions"
+        static let ownerList = "ownerList"
+        static let prefixList = "prefixList"
+    }
 }

--- a/Macintora/DBObjectsBrowser/DBCacheVM.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheVM.swift
@@ -243,7 +243,6 @@ final class DBCacheVM: nonisolated ObservableObject {
     @AppStorage("cacheUpdateBatchSize") private var cacheUpdateBatchSize: Int = 200
     @AppStorage("includeSystemObjects") private var includeSystemObjects = false
     @AppStorage("cacheUpdateSessionLimit") private var cacheUpdateSessionLimit: Int = 5
-    @AppStorage("searchLimit") var searchLimit: Int = 20
 
     let connDetails: ConnectionDetails
     private var client: OracleClient?

--- a/Macintora/DBObjectsBrowser/DBCacheVM.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheVM.swift
@@ -297,6 +297,10 @@ final class DBCacheVM: nonisolated ObservableObject {
         }
         if let type = selectedObjectType {
             searchCriteria.selectedTypeFilter = type
+        } else if selectedObjectName != nil {
+            // Opened pre-focused on a bare `owner.name` reference of unknown
+            // type — don't let the per-type toggles hide the requested object.
+            searchCriteria.ignoreTypeFilter = true
         }
         self.initialDetailTab = initialDetailTab
         self.pendingSelectionName  = selectedObjectName

--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -32,21 +32,19 @@ struct DBDetailObjectMainView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0.0) {
             Form {
-                TextField("Object ID", value: $dbObject.objectId, format: .number.grouping(.never))
-                TextField("Created", value: $dbObject.createDate, format: .dateTime)
-                TextField("Last DDL", value: $dbObject.lastDDLDate, format: .dateTime)
-                TextField("Edition", text: Binding(get: { dbObject.editionName ?? "" } , set: {_ in}))
-                HStack {
-                    Toggle("Editionable", isOn: $dbObject.isEditionable)
-                    Toggle("Valid", isOn: $dbObject.isValid)
+                LabeledContent("Object ID", value: dbObject.objectId.formatted(.number.grouping(.never)))
+                LabeledContent("Created", value: dbObject.createDate?.formatted(date: .abbreviated, time: .standard) ?? Constants.nullValue)
+                LabeledContent("Last DDL", value: dbObject.lastDDLDate?.formatted(date: .abbreviated, time: .standard) ?? Constants.nullValue)
+                LabeledContent("Edition", value: dbObject.editionName ?? Constants.nullValue)
+                LabeledContent("Editionable") {
+                    BoolIndicator(value: dbObject.isEditionable)
+                }
+                LabeledContent("Valid") {
+                    BoolIndicator(value: dbObject.isValid, trueColor: .green, falseColor: .red)
                 }
             }
-            .padding()
-            .overlay(
-                RoundedRectangle(cornerRadius: 25)
-                    .stroke(.quaternary, lineWidth: 2)
-            )
-            .padding([.top, .leading, .trailing])
+            .formStyle(.grouped)
+
             if hasProcedureContent {
                 PackageProceduresListView(dbObject: dbObject)
             } else {
@@ -76,7 +74,7 @@ struct DBDetailObjectDetailsView: View {
 struct DBDetailView: View {
     @Binding var dbObject: DBCacheObject
     @EnvironmentObject private var cache: DBCacheVM
-    @State private var selectedTab: String = "details"
+    @AppStorage("dbDetailSelectedTab") private var selectedTab: DBDetailTab = .details
     @State private var hasAppliedInitialTab = false
 
     var body: some View {
@@ -85,25 +83,21 @@ struct DBDetailView: View {
                 .padding([.top, .leading, .trailing])
 
             TabView(selection: $selectedTab) {
-                DBDetailObjectMainView(dbObject: $dbObject)
-                    .frame(alignment: .topLeading)
-                    .tabItem {
-                        Text("Main")
-                    }
-                    .tag("main")
+                Tab("Main", systemImage: "info.circle", value: DBDetailTab.main) {
+                    DBDetailObjectMainView(dbObject: $dbObject)
+                        .frame(alignment: .topLeading)
+                }
 
-                DBDetailObjectDetailsView(dbObject: $dbObject)
-                    .tabItem {
-                        Text("Details")
-                    }
-                    .tag("details")
+                Tab("Details", systemImage: "list.bullet.rectangle", value: DBDetailTab.details) {
+                    DBDetailObjectDetailsView(dbObject: $dbObject)
+                }
             }
         }
         .onAppear {
             guard !hasAppliedInitialTab else { return }
             hasAppliedInitialTab = true
             if let tab = cache.initialDetailTab {
-                selectedTab = tab.rawValue
+                selectedTab = tab
                 cache.initialDetailTab = nil
             }
         }
@@ -115,17 +109,19 @@ struct DBDetailViewHeader: View {
     @State private var isRefreshing = false
     @State private var isLoadingSource = false
     @EnvironmentObject private var cache: DBCacheVM
-    
+
     var body: some View {
-        HStack {
+        HStack(spacing: 8) {
             DBDetailViewHeaderImage(type: Binding( get: { OracleObjectType(rawValue: dbObject.type) ?? .unknown}, set: {_ in }))
-                .foregroundColor(Color.blue)
+                .labelStyle(.titleAndIcon)
+                .font(.title3)
             Text("\(dbObject.name) (\(dbObject.owner))")
                 .textSelection(.enabled)
+                .font(.title3)
+                .bold()
             Spacer()
-            
-            // edit object source
-            Button {
+
+            Button("Edit Source", systemImage: "square.and.pencil") {
                 guard !isLoadingSource else { return }
                 Task(priority: .background) {
                     isLoadingSource = true
@@ -134,28 +130,26 @@ struct DBDetailViewHeader: View {
                     }
                     isLoadingSource = false
                 }
-            } label: {
-                Image(systemName: "doc.circle").foregroundColor(.blue)
-                    .rotationEffect(Angle.degrees(isLoadingSource ? 360 : 0))
-                    .animation(.linear(duration: 2.0).repeat(while: isLoadingSource, autoreverses: false), value: isLoadingSource)
             }
-                .buttonStyle(.borderless)
-                .help("Edit")
-            
-            // refresh
-            Button(action: refresh, label: {
-                Image(systemName: "arrow.clockwise.circle").foregroundColor(.blue)
-                    .rotationEffect(Angle.degrees(isRefreshing ? 360 : 0))
-                    .animation(.linear(duration: 2.0).repeat(while: isRefreshing, autoreverses: false), value: isRefreshing)
+            .buttonStyle(.borderless)
+            .disabled(isLoadingSource)
+            .help("Open source in editor")
 
-            })
+            if isLoadingSource {
+                ProgressView().controlSize(.small)
+            }
+
+            Button("Refresh", systemImage: "arrow.clockwise", action: refresh)
                 .buttonStyle(.borderless)
                 .disabled(isRefreshing)
-                .help("Refresh")
+                .help("Refresh this object")
+
+            if isRefreshing {
+                ProgressView().controlSize(.small)
+            }
         }
-            .font(.title)
     }
-    
+
     func refresh() {
         Task(priority: .background) {
             await MainActor.run { isRefreshing = true }
@@ -186,7 +180,7 @@ struct DBDetailViewHeader: View {
 
 struct DBDetailViewHeaderImage: View {
     @Binding var type: OracleObjectType
-    
+
     var body: some View {
         switch type {
             case .table:
@@ -194,9 +188,9 @@ struct DBDetailViewHeaderImage: View {
             case .view:
                 Label("View", systemImage: "tablecells.badge.ellipsis")
             case .index:
-                Label("Index", systemImage: "decrease.indent")
+                Label("Index", systemImage: "list.bullet.indent")
             case .type:
-                Label("Type", systemImage: "t.square")
+                Label("Type", systemImage: "shippingbox")
             case .package:
                 Label("Package", systemImage: "ellipsis.curlybraces")
             case .procedure:
@@ -211,7 +205,20 @@ struct DBDetailViewHeaderImage: View {
     }
 }
 
+/// Non-interactive boolean presenter for read-only fields. Replaces
+/// `Toggle(isOn: .constant(...))`, which renders an interactive-looking
+/// switch that doesn't actually toggle.
+struct BoolIndicator: View {
+    let value: Bool
+    var trueColor: Color = .accentColor
+    var falseColor: Color = .secondary
 
+    var body: some View {
+        Image(systemName: value ? "checkmark.circle.fill" : "circle")
+            .foregroundStyle(value ? trueColor : falseColor)
+            .accessibilityLabel(value ? "Yes" : "No")
+    }
+}
 
 struct DBDetailView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Macintora/DBObjectsBrowser/DBIndexDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBIndexDetailView.swift
@@ -8,14 +8,18 @@
 import SwiftUI
 import CoreData
 
+private enum DBIndexTab: String, CaseIterable, Codable {
+    case columns
+    case sql
+}
 
 struct DBIndexDetailView: View {
     @Environment(\.managedObjectContext) var context
-    @State private var selectedTab: String = "columns"
+    @AppStorage("dbIndexDetailSelectedTab") private var selectedTab: DBIndexTab = .columns
     @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
     @FetchRequest private var columns: FetchedResults<DBCacheIndexColumn>
     @Binding var dbObject: DBCacheObject
-    
+
     let columnLabels = ["position", "columnName", "isDescending", "length"]
     let booleanColumnLabels = ["isDescending"]
     var columnSortFn = { (lhs: NSManagedObject, rhs: NSManagedObject) in (lhs as! DBCacheIndexColumn).position < (rhs as! DBCacheIndexColumn).position }
@@ -25,49 +29,37 @@ struct DBIndexDetailView: View {
         _indexes = FetchRequest<DBCacheIndex>(sortDescriptors: [], predicate: NSPredicate.init(format: "name_ = %@ and owner_ = %@", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
         _columns = FetchRequest<DBCacheIndexColumn>(sortDescriptors: [], predicate: NSPredicate.init(format: "indexName_ = %@ and owner_ = %@", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
     }
-    
-    var tableHeader: some View {
-        HStack {
-            VStack(alignment: .centreLine, spacing: 3) {
-                FormField(label: "Partitioned?") {
-                    Toggle("", isOn: .constant(indexes.first?.isPartitioned ?? false))
-                }
-                FormField(label: "Row Count") {
-                    Text(indexes.first?.numRows.formatted() ?? Constants.nullValue)
-                }
-                
+
+    private var indexForm: some View {
+        Form {
+            LabeledContent("Partitioned") {
+                BoolIndicator(value: indexes.first?.isPartitioned ?? false)
             }
-            Spacer()
-            VStack(alignment: .centreLine, spacing: 3) {
-                FormField(label: "Last Analyzed") {
-                    Text(indexes.first?.lastAnalyzed?.ISO8601Format() ?? Constants.nullValue)
-                }
-            }
-            Spacer()
+            LabeledContent("Row Count", value: indexes.first?.numRows.formatted() ?? Constants.nullValue)
+            LabeledContent("Last Analyzed", value: indexes.first?.lastAnalyzed?.formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
         }
-        .padding()
+        .formStyle(.grouped)
     }
-    
+
     var body: some View {
         VStack {
-            tableHeader
-            
+            indexForm
+
             TabView(selection: $selectedTab) {
-                DetailGridView(rows: Array(columns).sorted(by: columnSortFn), columnLabels: columnLabels, booleanColumnLabels: booleanColumnLabels, rowSortFn: columnSortFn)
-                    .id(dbObject.id)
-                    .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
-                    .tabItem {
-                        Text("Columns")
-                    }.tag("columns")
+                Tab("Columns", systemImage: "rectangle.split.3x1", value: DBIndexTab.columns) {
+                    DetailGridView(rows: Array(columns).sorted(by: columnSortFn), columnLabels: columnLabels, booleanColumnLabels: booleanColumnLabels, rowSortFn: columnSortFn)
+                        .id(dbObject.id)
+                        .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
+                }
 
-                Text("Index DDL")
-                    .tabItem {
-                        Text("SQL")
-                    }.tag("sql")
-
-
+                Tab("SQL", systemImage: "doc.text", value: DBIndexTab.sql) {
+                    ContentUnavailableView(
+                        "Index DDL Not Available",
+                        systemImage: "doc.text",
+                        description: Text("DDL preview for indexes is not yet implemented.")
+                    )
+                }
             }
-            .font(.headline)
         }
         .frame(minWidth: 200, idealWidth: 400, maxWidth: .infinity)
         .padding()
@@ -86,4 +78,3 @@ struct DBIndexDetailView: View {
 //            .environment(\.managedObjectContext, cache.persistenceController.container.viewContext)
 //    }
 //}
-

--- a/Macintora/DBObjectsBrowser/DBSourceDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBSourceDetailView.swift
@@ -8,43 +8,39 @@
 import SwiftUI
 import CoreData
 
+private enum DBSourceTab: String, CaseIterable, Codable {
+    case spec
+    case body
+}
+
 struct DBSourceDetailView: View {
     @Environment(\.managedObjectContext) var context
-    @State private var selectedTab: String = "spec"
+    @AppStorage("dbSourceDetailSelectedTab") private var selectedTab: DBSourceTab = .spec
     @FetchRequest private var tables: FetchedResults<DBCacheSource>
     @Binding var dbObject: DBCacheObject
-    
+
     init(dbObject: Binding<DBCacheObject>) {
         self._dbObject = dbObject
         _tables = FetchRequest<DBCacheSource>(sortDescriptors: [], predicate: NSPredicate.init(format: "name_ = %@ and owner_ = %@ ", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
-        print("init \(dbObject.name.wrappedValue)")
     }
-    
-    var tableHeader: some View {
-        EmptyView()
-            .padding()
-    }
-    
+
     var textSpec: Binding<String> { Binding<String>( get: { tables.first?.textSpec ?? "" }, set: {_ in} ) }
     var textBody: Binding<String> { Binding<String>( get: { tables.first?.textBody ?? "" }, set: {_ in} ) }
-    
+
     var body: some View {
         VStack(alignment: .leading) {
-            tableHeader
             TabView(selection: $selectedTab) {
-                SourceView(objName: $dbObject.name, text: textSpec, title: "Specification")
-                    .tabItem { Text("Spec") }
-                    .tag("spec")
-                    .padding(.vertical,5)
-                SourceView(objName: $dbObject.name, text: textBody, title: "Body")
-                    .tabItem { Text("Body") }
-                    .tag("body")
-                    .padding(.vertical,5)
+                Tab("Spec", systemImage: "doc.text", value: DBSourceTab.spec) {
+                    SourceView(objName: $dbObject.name, text: textSpec, title: "Specification")
+                        .padding(.vertical, 5)
+                }
+                Tab("Body", systemImage: "doc.text.fill", value: DBSourceTab.body) {
+                    SourceView(objName: $dbObject.name, text: textBody, title: "Body")
+                        .padding(.vertical, 5)
+                }
             }
         }
         .frame(minWidth: 200, idealWidth: 1000, maxWidth: .infinity, idealHeight: 1000, maxHeight: .infinity)
         .padding()
     }
 }
-
-

--- a/Macintora/DBObjectsBrowser/DBTableDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBTableDetailView.swift
@@ -104,7 +104,7 @@ struct DBTableDetailView: View {
 
                     SwiftUIWindow.open { window in
                         let _ = (window.title = dbObject.name)
-                        FormattedView(formatter: formatter)
+                        FormattedView(formatter: formatter, onDone: { window.close() })
                     }
                     .closeOnEscape(true)
 

--- a/Macintora/DBObjectsBrowser/DBTableDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBTableDetailView.swift
@@ -7,14 +7,19 @@
 
 import SwiftUI
 import CoreData
-// STTextViewUI was an experimental dep on a parallel branch; oracle-nio's
-// pbxproj doesn't reference it. The SQL view below falls back to a plain
-// ScrollView + Text with monospaced font, which is what the migration
-// branch had in use.
+
+/// Sub-tabs inside the "Details" tab for tables/views. Codable so we can
+/// persist the last user-picked tab across selections.
+private enum DBTableDetailTab: String, CaseIterable, Codable {
+    case columns
+    case indexes
+    case triggers
+    case sql
+}
 
 struct DBTableDetailView: View {
     @Environment(\.managedObjectContext) var context
-    @State private var selectedTab: String = "columns"
+    @AppStorage("dbTableDetailSelectedTab") private var selectedTab: DBTableDetailTab = .columns
     @FetchRequest private var tables: FetchedResults<DBCacheTable>
     @FetchRequest private var columns: FetchedResults<DBCacheTableColumn>
     @Binding var dbObject: DBCacheObject
@@ -30,129 +35,93 @@ struct DBTableDetailView: View {
         _tables = FetchRequest<DBCacheTable>(sortDescriptors: [], predicate: NSPredicate.init(format: "name_ = %@ and owner_ = %@", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
         _columns = FetchRequest<DBCacheTableColumn>(sortDescriptors: [], predicate: NSPredicate.init(format: "tableName_ = %@ and owner_ = %@", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
     }
-    
+
     var sqlText: String { tables.first?.sqltext ?? "" }
-//    var text: Binding<String> = Binding(get: {sqlText}, set: {_ in})
-    
-    var tableHeader: some View {
-        HStack {
-            VStack(alignment: .centreLine, spacing: 3) {
-                FormField(label: "Partitioned?") {
-                    Toggle("", isOn: .constant(tables.first?.isPartitioned ?? false))
-                }
-                FormField(label: "Row Count") {
-                    Text(tables.first?.numRows.formatted() ?? Constants.nullValue)
-                }
-                
+
+    private var tableHeader: some View {
+        Form {
+            LabeledContent("Partitioned") {
+                BoolIndicator(value: tables.first?.isPartitioned ?? false)
             }
-            Spacer()
-            VStack(alignment: .centreLine, spacing: 3) {
-                FormField(label: "Last Analyzed") {
-                    Text(tables.first?.lastAnalyzed?.ISO8601Format() ?? Constants.nullValue)
-                }
-            }
-            Spacer()
+            LabeledContent("Row Count", value: tables.first?.numRows.formatted() ?? Constants.nullValue)
+            LabeledContent("Last Analyzed", value: tables.first?.lastAnalyzed?.formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
         }
-        .padding()
-        .overlay(
-            RoundedRectangle(cornerRadius: 25)
-                .stroke(.quaternary, lineWidth: 2)
-        )
+        .formStyle(.grouped)
     }
-    
-    var viewHeader: some View {
-        HStack {
-            VStack(alignment: .centreLine, spacing: 3) {
-                FormField(label: "Editioning?") {
-                    Toggle("", isOn: .constant(tables.first?.isEditioning ?? false))
-                }
-                FormField(label: "Read Only?") {
-                    Toggle("", isOn: .constant(tables.first?.isReadOnly ?? false))
-                }
-                
+
+    private var viewHeader: some View {
+        Form {
+            LabeledContent("Editioning") {
+                BoolIndicator(value: tables.first?.isEditioning ?? false)
             }
-            Spacer()
+            LabeledContent("Read Only") {
+                BoolIndicator(value: tables.first?.isReadOnly ?? false)
+            }
         }
-        .padding()
-        .overlay(
-            RoundedRectangle(cornerRadius: 25)
-                .stroke(.quaternary, lineWidth: 2)
-        )
+        .formStyle(.grouped)
     }
-    
+
     var body: some View {
         VStack {
             if tables.first?.isView ?? false { viewHeader } else { tableHeader }
-            
+
             TabView(selection: $selectedTab) {
-                DetailGridView(rows: Array(columns).sorted(by: columnSortFn), columnLabels: columnLabels, booleanColumnLabels: booleanColumnLabels, rowSortFn: columnSortFn)
-                    .id(dbObject.id)
-                    .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
-                    .tabItem {
-                        Text("Columns")
-                    }.tag("columns")
-                
-                if !(tables.first?.isView ?? false) {
-                    TableIndexListView(dbObject: dbObject)
+                Tab("Columns", systemImage: "rectangle.split.3x1", value: DBTableDetailTab.columns) {
+                    DetailGridView(rows: Array(columns).sorted(by: columnSortFn), columnLabels: columnLabels, booleanColumnLabels: booleanColumnLabels, rowSortFn: columnSortFn)
+                        .id(dbObject.id)
                         .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
-                        .tabItem {
-                            Text("Indexes")
-                        }.tag("indexes")
-                    
-                    TableTriggerListView(dbObject: dbObject)
-                        .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
-                        .tabItem {
-                            Text("Triggers")
-                        }.tag("triggers")
                 }
-                
-                if tables.first?.isView ?? false {
-                    VStack {
-                        Button {
-                            let formatter = Formatter()
-                            formatter.formattedSource = "...formatting, please wait..."
 
-                            SwiftUIWindow.open {window in
-                                let _ = (window.title = dbObject.name)
-                                FormattedView(formatter: formatter)
-                            }
-                            .closeOnEscape(true)
-
-                            formatter.formatSource(name: dbObject.name, text: tables.first?.sqltext)
-
-                        } label: { Text("Format Source") }
-
-                        //                        CodeEditor(source: .constant(tables.first?.sqltext ?? "N/A"), language: .pgsql, theme: .atelierDuneLight, flags: [.selectable], autoscroll: false, wordWrap: .constant(true))
-                        //                        ScrollView {
-                        //                            Text("\(sqlText)")
-                        //                                .monospaced()
-                        //                                .textSelection(.enabled)
-                        //                                .lineLimit(nil)
-                        //                                .multilineTextAlignment(.leading)
-                        //                                .frame(maxWidth: .infinity)
-                        //                        }
-
-                        //                        CodeEditTextView( Binding<String>(get: { sqlText }, set: {_ in }), language: .sql, theme: sqlTheme, font: sourceFont, tabWidth: tabWidth, lineHeight: lineHeight, wrapLines: true, editorOverscroll: editorOverscroll, cursorPosition: $cursorPosition, isEditable: true)
-                        
-                        ScrollView {
-                            Text(sqlText)
-                                .monospaced()
-                                .textSelection(.enabled)
-                                .lineLimit(nil)
-                                .multilineTextAlignment(.leading)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(8)
-                        }
-
-
+                if !(tables.first?.isView ?? false) {
+                    Tab("Indexes", systemImage: "list.bullet.indent", value: DBTableDetailTab.indexes) {
+                        TableIndexListView(dbObject: dbObject)
+                            .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
                     }
-                    .tabItem {
-                        Text("SQL")
-                    }.tag("sql")
+
+                    Tab("Triggers", systemImage: "bolt", value: DBTableDetailTab.triggers) {
+                        TableTriggerListView(dbObject: dbObject)
+                            .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
+                    }
+                }
+
+                if tables.first?.isView ?? false {
+                    Tab("SQL", systemImage: "doc.text", value: DBTableDetailTab.sql) {
+                        viewSqlTab
+                    }
                 }
             }
         }
         .padding()
+    }
+
+    private var viewSqlTab: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Button("Format Source") {
+                    let formatter = Formatter()
+                    formatter.formattedSource = "...formatting, please wait..."
+
+                    SwiftUIWindow.open { window in
+                        let _ = (window.title = dbObject.name)
+                        FormattedView(formatter: formatter)
+                    }
+                    .closeOnEscape(true)
+
+                    formatter.formatSource(name: dbObject.name, text: tables.first?.sqltext)
+                }
+            }
+
+            ScrollView {
+                Text(sqlText)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .lineLimit(nil)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+            }
+        }
     }
 }
 

--- a/Macintora/DBObjectsBrowser/DBTriggerDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBTriggerDetailView.swift
@@ -13,57 +13,44 @@ struct DBTriggerDetailView: View {
     @Environment(\.managedObjectContext) var context
     @FetchRequest private var tables: FetchedResults<DBCacheTrigger>
     @Binding var dbObject: DBCacheObject
-    
+
     init(dbObject: Binding<DBCacheObject>) {
         self._dbObject = dbObject
         _tables = FetchRequest<DBCacheTrigger>(sortDescriptors: [], predicate: NSPredicate.init(format: "name_ = %@ and owner_ = %@ ", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
     }
-    
-    var tableHeader: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Form {
-                Section("Trigger Details") {
-                    TextField("Type", text: .constant(tables.first?.type ?? ""))
-                    TextField("When", text: .constant(tables.first?.whenClause ?? ""))
-                    TextField("Column", text: .constant(tables.first?.columnName ?? ""))
-                    TextField("Base Type", text: .constant(tables.first?.objectType ?? ""))
-                    TextField("Base Owner", text: .constant(tables.first?.objectOwner ?? ""))
-                    TextField("Base Name", text: .constant(tables.first?.objectName ?? ""))
-                    TextField("Referencing", text: .constant(tables.first?.referencingNames ?? ""))
-                    TextField("Description", text: .constant(tables.first?.descr ?? ""))
-                }
-                        
-                Section("") {
-                    HStack(alignment: .top) {
-                        VStack(alignment: .leading) {
-                            Toggle("Before Row", isOn: .constant(tables.first?.isBeforeRow ?? false))
-                            Toggle("Ater Row", isOn: .constant(tables.first?.isAfterRow ?? false))
-                            Toggle("CrossEdition", isOn: .constant(tables.first?.isCrossEdition ?? false))
-                            Toggle("Fire Once", isOn: .constant(tables.first?.isFireOnce ?? false))
-                        }
-                        VStack(alignment: .leading) {
-                            Toggle("Before Statement", isOn: .constant(tables.first?.isBeforeStatement ?? false))
-                            Toggle("Ater Statement", isOn: .constant(tables.first?.isAfterStatement ?? false))
-                            Toggle("Instead Of", isOn: .constant(tables.first?.isInsteadOfRow ?? false))
-                            Toggle("Enabled", isOn: .constant(tables.first?.isEnabled ?? false))
-                        }
-                    }
-                }
+
+    private var triggerForm: some View {
+        let trigger = tables.first
+        return Form {
+            Section("Trigger Details") {
+                LabeledContent("Type", value: trigger?.type ?? Constants.nullValue)
+                LabeledContent("When", value: trigger?.whenClause ?? Constants.nullValue)
+                LabeledContent("Column", value: trigger?.columnName ?? Constants.nullValue)
+                LabeledContent("Base Type", value: trigger?.objectType ?? Constants.nullValue)
+                LabeledContent("Base Owner", value: trigger?.objectOwner ?? Constants.nullValue)
+                LabeledContent("Base Name", value: trigger?.objectName ?? Constants.nullValue)
+                LabeledContent("Referencing", value: trigger?.referencingNames ?? Constants.nullValue)
+                LabeledContent("Description", value: trigger?.descr ?? Constants.nullValue)
             }
-            .padding()
-            .overlay(
-                RoundedRectangle(cornerRadius: 25)
-                    .stroke(.quaternary, lineWidth: 2)
-            )
+
+            Section("Timing") {
+                LabeledContent("Before Row") { BoolIndicator(value: trigger?.isBeforeRow ?? false) }
+                LabeledContent("After Row") { BoolIndicator(value: trigger?.isAfterRow ?? false) }
+                LabeledContent("Before Statement") { BoolIndicator(value: trigger?.isBeforeStatement ?? false) }
+                LabeledContent("After Statement") { BoolIndicator(value: trigger?.isAfterStatement ?? false) }
+                LabeledContent("Instead Of") { BoolIndicator(value: trigger?.isInsteadOfRow ?? false) }
+                LabeledContent("CrossEdition") { BoolIndicator(value: trigger?.isCrossEdition ?? false) }
+                LabeledContent("Fire Once") { BoolIndicator(value: trigger?.isFireOnce ?? false) }
+                LabeledContent("Enabled") { BoolIndicator(value: trigger?.isEnabled ?? false, trueColor: .green, falseColor: .red) }
+            }
         }
+        .formStyle(.grouped)
     }
-    
+
     var body: some View {
         VStack(alignment: .leading) {
-            tableHeader
-            
+            triggerForm
             SourceView(objName: $dbObject.name, text: Binding<String>(get: {tables.first?.body ?? ""}, set: {_ in}), title: "Body")
-
         }
         .padding()
     }

--- a/Macintora/DBObjectsBrowser/DetailGridView.swift
+++ b/Macintora/DBObjectsBrowser/DetailGridView.swift
@@ -177,7 +177,13 @@ class DetailGridViewCoordinator: NSObject, nonisolated NSTableViewDelegate, noni
                 tabCol.sizeToFit()
                 tabCol.width += 20
                 tabCol.sortDescriptorPrototype = NSSortDescriptor(key: col, ascending: true)
-                tabCol.headerCell.attributedStringValue = NSAttributedString(string: col, attributes: [NSAttributedString.Key.font: NSFont.boldSystemFont(ofSize: 12), NSAttributedString.Key.foregroundColor: NSColor.systemBlue])
+                tabCol.headerCell.attributedStringValue = NSAttributedString(
+                    string: col,
+                    attributes: [
+                        .font: NSFont.preferredFont(forTextStyle: .headline),
+                        .foregroundColor: NSColor.secondaryLabelColor
+                    ]
+                )
                 
                 tableView.addTableColumn(tabCol)
                 tableView.columnWidths.append(tabCol.width)
@@ -223,7 +229,7 @@ class DetailGridViewCoordinator: NSObject, nonisolated NSTableViewDelegate, noni
         text.drawsBackground = false
         text.isBordered = false
         text.translatesAutoresizingMaskIntoConstraints = false
-        text.font = NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)
+        text.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
         text.placeholderString = "this is a text field"
         text.maximumNumberOfLines = 1
         text.preferredMaxLayoutWidth = 400

--- a/Macintora/DBObjectsBrowser/DetailGridView.swift
+++ b/Macintora/DBObjectsBrowser/DetailGridView.swift
@@ -282,7 +282,11 @@ class DetailGridViewCoordinator: NSObject, nonisolated NSTableViewDelegate, noni
     }
     
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-        20.0
+        // Track Dynamic Type rather than the legacy 20-pt hard-coded
+        // value (Item 27): use the user's preferred body font size with
+        // a small leading margin so descenders aren't clipped.
+        let font = NSFont.preferredFont(forTextStyle: .body)
+        return ceil(font.boundingRectForFont.height) + 6
     }
     
     func tableView(_ tableView: NSTableView, sizeToFitWidthOfColumn column: Int) -> CGFloat {

--- a/Macintora/DBObjectsBrowser/FormattedView.swift
+++ b/Macintora/DBObjectsBrowser/FormattedView.swift
@@ -10,20 +10,46 @@ import SwiftUI
 struct FormattedView: View {
     @ObservedObject var formatter: Formatter
     @State private var selection: Range<String.Index> = "".startIndex..<"".endIndex
+    /// Closure invoked by the Done button. The `SwiftUIWindow` host passes
+    /// its close action so the view doesn't need an NSWindow reference.
+    /// Optional so the existing call sites that haven't been migrated
+    /// still compile, but every site in this app now wires it.
+    var onDone: (() -> Void)? = nil
 
     var body: some View {
-        MacintoraEditor(
-            text: $formatter.formattedSource,
-            selection: $selection,
-            language: .sql,
-            isEditable: false,
-            isSelectable: true,
-            wordWrap: .constant(true),
-            showsLineNumbers: true,
-            highlightsSelectedLine: false,
-            accessibilityIdentifier: "editor.db.formatted"
-        )
+        VStack(spacing: 0) {
+            MacintoraEditor(
+                text: $formatter.formattedSource,
+                selection: $selection,
+                language: .sql,
+                isEditable: false,
+                isSelectable: true,
+                wordWrap: .constant(true),
+                showsLineNumbers: true,
+                highlightsSelectedLine: false,
+                accessibilityIdentifier: "editor.db.formatted"
+            )
+            actionBar
+        }
         .frame(minWidth: 400, idealWidth: 1000, maxWidth: .infinity, minHeight: 400, idealHeight: 1000, maxHeight: .infinity)
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 8) {
+            Spacer()
+            Button("Copy SQL") {
+                let pb = NSPasteboard.general
+                pb.clearContents()
+                pb.setString(formatter.formattedSource, forType: .string)
+            }
+            Button("Done") {
+                onDone?()
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(onDone == nil)
+        }
+        .padding(12)
+        .background(.bar)
     }
 }
 

--- a/Macintora/DBObjectsBrowser/PackageProceduresListView.swift
+++ b/Macintora/DBObjectsBrowser/PackageProceduresListView.swift
@@ -79,11 +79,13 @@ struct PackageProceduresListView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        Group {
             if procedures.isEmpty {
-                Text("No procedures or functions cached for this object.")
-                    .foregroundStyle(.secondary)
-                    .padding()
+                ContentUnavailableView(
+                    "No Subprograms Cached",
+                    systemImage: "curlybraces",
+                    description: Text("No procedures or functions cached for this object.")
+                )
             } else {
                 List {
                     ForEach(groups) { group in
@@ -91,7 +93,7 @@ struct PackageProceduresListView: View {
                             if group.parameters.isEmpty {
                                 Text("(no parameters)")
                                     .foregroundStyle(.secondary)
-                                    .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+                                    .font(.system(.body, design: .monospaced))
                             } else {
                                 ForEach(group.parameters) { arg in
                                     ArgumentRow(argument: arg)
@@ -103,14 +105,9 @@ struct PackageProceduresListView: View {
                     }
                 }
                 .listStyle(.inset)
-                .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+                .font(.system(.body, design: .monospaced))
             }
         }
-        .padding()
-        .overlay(
-            RoundedRectangle(cornerRadius: 25)
-                .stroke(.quaternary, lineWidth: 2)
-        )
         .padding([.top, .leading, .trailing])
     }
 }
@@ -158,7 +155,7 @@ private struct ProcedureHeader: View {
             }
             Spacer()
         }
-        .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+        .font(.system(.body, design: .monospaced))
     }
 }
 

--- a/Macintora/DBObjectsBrowser/QuickFilterView.swift
+++ b/Macintora/DBObjectsBrowser/QuickFilterView.swift
@@ -7,57 +7,53 @@
 
 import SwiftUI
 
-struct GridControlGroupStyle: ControlGroupStyle {
-    func makeBody(configuration: Configuration) -> some View {
-//        LazyVGrid(columns: [GridItem(.adaptive(minimum: 100, maximum: .infinity), spacing: 0, alignment: .leading)], alignment: .leading, spacing: 2) {
-        LazyVGrid(columns: [GridItem(.fixed(120)), GridItem(.fixed(110))], alignment: .leading, spacing: 5) {
-            configuration.content
-                .toggleStyle(.switch)
-        }
-    }
-}
-
 struct QuickFilterView: View {
     @Binding var quickFilters: DBCacheSearchCriteria
-    @State private var isQuickFilterViewExpanded = true
 
     var body: some View {
-        Group {
-            VStack {
-                ControlGroup {
-                    Toggle(isOn: $quickFilters.showTables) { Text( "Tables").frame(width: 70, alignment: .leading) }
-                    Toggle(isOn: $quickFilters.showViews) { Text("Views").frame(width: 70, alignment: .leading)}
-                    Toggle(isOn: $quickFilters.showIndexes) { Text("Indexes").frame(width: 70, alignment: .leading)}
-                    Toggle(isOn: $quickFilters.showPackages) { Text("Packages").frame(width: 70, alignment: .leading)}
-                    Toggle(isOn: $quickFilters.showTypes) { Text("Types").frame(width: 70, alignment: .leading)}
-                    Toggle(isOn: $quickFilters.showTriggers) { Text("Triggers").frame(width: 70, alignment: .leading)}
-                    Toggle(isOn: $quickFilters.showProcedures) { Text("Procedures").frame(width: 70, alignment: .leading)}
-                    Toggle(isOn: $quickFilters.showFunctions) { Text("Functions").frame(width: 70, alignment: .leading)}
+        Form {
+            Section("Object Types") {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(minimum: 100), alignment: .leading),
+                        GridItem(.flexible(minimum: 100), alignment: .leading)
+                    ],
+                    alignment: .leading,
+                    spacing: 6
+                ) {
+                    Toggle("Tables", isOn: $quickFilters.showTables)
+                    Toggle("Views", isOn: $quickFilters.showViews)
+                    Toggle("Indexes", isOn: $quickFilters.showIndexes)
+                    Toggle("Packages", isOn: $quickFilters.showPackages)
+                    Toggle("Types", isOn: $quickFilters.showTypes)
+                    Toggle("Triggers", isOn: $quickFilters.showTriggers)
+                    Toggle("Procedures", isOn: $quickFilters.showProcedures)
+                    Toggle("Functions", isOn: $quickFilters.showFunctions)
                 }
-                .controlGroupStyle(GridControlGroupStyle())
-                
+                .toggleStyle(.switch)
+                .controlSize(.small)
+
                 if quickFilters.selectedTypeFilter != nil {
                     Button("Show all types") {
                         quickFilters.selectedTypeFilter = nil
                     }
                     .controlSize(.small)
                 }
-
-                TextField("Schemas, ex. SYSTEM,SYS", text: $quickFilters.ownerString)
-                    .lineLimit(3, reservesSpace: true)
-                    .textFieldStyle(.roundedBorder)
-                    .disableAutocorrection(true)
-
-                TextField("Object Prefix, ex. DBMS,DBA", text: $quickFilters.prefixString)
-                    .lineLimit(3, reservesSpace: true)
-                    .textFieldStyle(.roundedBorder)
-                    .disableAutocorrection(true)
-//                Button("save") {
-//                    quickFilters.changed.toggle()
-//                }
             }
-            .padding(.vertical)
+
+            Section("Schemas") {
+                TextField("ex. SYSTEM, SYS", text: $quickFilters.ownerString)
+                    .textFieldStyle(.roundedBorder)
+                    .disableAutocorrection(true)
+            }
+
+            Section("Object Prefix") {
+                TextField("ex. DBMS, DBA", text: $quickFilters.prefixString)
+                    .textFieldStyle(.roundedBorder)
+                    .disableAutocorrection(true)
+            }
         }
+        .formStyle(.grouped)
     }
 }
 

--- a/Macintora/DBObjectsBrowser/QuickFilterView.swift
+++ b/Macintora/DBObjectsBrowser/QuickFilterView.swift
@@ -10,6 +10,19 @@ import SwiftUI
 struct QuickFilterView: View {
     @Binding var quickFilters: DBCacheSearchCriteria
 
+    /// Sub-binding for a per-type toggle that also clears the transient
+    /// "ignore type filter" override the moment the user adjusts a toggle —
+    /// touching one means they want the toggles to take effect again.
+    private func typeToggle(_ keyPath: WritableKeyPath<DBCacheSearchCriteria, Bool>) -> Binding<Bool> {
+        Binding(
+            get: { quickFilters[keyPath: keyPath] },
+            set: { newValue in
+                quickFilters[keyPath: keyPath] = newValue
+                quickFilters.ignoreTypeFilter = false
+            }
+        )
+    }
+
     var body: some View {
         Form {
             Section("Object Types") {
@@ -21,14 +34,14 @@ struct QuickFilterView: View {
                     alignment: .leading,
                     spacing: 6
                 ) {
-                    Toggle("Tables", isOn: $quickFilters.showTables)
-                    Toggle("Views", isOn: $quickFilters.showViews)
-                    Toggle("Indexes", isOn: $quickFilters.showIndexes)
-                    Toggle("Packages", isOn: $quickFilters.showPackages)
-                    Toggle("Types", isOn: $quickFilters.showTypes)
-                    Toggle("Triggers", isOn: $quickFilters.showTriggers)
-                    Toggle("Procedures", isOn: $quickFilters.showProcedures)
-                    Toggle("Functions", isOn: $quickFilters.showFunctions)
+                    Toggle("Tables", isOn: typeToggle(\.showTables))
+                    Toggle("Views", isOn: typeToggle(\.showViews))
+                    Toggle("Indexes", isOn: typeToggle(\.showIndexes))
+                    Toggle("Packages", isOn: typeToggle(\.showPackages))
+                    Toggle("Types", isOn: typeToggle(\.showTypes))
+                    Toggle("Triggers", isOn: typeToggle(\.showTriggers))
+                    Toggle("Procedures", isOn: typeToggle(\.showProcedures))
+                    Toggle("Functions", isOn: typeToggle(\.showFunctions))
                 }
                 .toggleStyle(.switch)
                 .controlSize(.small)

--- a/Macintora/DBObjectsBrowser/SourceView.swift
+++ b/Macintora/DBObjectsBrowser/SourceView.swift
@@ -32,9 +32,9 @@ struct SourceView: View {
                     let formatter = Formatter()
                     formatter.formattedSource = "...formatting, please wait..."
                     
-                    SwiftUIWindow.open {window in
+                    SwiftUIWindow.open { window in
                         let _ = (window.title = objName)
-                        FormattedView(formatter: formatter)
+                        FormattedView(formatter: formatter, onDone: { window.close() })
                     }
                     .closeOnEscape(true)
 

--- a/Macintora/DBObjectsBrowser/SourceView.swift
+++ b/Macintora/DBObjectsBrowser/SourceView.swift
@@ -43,8 +43,8 @@ struct SourceView: View {
                         formatter.formattedSource = formatted
                     }
                 }
-                label: { Text("Format&View") }
-                
+                label: { Text("Format & View") }
+
                 Button {
                     let formatter = Formatter()
                     formatter.formattedSource = "...formatting, please wait..."
@@ -52,7 +52,7 @@ struct SourceView: View {
                         _ = await formatter.formatSource(name: objName, text: text)
                     }
                 }
-                label: { Text("Format&Save") }
+                label: { Text("Format & Save") }
                     .disabled(true)
             }
 //            ScrollView {

--- a/Macintora/DBObjectsBrowser/TableIndexListView.swift
+++ b/Macintora/DBObjectsBrowser/TableIndexListView.swift
@@ -13,41 +13,36 @@ struct TableIndexListView: View {
     @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
     private var dbObject: DBCacheObject
     @State private var selectedIndexRow: DBCacheIndex.ID?
-    
-    
+
+
     init(dbObject: DBCacheObject) {
         self.dbObject = dbObject
         _indexes = FetchRequest<DBCacheIndex>(sortDescriptors: [NSSortDescriptor(key: "name_", ascending: true)], predicate: NSPredicate.init(format: "tableName_ = %@ and tableOwner_ = %@", dbObject.name, dbObject.owner))
     }
-    
+
     var body: some View {
         Table(indexes, selection: $selectedIndexRow) {
             TableColumn("Index Name", value: \.name )
             TableColumn("Type", value: \.type)
             TableColumn("Index Owner", value: \.owner )
             TableColumn("Valid?") { value in
-                Toggle("", isOn: Binding(get: {value.isValid}, set: {_ in }))
-                    .toggleStyle(.checkbox)
+                BoolIndicator(value: value.isValid, trueColor: .green, falseColor: .red)
             }
             TableColumn("Visible?") { value in
-                Toggle("", isOn: Binding(get: {value.isVisible}, set: {_ in }))
-                    .toggleStyle(.checkbox)
+                BoolIndicator(value: value.isVisible)
             }
             TableColumn("Unique?") { value in
-                Toggle("", isOn: Binding(get: {value.isUnique}, set: {_ in }))
-                    .toggleStyle(.checkbox)
+                BoolIndicator(value: value.isUnique)
             }
             TableColumn("Tablespace", value: \.tablespaceName )
             TableColumn("Last Analyzed") { value in
-                Text(value.lastAnalyzed?.ISO8601Format() ?? "")
+                Text(value.lastAnalyzed?.formatted(date: .abbreviated, time: .shortened) ?? "")
             }
             TableColumn("Degree", value: \.degree )
-            TableColumn("Tablespace", value: \.tablespaceName )
-            
         }
-        .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+        .font(.system(.body, design: .monospaced))
     }
-    
+
 }
 
 //struct TableIndexListView_Previews: PreviewProvider {

--- a/Macintora/DBObjectsBrowser/TableTriggerListView.swift
+++ b/Macintora/DBObjectsBrowser/TableTriggerListView.swift
@@ -13,28 +13,27 @@ struct TableTriggerListView: View {
     @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
     private var dbObject: DBCacheObject
     @State private var selectedIndexRow: DBCacheTrigger.ID?
-    
-    
+
+
     init(dbObject: DBCacheObject) {
         self.dbObject = dbObject
         _triggers = FetchRequest<DBCacheTrigger>(sortDescriptors: [], predicate: NSPredicate.init(format: "objectName = %@ and objectOwner = %@", dbObject.name, dbObject.owner))
     }
-    
+
     var body: some View {
         Table(triggers, selection: $selectedIndexRow) {
             TableColumn("Trigger Name", value: \.name )
             TableColumn("Trigger Owner", value: \.owner )
             TableColumn("Enabled?") { value in
-                Toggle("", isOn: Binding(get: {value.isEnabled}, set: {_ in }))
-                    .toggleStyle(.checkbox)
+                BoolIndicator(value: value.isEnabled, trueColor: .green, falseColor: .red)
             }
             TableColumn("Type", value: \.type )
             TableColumn("Action Type", value: \.actionType )
             TableColumn("Event", value: \.event )
         }
-        .font(Font(NSFont(name: "Source Code Pro", size: NSFont.systemFontSize)!))
+        .font(.system(.body, design: .monospaced))
     }
-    
+
 }
 
 //struct TableIndexListView_Previews: PreviewProvider {
@@ -42,4 +41,3 @@ struct TableTriggerListView: View {
 //        TableIndexListView()
 //    }
 //}
-

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -260,6 +260,7 @@ struct MacOraApp: App {
             ToolbarCommands()
             MainDocumentMenuCommands()
             EditorMenuCommands()
+            DBBrowserMenuCommands()
             HelpMenuCommands()
             CommandGroup(after: .newItem) {
                 Button("New Tab") {
@@ -449,6 +450,64 @@ struct MainDocumentMenuCommands: Commands {
             }
             .disabled(worksheetCommandsBox == nil)
             .keyboardShortcut("f", modifiers: [.command, .control])
+        }
+    }
+}
+
+/// Menu peers for every DB Browser toolbar action. HIG: "Make every toolbar
+/// item available as a command in the menu bar." Disabled state mirrors the
+/// browser's `isReloading` so refresh items can't fire while a refresh is
+/// in flight.
+struct DBBrowserMenuCommands: Commands {
+    @FocusedValue(\.dbBrowserCommandsBox) var box
+    @FocusedValue(\.dbBrowserIsReloading) var isReloading
+
+    private var isAvailable: Bool { box != nil }
+    private var canRefresh: Bool { isAvailable && (isReloading != true) }
+
+    var body: some Commands {
+        CommandMenu("DB Browser") {
+            Button("Incremental Refresh") { box?.incrementalRefresh?() }
+                .disabled(!canRefresh)
+                .keyboardShortcut("r", modifiers: [.command])
+
+            Button("Full Refresh") { box?.fullRefresh?() }
+                .disabled(!canRefresh)
+                .keyboardShortcut("r", modifiers: [.command, .shift])
+
+            Button("Full Refresh & Compact") { box?.fullRefreshAndCompact?() }
+                .disabled(!canRefresh)
+
+            Button("Compact Cache") { box?.compactOnly?() }
+                .disabled(!canRefresh)
+                .keyboardShortcut("r", modifiers: [.command, .option])
+
+            Divider()
+
+            Button("Focus Search") { box?.focusSearch?() }
+                .disabled(!isAvailable)
+                .keyboardShortcut("f", modifiers: [.command])
+
+            Button("Clear Search") { box?.clearSearch?() }
+                .disabled(!isAvailable)
+
+            Divider()
+
+            Button("Main Tab") { box?.selectMainTab?() }
+                .disabled(!isAvailable)
+                .keyboardShortcut("1", modifiers: [.command])
+
+            Button("Details Tab") { box?.selectDetailsTab?() }
+                .disabled(!isAvailable)
+                .keyboardShortcut("2", modifiers: [.command])
+
+            Divider()
+
+            Button("Show Counts") { box?.showCounts?() }
+                .disabled(!isAvailable)
+
+            Button("Clear Cache") { box?.clear?() }
+                .disabled(!canRefresh)
         }
     }
 }

--- a/Macintora/MainApp/MainDocumentView.swift
+++ b/Macintora/MainApp/MainDocumentView.swift
@@ -228,11 +228,11 @@ struct MainDocumentView: View {
                     focusedView = .codeEditor
                 } label: {
                     if document.isConnected == .connected {
-                        Image(systemName: "wifi").foregroundColor(Color.green)
+                        Image(systemName: "wifi").foregroundStyle(Color.green)
                     } else if document.isConnected == .disconnected {
-                        Image(systemName: "wifi.slash").foregroundColor(Color.red)
+                        Image(systemName: "wifi.slash").foregroundStyle(Color.red)
                     } else {
-                        Image(systemName: "wifi").foregroundColor(Color.orange)
+                        Image(systemName: "wifi").foregroundStyle(Color.orange)
                     }
                 }
                 .disabled(document.isConnected == .changing)
@@ -263,9 +263,9 @@ struct MainDocumentView: View {
                     focusedView = .codeEditor
                 } label: {
                     if document.resultsController?.isExecuting ?? false {
-                        Image(systemName: "stop").foregroundColor(Color.red)
+                        Image(systemName: "stop").foregroundStyle(Color.red)
                     } else if document.isConnected == .connected && document.resultsController?.isExecuting == false {
-                        Image(systemName: "play").foregroundColor(Color.green)
+                        Image(systemName: "play").foregroundStyle(Color.green)
                     } else {
                         Image(systemName: "play")
                     }
@@ -372,13 +372,13 @@ struct MainDocumentView: View {
                 } label: {
                     switch document.connectionHealth {
                         case .notConnected:
-                            Image(systemName: "hand.thumbsup").foregroundColor(Color.gray)
+                            Image(systemName: "hand.thumbsup").foregroundStyle(Color.gray)
                         case .ok:
-                            Image(systemName: "hand.thumbsup").foregroundColor(Color.green)
+                            Image(systemName: "hand.thumbsup").foregroundStyle(Color.green)
                         case .lost:
-                            Image(systemName: "hand.thumbsdown.fill").foregroundColor(Color.red)
+                            Image(systemName: "hand.thumbsdown.fill").foregroundStyle(Color.red)
                         case .busy:
-                            Image(systemName: "hand.thumbsup.fill").foregroundColor(Color.orange)
+                            Image(systemName: "hand.thumbsup.fill").foregroundStyle(Color.orange)
                     }
                 }
                 .help("Ping")

--- a/Macintora/MainApp/SettingsView.swift
+++ b/Macintora/MainApp/SettingsView.swift
@@ -127,7 +127,6 @@ struct DBBrowserSettings: View {
     @AppStorage("cacheUpdatePrefetchSize") private var cacheUpdatePrefetchSize: Int = 10000
     @AppStorage("cacheUpdateBatchSize") private var cacheUpdateBatchSize: Int = 200
     @AppStorage("cacheUpdateSessionLimit") private var cacheUpdateSessionLimit: Int = 5
-    @AppStorage("searchLimit") private var searchLimit: Int = 20
 
     var body: some View {
         VStack {
@@ -141,10 +140,6 @@ struct DBBrowserSettings: View {
                     .textFieldStyle(.roundedBorder)
 
                 TextField("Cache Update Max Sessions", value: $cacheUpdateSessionLimit, format: .number)
-                    .disableAutocorrection(true)
-                    .textFieldStyle(.roundedBorder)
-
-                TextField("Search Limit", value: $searchLimit, format: .number)
                     .disableAutocorrection(true)
                     .textFieldStyle(.roundedBorder)
 

--- a/Macintora/Results/ResultViewWrapper.swift
+++ b/Macintora/Results/ResultViewWrapper.swift
@@ -104,13 +104,13 @@ struct ResultViewWrapper: View {
                 Button {
                     self.queryResults.refreshData()
                 } label: {
-                    Image(systemName: "arrow.clockwise").foregroundColor(Color.blue)
+                    Image(systemName: "arrow.clockwise").foregroundStyle(Color.blue)
                 }
                 .help("Refresh")
                 
                 Button {
                     sqlShown.toggle()
-                } label: { Text("SQL").foregroundColor(Color.blue)}
+                } label: { Text("SQL").foregroundStyle(Color.blue)}
                     .help("show SQL")
                     .sheet(isPresented: $sqlShown) {
                         VStack {
@@ -147,7 +147,7 @@ struct ResultViewWrapper: View {
                 Button {
                     self.queryResults.getSQLCount()
                 } label: {
-                    Image(systemName: "sum") //.foregroundColor(Color.blue)
+                    Image(systemName: "sum") //.foregroundStyle(Color.blue)
                 }
                 .help("Count")
                 
@@ -182,7 +182,7 @@ struct ResultViewWrapper: View {
             serverTimeToolbar
             
             Toggle(isOn: $queryResults.showingLog) {
-                Image(systemName: "list.dash") //.foregroundColor(Color.blue)
+                Image(systemName: "list.dash") //.foregroundStyle(Color.blue)
             }
             .toggleStyle(.button)
             .padding(.horizontal)

--- a/Macintora/SessionBrowser/SBMainView.swift
+++ b/Macintora/SessionBrowser/SBMainView.swift
@@ -36,24 +36,24 @@ struct SBMainView: View {
                             Button {
                                 vm.populateData()
                             } label: {
-                                Label("Refresh", systemImage: "arrow.triangle.2.circlepath").foregroundColor(.blue)
+                                Label("Refresh", systemImage: "arrow.triangle.2.circlepath").foregroundStyle(.blue)
                             }
                                 .keyboardShortcut("r", modifiers: .command)
                                 .help("Refresh")
                             
                             Toggle(isOn: $vm.activeOnly) { Label("Active Only", systemImage: vm.activeOnly ? "externaldrive.fill.badge.wifi" : "externaldrive.badge.wifi") }
                                 .toggleStyle(.automatic)
-                                .foregroundColor(vm.activeOnly ? .green : nil)
+                                .foregroundStyle(vm.activeOnly ? AnyShapeStyle(Color.green) : AnyShapeStyle(.primary))
                                 .help("Active Only")
                             
                             Toggle(isOn: $vm.userOnly) { Label("User Only", systemImage: vm.userOnly ? "person.fill" : "person") }
                                 .toggleStyle(.automatic)
-                                .foregroundColor(vm.userOnly ? .green : nil)
+                                .foregroundStyle(vm.userOnly ? AnyShapeStyle(Color.green) : AnyShapeStyle(.primary))
                                 .help("User Only")
                             
                             Toggle(isOn: $vm.localInstanceOnly) { Label("Local Instance Only", systemImage: "server.rack") }
                                 .toggleStyle(.automatic)
-                                .foregroundColor(vm.localInstanceOnly ? .green : nil)
+                                .foregroundStyle(vm.localInstanceOnly ? AnyShapeStyle(Color.green) : AnyShapeStyle(.primary))
                                 .help("Local Instance Only")
                         }
                     }

--- a/MacintoraTests/DBBrowser/DBBrowserCommandsBoxTests.swift
+++ b/MacintoraTests/DBBrowser/DBBrowserCommandsBoxTests.swift
@@ -1,0 +1,101 @@
+//
+//  DBBrowserCommandsBoxTests.swift
+//  MacintoraTests
+//
+//  Mirrors `WorksheetCommandsBoxTests` for the DB Browser bridge box that
+//  lets the "DB Browser" `CommandMenu` reach the focused browser window
+//  (issue #25, Item 3). The contract is the same: each trigger is an
+//  optional closure; setting it then calling it invokes the closure once;
+//  reassigning replaces the previous closure (document re-mount); clearing
+//  disables invocation.
+//
+
+import XCTest
+@testable import Macintora
+
+@MainActor
+final class DBBrowserCommandsBoxTests: XCTestCase {
+
+    func test_freshBox_allTriggersAreNil() {
+        let box = DBBrowserCommandsBox()
+        XCTAssertNil(box.incrementalRefresh)
+        XCTAssertNil(box.fullRefresh)
+        XCTAssertNil(box.fullRefreshAndCompact)
+        XCTAssertNil(box.compactOnly)
+        XCTAssertNil(box.clear)
+        XCTAssertNil(box.showCounts)
+        XCTAssertNil(box.focusSearch)
+        XCTAssertNil(box.clearSearch)
+        XCTAssertNil(box.selectMainTab)
+        XCTAssertNil(box.selectDetailsTab)
+        XCTAssertNil(box.editSource)
+        XCTAssertNil(box.refreshObject)
+    }
+
+    func test_eachTrigger_invokesClosure() {
+        let box = DBBrowserCommandsBox()
+        var calls: [String] = []
+        box.incrementalRefresh = { calls.append("incrementalRefresh") }
+        box.fullRefresh = { calls.append("fullRefresh") }
+        box.fullRefreshAndCompact = { calls.append("fullRefreshAndCompact") }
+        box.compactOnly = { calls.append("compactOnly") }
+        box.clear = { calls.append("clear") }
+        box.showCounts = { calls.append("showCounts") }
+        box.focusSearch = { calls.append("focusSearch") }
+        box.clearSearch = { calls.append("clearSearch") }
+        box.selectMainTab = { calls.append("selectMainTab") }
+        box.selectDetailsTab = { calls.append("selectDetailsTab") }
+        box.editSource = { calls.append("editSource") }
+        box.refreshObject = { calls.append("refreshObject") }
+
+        box.incrementalRefresh?()
+        box.fullRefresh?()
+        box.fullRefreshAndCompact?()
+        box.compactOnly?()
+        box.clear?()
+        box.showCounts?()
+        box.focusSearch?()
+        box.clearSearch?()
+        box.selectMainTab?()
+        box.selectDetailsTab?()
+        box.editSource?()
+        box.refreshObject?()
+
+        XCTAssertEqual(calls, [
+            "incrementalRefresh",
+            "fullRefresh",
+            "fullRefreshAndCompact",
+            "compactOnly",
+            "clear",
+            "showCounts",
+            "focusSearch",
+            "clearSearch",
+            "selectMainTab",
+            "selectDetailsTab",
+            "editSource",
+            "refreshObject",
+        ])
+    }
+
+    func test_overwriteTrigger_replacesPreviousClosure() {
+        // Document re-mount must drop the previous closure so a stale,
+        // dismantled VM isn't called into.
+        let box = DBBrowserCommandsBox()
+        var firstCalls = 0
+        var secondCalls = 0
+        box.incrementalRefresh = { firstCalls += 1 }
+        box.incrementalRefresh = { secondCalls += 1 }
+        box.incrementalRefresh?()
+        XCTAssertEqual(firstCalls, 0)
+        XCTAssertEqual(secondCalls, 1)
+    }
+
+    func test_clearTrigger_disablesInvocation() {
+        let box = DBBrowserCommandsBox()
+        var calls = 0
+        box.fullRefresh = { calls += 1 }
+        box.fullRefresh = nil
+        box.fullRefresh?()
+        XCTAssertEqual(calls, 0)
+    }
+}

--- a/MacintoraTests/DBBrowser/DBCacheObjectFetchRequestTests.swift
+++ b/MacintoraTests/DBBrowser/DBCacheObjectFetchRequestTests.swift
@@ -1,0 +1,43 @@
+//
+//  DBCacheObjectFetchRequestTests.swift
+//  MacintoraTests
+//
+//  Locks in the "no more 20-row cap" behaviour (issue #25, Item 2):
+//  `DBCacheObject.fetchRequest(limit:predicate:)` treats `limit == 0`
+//  (the default) as "no cap" and only sets `fetchLimit` when a positive
+//  value is passed. Also pins the sort order the list pane relies on.
+//
+
+import XCTest
+import CoreData
+@testable import Macintora
+
+final class DBCacheObjectFetchRequestTests: XCTestCase {
+
+    func test_defaultLimit_meansNoFetchLimit() {
+        let request = DBCacheObject.fetchRequest(predicate: nil)
+        XCTAssertEqual(request.fetchLimit, 0, "no limit argument must leave fetchLimit unset (0 == unlimited)")
+    }
+
+    func test_zeroLimit_meansNoFetchLimit() {
+        let request = DBCacheObject.fetchRequest(limit: 0, predicate: nil)
+        XCTAssertEqual(request.fetchLimit, 0)
+    }
+
+    func test_positiveLimit_isApplied() {
+        let request = DBCacheObject.fetchRequest(limit: 250, predicate: nil)
+        XCTAssertEqual(request.fetchLimit, 250)
+    }
+
+    func test_predicateIsForwarded() {
+        let predicate = NSPredicate(format: "type_ = %@", "TABLE")
+        let request = DBCacheObject.fetchRequest(predicate: predicate)
+        XCTAssertEqual(request.predicate, predicate)
+    }
+
+    func test_sortDescriptors_areOwnerThenTypeThenName() {
+        let request = DBCacheObject.fetchRequest(predicate: nil)
+        XCTAssertEqual(request.sortDescriptors?.map(\.key), ["owner_", "type_", "name_"])
+        XCTAssertEqual(request.sortDescriptors?.allSatisfy(\.ascending), true)
+    }
+}

--- a/MacintoraTests/DBBrowser/DBCacheSearchCriteriaTests.swift
+++ b/MacintoraTests/DBBrowser/DBCacheSearchCriteriaTests.swift
@@ -1,0 +1,163 @@
+//
+//  DBCacheSearchCriteriaTests.swift
+//  MacintoraTests
+//
+//  Covers the DB Browser filter state (issue #25, Items 1, 16, 17):
+//  - mutating a type toggle / owner / prefix / search text changes the
+//    derived `predicate` (and therefore `Equatable`), which is what makes
+//    `onChange(of: cache.searchCriteria)` re-run the live fetch — the root
+//    cause of the "toggles don't refresh" bug.
+//  - `selectedTypeFilter` overrides the per-type toggles.
+//  - `persist()` round-trips the toggles and the per-TNS owner/prefix
+//    strings through `UserDefaults`, and `init(for:)` reads them back.
+//
+//  The persistence tests touch `UserDefaults.standard` (the type uses it
+//  directly), so setUp snapshots the relevant keys and tearDown restores
+//  them — and a throwaway TNS name keeps the per-TNS dictionaries clean.
+//
+
+import XCTest
+@testable import Macintora
+
+final class DBCacheSearchCriteriaTests: XCTestCase {
+
+    private static let testTNS = "__macintora_unit_test_tns__"
+    private static let boolKeys = [
+        "showTables", "showViews", "showIndexes", "showPackages",
+        "showTypes", "showTriggers", "showProcedures", "showFunctions",
+    ]
+    private static let dictKeys = ["ownerList", "prefixList"]
+
+    private var savedDefaults: [String: Any?] = [:]
+
+    override func setUp() {
+        super.setUp()
+        let d = UserDefaults.standard
+        for key in Self.boolKeys + Self.dictKeys {
+            savedDefaults[key] = d.object(forKey: key)
+        }
+    }
+
+    override func tearDown() {
+        let d = UserDefaults.standard
+        for (key, value) in savedDefaults {
+            if let value { d.set(value, forKey: key) } else { d.removeObject(forKey: key) }
+        }
+        savedDefaults = [:]
+        super.tearDown()
+    }
+
+    // MARK: - Predicate reflects toggles
+
+    func test_defaultCriteria_predicateIncludesEveryType() {
+        let format = DBCacheSearchCriteria(for: Self.testTNS).predicate.predicateFormat
+        for type in ["TABLE", "VIEW", "INDEX", "PACKAGE", "TYPE", "TRIGGER", "PROCEDURE", "FUNCTION"] {
+            XCTAssertTrue(format.contains(type), "default predicate should include \(type); format = \(format)")
+        }
+    }
+
+    func test_disablingTables_changesPredicateAndEquality() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        let before = criteria
+        criteria.showTables = false
+
+        XCTAssertNotEqual(before, criteria, "flipping a type toggle must change the predicate so the list refreshes")
+        XCTAssertFalse(criteria.predicate.predicateFormat.contains("TABLE"),
+                       "TABLE should be gone once showTables is false; format = \(criteria.predicate.predicateFormat)")
+    }
+
+    func test_clearingAllTypeToggles_predicateHasNoTypeClause() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        criteria.showTables = false
+        criteria.showViews = false
+        criteria.showIndexes = false
+        criteria.showPackages = false
+        criteria.showTypes = false
+        criteria.showTriggers = false
+        criteria.showProcedures = false
+        criteria.showFunctions = false
+
+        XCTAssertFalse(criteria.predicate.predicateFormat.contains("type_"),
+                       "no type clause expected when every toggle is off; format = \(criteria.predicate.predicateFormat)")
+    }
+
+    func test_selectedTypeFilter_overridesToggles() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        criteria.showViews = false                 // would normally drop VIEW
+        criteria.selectedTypeFilter = "VIEW"
+
+        let format = criteria.predicate.predicateFormat
+        XCTAssertTrue(format.contains("type_ ==") && format.contains("VIEW"),
+                      "forced filter should pin to VIEW; format = \(format)")
+        XCTAssertFalse(format.contains("TABLE"),
+                       "forced filter should not also include the toggle types; format = \(format)")
+    }
+
+    func test_searchText_addsContainsClause() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        let before = criteria
+        criteria.searchText = "EMP"
+
+        XCTAssertNotEqual(before, criteria)
+        XCTAssertTrue(criteria.predicate.predicateFormat.contains("name_ CONTAINS[c] \"EMP\""),
+                      "format = \(criteria.predicate.predicateFormat)")
+    }
+
+    func test_ownerString_addsOwnerInClause_uppercasedAndSplit() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        criteria.ownerString = "hr, scott"
+
+        XCTAssertEqual(criteria.ownerInclusionList, ["HR", "SCOTT"])
+        let format = criteria.predicate.predicateFormat
+        XCTAssertTrue(format.contains("owner_ IN") && format.contains("HR") && format.contains("SCOTT"),
+                      "format = \(format)")
+    }
+
+    func test_prefixString_addsBeginsWithClause() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        criteria.prefixString = "dbms, dba"
+
+        XCTAssertEqual(criteria.namePrefixInclusionList, ["DBMS", "DBA"])
+        let format = criteria.predicate.predicateFormat
+        XCTAssertTrue(format.contains("name_ BEGINSWITH[c] \"DBMS\""), "format = \(format)")
+        XCTAssertTrue(format.contains("name_ BEGINSWITH[c] \"DBA\""), "format = \(format)")
+    }
+
+    func test_equality_comparesOnPredicateOnly() {
+        let a = DBCacheSearchCriteria(for: "alpha")
+        let b = DBCacheSearchCriteria(for: "beta")
+        // Different TNS, identical filter state -> same predicate -> equal.
+        XCTAssertEqual(a, b)
+    }
+
+    // MARK: - Persistence round-trip
+
+    func test_persist_roundTripsTogglesAndPerTNSStrings() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        criteria.showTriggers = false
+        criteria.showFunctions = false
+        criteria.ownerString = "HR"
+        criteria.prefixString = "DBMS"
+        criteria.persist()
+
+        let reloaded = DBCacheSearchCriteria(for: Self.testTNS)
+        XCTAssertFalse(reloaded.showTriggers)
+        XCTAssertFalse(reloaded.showFunctions)
+        XCTAssertTrue(reloaded.showTables, "untouched toggles should survive the round-trip")
+        XCTAssertEqual(reloaded.ownerString, "HR")
+        XCTAssertEqual(reloaded.prefixString, "DBMS")
+    }
+
+    func test_perTNSStrings_areKeyedByTNS() {
+        var alpha = DBCacheSearchCriteria(for: "\(Self.testTNS).alpha")
+        alpha.ownerString = "AONLY"
+        alpha.persist()
+
+        var beta = DBCacheSearchCriteria(for: "\(Self.testTNS).beta")
+        beta.ownerString = "BONLY"
+        beta.persist()
+
+        XCTAssertEqual(DBCacheSearchCriteria(for: "\(Self.testTNS).alpha").ownerString, "AONLY")
+        XCTAssertEqual(DBCacheSearchCriteria(for: "\(Self.testTNS).beta").ownerString, "BONLY")
+    }
+}

--- a/MacintoraTests/DBBrowser/DBCacheSearchCriteriaTests.swift
+++ b/MacintoraTests/DBBrowser/DBCacheSearchCriteriaTests.swift
@@ -36,6 +36,10 @@ final class DBCacheSearchCriteriaTests: XCTestCase {
         for key in Self.boolKeys + Self.dictKeys {
             savedDefaults[key] = d.object(forKey: key)
         }
+        // The type toggles are stored globally (not per-TNS), so a developer's
+        // own saved prefs would otherwise leak in. Force a known all-on
+        // baseline; tearDown restores whatever was there before.
+        for key in Self.boolKeys { d.set(true, forKey: key) }
     }
 
     override func tearDown() {
@@ -79,6 +83,29 @@ final class DBCacheSearchCriteriaTests: XCTestCase {
 
         XCTAssertFalse(criteria.predicate.predicateFormat.contains("type_"),
                        "no type clause expected when every toggle is off; format = \(criteria.predicate.predicateFormat)")
+    }
+
+    func test_ignoreTypeFilter_dropsTypeClauseEntirely_butKeepsOtherClauses() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        criteria.searchText = "RAISE_SALARY"
+        criteria.ownerString = "HR"
+        let before = criteria
+        criteria.ignoreTypeFilter = true
+
+        XCTAssertNotEqual(before, criteria, "toggling ignoreTypeFilter must change the predicate")
+        let format = criteria.predicate.predicateFormat
+        XCTAssertFalse(format.contains("type_"), "no type clause expected; format = \(format)")
+        XCTAssertTrue(format.contains("name_ CONTAINS[c] \"RAISE_SALARY\""), "format = \(format)")
+        XCTAssertTrue(format.contains("owner_ IN") && format.contains("HR"), "format = \(format)")
+    }
+
+    func test_selectedTypeFilter_winsOverIgnoreTypeFilter() {
+        var criteria = DBCacheSearchCriteria(for: Self.testTNS)
+        criteria.ignoreTypeFilter = true
+        criteria.selectedTypeFilter = "PROCEDURE"
+
+        let format = criteria.predicate.predicateFormat
+        XCTAssertTrue(format.contains("type_ ==") && format.contains("PROCEDURE"), "format = \(format)")
     }
 
     func test_selectedTypeFilter_overridesToggles() {

--- a/MacintoraTests/DBBrowser/DBCacheVMInitTests.swift
+++ b/MacintoraTests/DBBrowser/DBCacheVMInitTests.swift
@@ -45,6 +45,24 @@ final class DBCacheVMInitTests: XCTestCase {
         XCTAssertEqual(vm.pendingSelectionName, "EMPLOYEES")
     }
 
+    func test_selectedObjectNameWithoutType_ignoresTypeFilter() {
+        // A bare `owner.name` reference: the per-type toggles must not be
+        // allowed to hide the requested object.
+        let vm = DBCacheVM(connDetails: connDetails,
+                          persistenceController: persistence,
+                          selectedOwner: "HR",
+                          selectedObjectName: "RAISE_SALARY") // a procedure, say
+        XCTAssertTrue(vm.searchCriteria.ignoreTypeFilter)
+        XCTAssertNil(vm.searchCriteria.selectedTypeFilter)
+        XCTAssertFalse(vm.searchCriteria.predicate.predicateFormat.contains("type_"),
+                       "predicate must not constrain by type; format = \(vm.searchCriteria.predicate.predicateFormat)")
+    }
+
+    func test_defaultInit_doesNotIgnoreTypeFilter() {
+        let vm = DBCacheVM(connDetails: connDetails, persistenceController: persistence)
+        XCTAssertFalse(vm.searchCriteria.ignoreTypeFilter)
+    }
+
     func test_selectedOwner_seedsOwnerStringAndPending() {
         let vm = DBCacheVM(connDetails: connDetails,
                           persistenceController: persistence,
@@ -59,6 +77,8 @@ final class DBCacheVMInitTests: XCTestCase {
                           selectedObjectType: "TABLE")
         XCTAssertEqual(vm.searchCriteria.selectedTypeFilter, "TABLE")
         XCTAssertEqual(vm.pendingSelectionType, "TABLE")
+        // A known type pins via selectedTypeFilter, so the broad bypass stays off.
+        XCTAssertFalse(vm.searchCriteria.ignoreTypeFilter)
     }
 
     func test_initialDetailTab_isStoredAndNotClearedByInit() {

--- a/MacintoraUITests/DBBrowserMenuUITests.swift
+++ b/MacintoraUITests/DBBrowserMenuUITests.swift
@@ -1,0 +1,107 @@
+//
+//  DBBrowserMenuUITests.swift
+//  MacintoraUITests
+//
+//  Verifies the "DB Browser" menu (issue #25, Item 3): the `CommandMenu`
+//  wired by `DBBrowserMenuCommands` is present in the menu bar with every
+//  expected item, and — because no DB Browser window is keyed when only a
+//  worksheet document is open — every item is disabled (the menu gates on
+//  `@FocusedValue(\.dbBrowserCommandsBox)`). That gating is what keeps ⌘R
+//  meaning "Run" while an editor is keyed; the dispatch side of that is
+//  covered by `EditorShortcutsUITests.test_cmd_R_fires_run`.
+//
+//  Skips when the local fixture document is missing — same convention as
+//  the other UI suites so this stays runnable on machines without fixtures.
+//
+
+import XCTest
+
+final class DBBrowserMenuUITests: XCTestCase {
+
+    private static let fixtureURL = URL(fileURLWithPath:
+        "/Users/ilia/Documents/macintora/local.macintora")
+
+    /// Items the `DB Browser` menu must expose, in declaration order.
+    private static let expectedItems = [
+        "Incremental Refresh",
+        "Full Refresh",
+        "Full Refresh & Compact",
+        "Compact Cache",
+        "Focus Search",
+        "Clear Search",
+        "Main Tab",
+        "Details Tab",
+        "Show Counts",
+        "Clear Cache",
+    ]
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        let path = Self.fixtureURL.path
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: path),
+            "Fixture document \(path) does not exist — required for UI tests."
+        )
+    }
+
+    @MainActor
+    private func launchAppWithFixture() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [Self.fixtureURL.path]
+        app.launchEnvironment["OS_ACTIVITY_MODE"] = "disable"
+        app.launch()
+        return app
+    }
+
+    @MainActor
+    func test_dbBrowserMenu_existsWithAllItems_andIsDisabledWithoutABrowserWindow() throws {
+        let app = launchAppWithFixture()
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10), "document window did not appear")
+
+        let menuBar = app.menuBars.firstMatch
+        let dbBrowserMenu = menuBar.menuBarItems["DB Browser"]
+        XCTAssertTrue(
+            dbBrowserMenu.waitForExistence(timeout: 5),
+            "the 'DB Browser' CommandMenu is missing from the menu bar"
+        )
+
+        dbBrowserMenu.click()
+
+        for title in Self.expectedItems {
+            let item = menuBar.menuItems[title]
+            XCTAssertTrue(item.waitForExistence(timeout: 3), "menu item '\(title)' is missing from the DB Browser menu")
+            XCTAssertFalse(
+                item.isEnabled,
+                "menu item '\(title)' should be disabled when no DB Browser window is keyed — it gates on @FocusedValue(\\.dbBrowserCommandsBox)"
+            )
+        }
+
+        // Close the menu so the app is left in a clean state.
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    @MainActor
+    func test_dbBrowserMenu_doesNotStealRunFromEditor() throws {
+        // Sanity peer to the above: with only a worksheet open, the editor's
+        // ⌘R "Run" item must be enabled (the DB Browser "Incremental Refresh"
+        // ⌘R peer is disabled, so AppKit routes ⌘R to Run). This catches a
+        // regression where the DB Browser menu would shadow the editor's.
+        let app = launchAppWithFixture()
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10), "document window did not appear")
+
+        let textView = window.textViews.firstMatch
+        XCTAssertTrue(textView.waitForExistence(timeout: 5), "editor text view not found")
+        textView.click()
+
+        let menuBar = app.menuBars.firstMatch
+        let dbIncremental = menuBar.menuItems["Incremental Refresh"]
+        // (No need to open a menu first — menuItems are queryable regardless.)
+        if dbIncremental.exists {
+            XCTAssertFalse(dbIncremental.isEnabled, "DB Browser ⌘R peer must stay disabled while an editor is keyed")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Addresses every acceptance-criteria bullet from issue #25 plus essentially every actionable item in the audit. Items below refer to the numbered audit list in #25.

Closes #25, closes #30, closes #34.

**Critical bugs**
- **Item 1 — Quick-filter toggles don't refresh reliably**: `DBCacheSearchCriteria` now uses plain stored properties; UserDefaults is read once in `init(for:)` and rewritten via a `persist()` call from `onChange(of: cache.searchCriteria)`. Toggles route through `@Published` and update the list immediately in the same window.
- **Item 2 — 20-row cap**: `DBCacheObject.fetchRequest(limit:predicate:)` treats `limit == 0` as no cap, and the live `SectionedFetchRequest` no longer passes a limit. Core Data faulting + `List`'s lazy materialisation handles tens of thousands of rows.
- **Item 3 — Keyboard shortcuts**: New `DBBrowserCommandsBox` + `DBBrowserMenuCommands` `CommandMenu` ("DB Browser" in the menu bar). Bindings: ⌘R Incremental Refresh, ⇧⌘R Full Refresh, ⌥⌘R Compact, ⌘F Focus Search, ⌘1 Main tab, ⌘2 Details tab. Every toolbar item has a menu-bar peer.
- **Items 4 & 29 — Refresh progress**: Custom rotation animations (incl. the red toolbar status) removed. Replaced with system `ProgressView().controlSize(.small)` that only renders while `isReloading` is true.

**HIG / structural**
- **Items 5 & 20**: Filter panel lives in a trailing `.inspector` (toggleable from the toolbar). DB name + version + last-updated moved to `.navigationTitle` + `.navigationSubtitle`.
- **Item 6**: Removed redundant `NavigationLink(value:)` inside `List(selection:)`. `SidebarListStyle()` → `.listStyle(.sidebar)`.
- **Items 7 & 8**: `DBDetailObjectMainView`, `DBTableDetailView`, `DBTriggerDetailView`, `DBIndexDetailView` rewritten as `Form { LabeledContent(...) }.formStyle(.grouped)`. New `BoolIndicator` presenter replaces every `Toggle(isOn: .constant(...))`. All hand-rolled `RoundedRectangle(cornerRadius: 25)` strokes gone.
- **Items 9 & 10**: Sidebar icons no longer pinned to `.blue`; invalid objects show a red `!` badge. Header "Edit Source" / "Refresh" buttons get visible titles, drop the blue tint, and use inline `ProgressView` for activity.

**Polish**
- **Item 11**: Every `TabView` migrated to the new `Tab(_:systemImage:value:_:)` API with proper enum tags (`DBDetailTab`, `DBTableDetailTab`, `DBSourceTab`, `DBIndexTab`).
- **Item 12**: All force-unwrapped `NSFont(name: "Source Code Pro", …)!` lookups in the DB-browser scope replaced with `.font(.system(.body, design: .monospaced))`. `DetailGridView`'s NSFont uses `NSFont.monospacedSystemFont(...)`; header column styling switched from `systemBlue` to `secondaryLabelColor`.
- **Item 13**: Cache Counts sheet is a properly-sized panel with a default-action **Done** button.
- **Items 14 & 15**: Refresh menu titles are stable; the menu is `.disabled(cache.isReloading)` while a refresh runs. Vacuum jargon renamed to "Full Refresh & Compact" / "Compact Cache".
- **Items 16 & 17**: `QuickFilterView` uses a `LazyVGrid` with `.flexible` columns and a single-line schema/prefix text field — no more fixed widths or 3-line bezels.
- **Item 18 — Debounced search**: A local `pendingSearchText` mirrors the search field; a `.task(id: pendingSearchText)` waits 200ms (cancelled on every keystroke) before committing into `cache.searchCriteria.searchText`. Predicate recomputes once per pause.
- **Item 19**: `ContentUnavailableView` for the empty selection state and the "no procedures cached" placeholder.
- **Item 21**: Stray `print()` removed from `DBSourceDetailView.init`.
- **Items 22 & 23**: "Format&View" → "Format & View"; "Ater Row/Statement" → "After Row/Statement".
- **Item 24 — Row context menu**: Copy Name, Copy Owner.Name, Reveal in Sidebar, Open in New Window (focuses an existing DB Browser if one is open for the same TNS), Open Source in Editor.
- **Item 25 — Drag-and-drop**: each sidebar row is `.draggable("OWNER.NAME")`; STTextView/NSTextView accepts text drops natively, so dropping into the editor inserts the qualified name.
- **Items 26 & 27**: `DetailGridView` headers respect Dynamic Type / system colours and row height now scales with the user's preferred body font size (no more 20pt hard-code).
- **Item 30 — Last-selection persistence**: when no `DBCacheInputValue` selection is pending, the last selected object is restored per-TNS from UserDefaults on appear. Cleared only on actual user pick, not on filter-driven transient nils.
- **Item 31 — `.cancellationAction` / Done convention** (issue #30): the Format & View window has a bottom action bar with Copy SQL and a default-action **Done** button. Cache Counts sheet already adopted the pattern earlier in this PR.
- **Item 32**: Detail tab now persists across object selections via `@AppStorage` (the original complaint — "clicking through five objects loses the preferred tab").
- **Item 34 — `foregroundColor` sweep**: every remaining `.foregroundColor(...)` usage across the app converted to `.foregroundStyle(...)` (Session Browser, MainDocumentView, ResultViewWrapper). Optional-color sites (`vm.flag ? .green : nil`) became `AnyShapeStyle(.primary)` defaults.
- **Item 38 — Section header prominence** (issue #34): sidebar schema sections render with `.headerProminence(.increased)`.

**Removed**
- `searchLimit` AppStorage in `DBCacheVM` and the corresponding `Search Limit` field in `DBBrowserSettings` — no longer used now that the cap is dropped.

**Post-review fix**
- Opening the browser pre-focused on a bare `owner.name` reference (e.g. ⌘⇧I on a standalone procedure, which `DBBrowserInputMapper.schemaObject` can't type) no longer lets the per-type toggles hide the requested object — you'd see an empty sidebar and "No Results" in the detail pane. New session-only `DBCacheSearchCriteria.ignoreTypeFilter`: set by `DBCacheVM.init` whenever a `selectedObjectName` is supplied without a `selectedObjectType` (the predicate then skips the per-type clause; `selectedTypeFilter` still wins when a type *is* known); cleared the moment the user touches a type toggle in `QuickFilterView`.

## Explicitly deferred to follow-up issues
- **Item 28 — Index DDL preview tab** — needs a backend `DBMS_METADATA.GET_DDL` call + Core Data column. Tracked in issue #29.
- **Item 33 — `@Observable` migration of `DBCacheVM`** — a ~1700-line refactor that touches every `@Published` observer. Tracked in issue #31.
- **Item 36 — Cancel button during a long refresh** — tracked in issue #32.
- **Item 37 — Last refresh duration / row-count delta** — tracked in issue #33.
- **Replace `DetailGridView` with SwiftUI `Table`** — tracked in issue #35.
- **Recent / Favourites sidebar section** — tracked in issue #36.

## Test plan
Rebased onto `main` @ `be5713e`. Full build is green (`xcodebuild build` / `build-for-testing` → `BUILD SUCCEEDED`, macOS 26 SDK); the whole unit-test target passes (499 tests, 1 skipped — the live-DB smoke test) and the DB-Browser UI suite passes; every interactive item below was confirmed by hand.

**Automated tests added (all green)**
- `MacintoraTests/DBBrowser/DBCacheSearchCriteriaTests` — Item 1: flipping any type toggle / owner / prefix / search text changes the derived `predicate` (so `onChange(of: cache.searchCriteria)` re-runs the fetch — the root cause of the "toggles don't refresh" bug); `selectedTypeFilter` overrides the toggles; `ignoreTypeFilter` drops the type clause entirely while keeping owner/search clauses, and `selectedTypeFilter` still wins over it; `persist()` / `init(for:)` round-trip the toggles and the per-TNS owner/prefix strings through `UserDefaults`.
- `MacintoraTests/DBBrowser/DBCacheObjectFetchRequestTests` — Item 2: `limit == 0` (the default) leaves `fetchLimit` unset; a positive limit is applied; the predicate is forwarded; sort order is owner → type → name.
- `MacintoraTests/DBBrowser/DBBrowserCommandsBoxTests` — Item 3: fresh box has all-nil triggers; each closure fires exactly once; reassigning replaces the previous closure; clearing disables invocation (mirrors `WorksheetCommandsBoxTests`).
- `MacintoraTests/DBBrowser/DBCacheVMInitTests` — `init` seeds `searchText` / `ownerString` / `selectedTypeFilter` / pending-selection / `initialDetailTab` from the constructor args, and sets `ignoreTypeFilter` only for a name-without-type open.
- `MacintoraUITests/DBBrowserMenuUITests` — the **DB Browser** `CommandMenu` is present with all ten items, every item is disabled when no browser window is keyed, and ⌘R still routes to the editor's **Run** while an editor is keyed; the existing `EditorShortcutsUITests` ⌘R / ⇧⌘R / ⌥⌘R / ⇧⌘I cases were re-run and still pass alongside the new menu.

**Verified**
- [x] Clean build (macOS 26 SDK); full unit-test target + DB-Browser UI suite green.
- [x] Toggle every quick filter in the inspector — the object list refreshes immediately in the same window.
- [x] Scroll past row 20 — the list keeps loading (no cap).
- [x] ⌘R / ⇧⌘R / ⌥⌘R / ⌘F / ⌘1 / ⌘2 work while the DB Browser is keyed; ⌘R still triggers **Run** when an editor is keyed.
- [x] Refresh shows a `ProgressView` only while running; the toolbar status disappears when idle.
- [x] Detail tabs use the new `Tab` API; the selected tab persists across object selections.
- [x] Trigger detail shows "After Row" / "After Statement" (no typos).
- [x] Invalid objects show the red `!` badge in the sidebar.
- [x] Search field is debounced; the list updates ~200 ms after you stop typing.
- [x] Right-clicking a row shows Copy Name / Copy Owner.Name / Reveal / Open in New Window / Open Source.
- [x] Dragging a sidebar row into an open SQL editor inserts `OWNER.NAME`.
- [x] `DetailGridView` row height scales with System Settings → Accessibility → Display → Text size.
- [x] Close and re-open a DB Browser window — the previously selected object is restored automatically (when it still exists in the cache).
- [x] Sidebar schema-section headers render with increased prominence.
- [x] Format & View window has a bottom **Done** button; pressing Return closes it.
- [x] ⌘⇧I on a standalone procedure while the Procedures toggle is off — the procedure now loads (post-review `ignoreTypeFilter` fix); touching a type toggle afterwards restores normal type filtering.

https://claude.ai/code/session_01AXCwxkCXMHhV3FY3Smdr6y

