### PR TITLE
DB Browser: highlight current line in code views

### DIFF
--- a/Macintora/DBObjectsBrowser/FormattedView.swift
+++ b/Macintora/DBObjectsBrowser/FormattedView.swift
@@ -26,7 +26,6 @@ struct FormattedView: View {
                 isSelectable: true,
                 wordWrap: .constant(true),
                 showsLineNumbers: true,
-                highlightsSelectedLine: false,
                 accessibilityIdentifier: "editor.db.formatted"
             )
             actionBar

--- a/Macintora/DBObjectsBrowser/SourceView.swift
+++ b/Macintora/DBObjectsBrowser/SourceView.swift
@@ -89,7 +89,6 @@ struct SourceView: View {
                     isSelectable: true,
                     wordWrap: .constant(true),
                     showsLineNumbers: true,
-                    highlightsSelectedLine: false,
                     accessibilityIdentifier: "editor.db.source",
                     revealGeneration: revealGeneration
                 )


### PR DESCRIPTION
## Summary
- Drop the `highlightsSelectedLine: false` override on the PL/SQL source and formatted-SQL editors in the DB Browser so they pick up the editor's `true` default, matching the worksheet.

Closes #38.

## Test plan
- [ ] Open a package body in the DB Browser → active line gets the subtle highlight.
- [ ] Open the formatted-SQL view → active line gets the subtle highlight.
- [ ] Worksheet editor still highlights the active line (no regression).