### PR TITLE
DB Browser: align Trigger detail layout with Packages

### DIFF
--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -330,10 +330,6 @@ private extension Field where Content == Text {
 
 // MARK: - Trigger accordion extras
 
-/// Inline chips appended to the collapsed accordion summary when the selected
-/// object is a trigger. Surfaces the two things you most often want to see at
-/// a glance without expanding — the trigger's type (e.g. "BEFORE EACH ROW")
-/// and whether it's currently enabled.
 private struct TriggerAccordionSummary: View {
     @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
 
@@ -361,10 +357,6 @@ private struct TriggerAccordionSummary: View {
     }
 }
 
-/// Trigger-specific fields rendered below the generic accordion grid when the
-/// accordion is expanded. Replaces the old `triggerForm` that used to sit
-/// between the header and the body source — putting it here keeps the trigger
-/// layout aligned with packages (header on top, tabbed source below).
 private struct TriggerAccordionExpanded: View {
     @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
 

--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -178,6 +178,10 @@ struct DBDetailAccordion: View {
     @Binding var dbObject: DBCacheObject
     @Binding var isOpen: Bool
 
+    private var oracleType: OracleObjectType {
+        OracleObjectType(rawValue: dbObject.type) ?? .unknown
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             Button {
@@ -194,6 +198,9 @@ struct DBDetailAccordion: View {
                     if !isOpen {
                         AccordionSummary(dbObject: dbObject)
                             .padding(.leading, 6)
+                        if oracleType == .trigger {
+                            TriggerAccordionSummary(name: dbObject.name, owner: dbObject.owner)
+                        }
                     }
                     Spacer(minLength: 0)
                     Text("⌘I")
@@ -213,8 +220,13 @@ struct DBDetailAccordion: View {
             .background(Color.secondary.opacity(0.06))
 
             if isOpen {
-                AccordionExpanded(dbObject: dbObject)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                VStack(spacing: 0) {
+                    AccordionExpanded(dbObject: dbObject)
+                    if oracleType == .trigger {
+                        TriggerAccordionExpanded(name: dbObject.name, owner: dbObject.owner)
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
             Divider()
@@ -313,6 +325,87 @@ private struct Field<Content: View>: View {
 private extension Field where Content == Text {
     init(label: String, value: String) {
         self.init(label: label) { Text(value) }
+    }
+}
+
+// MARK: - Trigger accordion extras
+
+/// Inline chips appended to the collapsed accordion summary when the selected
+/// object is a trigger. Surfaces the two things you most often want to see at
+/// a glance without expanding — the trigger's type (e.g. "BEFORE EACH ROW")
+/// and whether it's currently enabled.
+private struct TriggerAccordionSummary: View {
+    @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
+
+    init(name: String, owner: String) {
+        _triggers = FetchRequest<DBCacheTrigger>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
+        )
+    }
+
+    var body: some View {
+        let trigger = triggers.first
+        HStack(spacing: 14) {
+            SummaryItem(label: "Type", value: trigger?.type ?? Constants.nullValue)
+            HStack(spacing: 4) {
+                Circle()
+                    .fill((trigger?.isEnabled ?? false) ? Color.green : Color.red)
+                    .frame(width: 6, height: 6)
+                Text((trigger?.isEnabled ?? false) ? "Enabled" : "Disabled")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption)
+    }
+}
+
+/// Trigger-specific fields rendered below the generic accordion grid when the
+/// accordion is expanded. Replaces the old `triggerForm` that used to sit
+/// between the header and the body source — putting it here keeps the trigger
+/// layout aligned with packages (header on top, tabbed source below).
+private struct TriggerAccordionExpanded: View {
+    @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
+
+    init(name: String, owner: String) {
+        _triggers = FetchRequest<DBCacheTrigger>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
+        )
+    }
+
+    private let columns = [GridItem(.flexible(), alignment: .topLeading),
+                           GridItem(.flexible(), alignment: .topLeading),
+                           GridItem(.flexible(), alignment: .topLeading),
+                           GridItem(.flexible(), alignment: .topLeading)]
+
+    var body: some View {
+        let trigger = triggers.first
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+            Field(label: "Type", value: trigger?.type ?? Constants.nullValue)
+            Field(label: "When", value: trigger?.whenClause ?? Constants.nullValue)
+            Field(label: "Column", value: trigger?.columnName ?? Constants.nullValue)
+            Field(label: "Base Type", value: trigger?.objectType ?? Constants.nullValue)
+            Field(label: "Base Owner", value: trigger?.objectOwner ?? Constants.nullValue)
+            Field(label: "Base Name", value: trigger?.objectName ?? Constants.nullValue)
+            Field(label: "Referencing", value: trigger?.referencingNames ?? Constants.nullValue)
+            Field(label: "Description", value: trigger?.descr ?? Constants.nullValue)
+
+            Field(label: "Before Row") { BoolIndicator(value: trigger?.isBeforeRow ?? false) }
+            Field(label: "After Row") { BoolIndicator(value: trigger?.isAfterRow ?? false) }
+            Field(label: "Before Statement") { BoolIndicator(value: trigger?.isBeforeStatement ?? false) }
+            Field(label: "After Statement") { BoolIndicator(value: trigger?.isAfterStatement ?? false) }
+            Field(label: "Instead Of") { BoolIndicator(value: trigger?.isInsteadOfRow ?? false) }
+            Field(label: "Cross Edition") { BoolIndicator(value: trigger?.isCrossEdition ?? false) }
+            Field(label: "Fire Once") { BoolIndicator(value: trigger?.isFireOnce ?? false) }
+            Field(label: "Enabled") {
+                BoolIndicator(value: trigger?.isEnabled ?? false, trueColor: .green, falseColor: .red)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Color.secondary.opacity(0.04))
     }
 }
 

--- a/Macintora/DBObjectsBrowser/DBTriggerDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBTriggerDetailView.swift
@@ -8,50 +8,41 @@
 import SwiftUI
 import CoreData
 
+private enum DBTriggerTab: String, CaseIterable, Codable {
+    case body
+}
 
 struct DBTriggerDetailView: View {
     @Environment(\.managedObjectContext) var context
-    @FetchRequest private var tables: FetchedResults<DBCacheTrigger>
+    @AppStorage("dbTriggerDetailSelectedTab") private var selectedTab: DBTriggerTab = .body
+    @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
     @Binding var dbObject: DBCacheObject
 
     init(dbObject: Binding<DBCacheObject>) {
         self._dbObject = dbObject
-        _tables = FetchRequest<DBCacheTrigger>(sortDescriptors: [], predicate: NSPredicate.init(format: "name_ = %@ and owner_ = %@ ", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
+        _triggers = FetchRequest<DBCacheTrigger>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@",
+                                   dbObject.name.wrappedValue,
+                                   dbObject.owner.wrappedValue)
+        )
     }
 
-    private var triggerForm: some View {
-        let trigger = tables.first
-        return Form {
-            Section("Trigger Details") {
-                LabeledContent("Type", value: trigger?.type ?? Constants.nullValue)
-                LabeledContent("When", value: trigger?.whenClause ?? Constants.nullValue)
-                LabeledContent("Column", value: trigger?.columnName ?? Constants.nullValue)
-                LabeledContent("Base Type", value: trigger?.objectType ?? Constants.nullValue)
-                LabeledContent("Base Owner", value: trigger?.objectOwner ?? Constants.nullValue)
-                LabeledContent("Base Name", value: trigger?.objectName ?? Constants.nullValue)
-                LabeledContent("Referencing", value: trigger?.referencingNames ?? Constants.nullValue)
-                LabeledContent("Description", value: trigger?.descr ?? Constants.nullValue)
-            }
-
-            Section("Timing") {
-                LabeledContent("Before Row") { BoolIndicator(value: trigger?.isBeforeRow ?? false) }
-                LabeledContent("After Row") { BoolIndicator(value: trigger?.isAfterRow ?? false) }
-                LabeledContent("Before Statement") { BoolIndicator(value: trigger?.isBeforeStatement ?? false) }
-                LabeledContent("After Statement") { BoolIndicator(value: trigger?.isAfterStatement ?? false) }
-                LabeledContent("Instead Of") { BoolIndicator(value: trigger?.isInsteadOfRow ?? false) }
-                LabeledContent("CrossEdition") { BoolIndicator(value: trigger?.isCrossEdition ?? false) }
-                LabeledContent("Fire Once") { BoolIndicator(value: trigger?.isFireOnce ?? false) }
-                LabeledContent("Enabled") { BoolIndicator(value: trigger?.isEnabled ?? false, trueColor: .green, falseColor: .red) }
-            }
-        }
-        .formStyle(.grouped)
+    private var bodyText: Binding<String> {
+        Binding<String>(get: { triggers.first?.body ?? "" }, set: { _ in })
     }
 
     var body: some View {
         VStack(alignment: .leading) {
-            triggerForm
-            SourceView(objName: $dbObject.name, text: Binding<String>(get: {tables.first?.body ?? ""}, set: {_ in}), title: "Body")
+            TabView(selection: $selectedTab) {
+                Tab("Body", systemImage: "doc.text.fill", value: DBTriggerTab.body) {
+                    SourceView(objName: $dbObject.name, text: bodyText, title: "Body")
+                        .padding(.vertical, 5)
+                }
+            }
         }
+        .frame(minWidth: 200, idealWidth: 1000, maxWidth: .infinity,
+               idealHeight: 1000, maxHeight: .infinity)
         .padding()
     }
 }

--- a/Macintora/DBObjectsBrowser/DBTriggerDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBTriggerDetailView.swift
@@ -8,13 +8,8 @@
 import SwiftUI
 import CoreData
 
-private enum DBTriggerTab: String, CaseIterable, Codable {
-    case body
-}
-
 struct DBTriggerDetailView: View {
     @Environment(\.managedObjectContext) var context
-    @AppStorage("dbTriggerDetailSelectedTab") private var selectedTab: DBTriggerTab = .body
     @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
     @Binding var dbObject: DBCacheObject
 
@@ -33,17 +28,11 @@ struct DBTriggerDetailView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading) {
-            TabView(selection: $selectedTab) {
-                Tab("Body", systemImage: "doc.text.fill", value: DBTriggerTab.body) {
-                    SourceView(objName: $dbObject.name, text: bodyText, title: "Body")
-                        .padding(.vertical, 5)
-                }
-            }
-        }
-        .frame(minWidth: 200, idealWidth: 1000, maxWidth: .infinity,
-               idealHeight: 1000, maxHeight: .infinity)
-        .padding()
+        SourceView(objName: $dbObject.name, text: bodyText, title: "Body")
+            .padding(.vertical, 5)
+            .frame(minWidth: 200, idealWidth: 1000, maxWidth: .infinity,
+                   idealHeight: 1000, maxHeight: .infinity)
+            .padding()
     }
 }
 


### PR DESCRIPTION
## Summary
Closes #41. Trigger detail now mirrors the package viewer — accordion header on top, tabbed source below — instead of having two grouped forms wedged between the header and the body source.

- **`DBTriggerDetailView`**: drop the "Trigger Details" / "Timing" forms; body is now a single-tab `TabView` wrapping `SourceView`, matching `DBSourceDetailView`.
- **`DBDetailAccordion`** (in `DBDetailView.swift`): when the selected object is a trigger,
  - collapsed strip gets a Type chip + green/red Enabled pill,
  - expanded section adds a 4-col grid of all 16 trigger attributes (Type, When, Column, Base Type/Owner/Name, Referencing, Description, and the timing/edition/enabled flags).

The fetch for `DBCacheTrigger` is driven from inside the new accordion subviews (predicate on `name_`/`owner_`), keyed by `name`/`owner` so it tracks selection changes the same way the existing `DBSourceDetailView` fetch does.

## Test plan
- [ ] Select a trigger in the DB Browser → header strip shows Type + Enabled chip, expanded accordion shows all 16 trigger fields, body area shows just the tabbed source (no intermediate forms).
- [ ] Select a package → no trigger chips/fields appear (regression check).
- [ ] Switch between triggers with different enable states → chip toggles correctly.
- [ ] Switch between trigger and non-trigger objects → accordion content updates without stale fields.