### PR TITLE
CI: grant claude-code-review `pull-requests: write` so it can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

The `claude-code-review` job has been running on every PR (back through #19, #22, #26, and the current #28) with conclusion `success` and started_at/completed_at timings that show it's actually doing 1–2 minutes of work — but it has **never** posted a single review comment.

## Cause

`.github/workflows/claude-code-review.yml` grants `pull-requests: read`. Per the `anthropics/claude-code-action` solutions doc, both inline review comments (`mcp__github_inline_comment__create_inline_comment`) and PR-level comments (`gh pr comment`) require **`pull-requests: write`**. With `read` only, the action analyses the diff, attempts the POST, gets a 403, and exits 0 — silent fail.

## Fix

One word: `read` → `write` on `pull-requests`. No prompt changes, no plugin changes.

## Test plan

- [ ] Merge this, then trigger `claude-code-review` on a PR with a non-trivial diff (e.g. by pushing a follow-up commit to #28) and confirm review comments actually appear.

https://claude.ai/code/session_012muSqZKEnr7bE2LrWYw2Qs

---
_Generated by [Claude Code](https://claude.ai/code/session_012muSqZKEnr7bE2LrWYw2Qs)_