### PR TITLE
Settings: user-selectable app accent color (#39)

### DIFF
--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -127,9 +127,7 @@ final class MacintoraCompletionItem: NSObject, STCompletionItem, @unchecked Send
         // contract for plain NSViews didn't propagate to the inner stack.
         // STTextView's own demo (`TextEdit/Mac/CompletionItem.swift`) uses
         // the same NSHostingView pattern.
-        // NSHostingView lives outside the scene tree, so the scene-root
-        // `.tint(...)` doesn't reach it. Re-apply via the same modifier so
-        // the completion icon honours the user's chosen accent.
+        // Re-apply `.macintoraAccentTint()` because NSHostingView sits outside the scene tree.
         NSHostingView(rootView: CompletionRowView(
             displayText: displayText,
             secondaryText: secondaryText,

--- a/Macintora/Editor/Completion/CompletionItem.swift
+++ b/Macintora/Editor/Completion/CompletionItem.swift
@@ -127,11 +127,15 @@ final class MacintoraCompletionItem: NSObject, STCompletionItem, @unchecked Send
         // contract for plain NSViews didn't propagate to the inner stack.
         // STTextView's own demo (`TextEdit/Mac/CompletionItem.swift`) uses
         // the same NSHostingView pattern.
+        // NSHostingView lives outside the scene tree, so the scene-root
+        // `.tint(...)` doesn't reach it. Re-apply via the same modifier so
+        // the completion icon honours the user's chosen accent.
         NSHostingView(rootView: CompletionRowView(
             displayText: displayText,
             secondaryText: secondaryText,
             symbolName: kind.symbolName,
-            allowsWrap: signatureInsertion != nil))
+            allowsWrap: signatureInsertion != nil)
+            .macintoraAccentTint())
     }
 }
 
@@ -151,7 +155,7 @@ private struct CompletionRowView: View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Image(systemName: symbolName)
                 .symbolRenderingMode(.monochrome)
-                .foregroundStyle(Color(nsColor: .controlAccentColor))
+                .foregroundStyle(Color.accentColor)
                 .frame(width: 14, alignment: .center)
 
             Text(displayText)

--- a/Macintora/Editor/Plugins/QuickView/QuickViewContent.swift
+++ b/Macintora/Editor/Plugins/QuickView/QuickViewContent.swift
@@ -22,26 +22,31 @@ struct QuickViewContent: View {
     let openInBrowserAction: (() -> Void)?
 
     var body: some View {
-        switch payload {
-        case .table(let table):
-            QuickViewTableView(payload: table,
-                               openInBrowserAction: openInBrowserAction)
-        case .packageOrType(let pkg):
-            QuickViewPackageView(payload: pkg,
-                                 openInBrowserAction: openInBrowserAction)
-        case .procedure(let proc):
-            QuickViewProcedureView(payload: proc,
+        // Quick View renders inside an NSHostingController popover (outside
+        // the scene tree), so re-apply the user-chosen accent here.
+        Group {
+            switch payload {
+            case .table(let table):
+                QuickViewTableView(payload: table,
                                    openInBrowserAction: openInBrowserAction)
-        case .column(let col):
-            QuickViewColumnView(payload: col,
-                                openInBrowserAction: openInBrowserAction)
-        case .unknownObject(let unknown):
-            QuickViewUnknownObjectView(payload: unknown,
+            case .packageOrType(let pkg):
+                QuickViewPackageView(payload: pkg,
+                                     openInBrowserAction: openInBrowserAction)
+            case .procedure(let proc):
+                QuickViewProcedureView(payload: proc,
                                        openInBrowserAction: openInBrowserAction)
-        case .notCached(let reference):
-            QuickViewNotCachedView(reference: reference,
-                                   openInBrowserAction: openInBrowserAction)
+            case .column(let col):
+                QuickViewColumnView(payload: col,
+                                    openInBrowserAction: openInBrowserAction)
+            case .unknownObject(let unknown):
+                QuickViewUnknownObjectView(payload: unknown,
+                                           openInBrowserAction: openInBrowserAction)
+            case .notCached(let reference):
+                QuickViewNotCachedView(reference: reference,
+                                       openInBrowserAction: openInBrowserAction)
+            }
         }
+        .macintoraAccentTint()
     }
 }
 

--- a/Macintora/MainApp/MacintoraApp.swift
+++ b/Macintora/MainApp/MacintoraApp.swift
@@ -241,6 +241,7 @@ struct MacOraApp: App {
                 .frame(minWidth: 600, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity)
                 .environment(\.connectionStore, connectionStore)
                 .environment(\.keychainService, keychainService)
+                .macintoraAccentTint()
                 .task(id: config.fileURL) {
                     config.document.fileURL = config.fileURL
                 }
@@ -288,18 +289,21 @@ struct MacOraApp: App {
                 .environment(\.managedObjectContext, cache.persistenceController.container.viewContext)
                 .environment(\.connectionStore, connectionStore)
                 .environment(\.keychainService, keychainService)
+                .macintoraAccentTint()
         }
 
         WindowGroup(for: SBInputValue.self) { $value in
             SBMainView(inputValue: value ?? .preview())
                 .environment(\.connectionStore, connectionStore)
                 .environment(\.keychainService, keychainService)
+                .macintoraAccentTint()
         }
 
         Settings {
             SettingsView()
                 .environment(\.connectionStore, connectionStore)
                 .environment(\.keychainService, keychainService)
+                .macintoraAccentTint()
         }
 
         // Read-only cheatsheet listing every Macintora-specific shortcut.
@@ -308,6 +312,7 @@ struct MacOraApp: App {
         // and the user can't drag it down to a useless thumbnail.
         Window("Keyboard Shortcuts", id: KeyboardShortcuts.windowID) {
             KeyboardShortcutsView()
+                .macintoraAccentTint()
         }
         .windowResizability(.contentSize)
     }

--- a/Macintora/MainApp/SettingsView.swift
+++ b/Macintora/MainApp/SettingsView.swift
@@ -10,7 +10,7 @@ import AppKit
 
 struct SettingsView: View {
     private enum Tabs: Hashable {
-        case editor, browser, connections
+        case editor, browser, appearance, connections
     }
     var body: some View {
         TabView {
@@ -25,12 +25,129 @@ struct SettingsView: View {
                 }
                 .tag(Tabs.browser)
                 .padding(10)
+            AppearanceSettings()
+                .tabItem {
+                    Label("Appearance", systemImage: "paintpalette")
+                }
+                .tag(Tabs.appearance)
             ConnectionsManagerView()
                 .tabItem {
                     Label("Connections", systemImage: "point.3.connected.trianglepath.dotted")
                 }
                 .tag(Tabs.connections)
         }
+    }
+}
+
+/// User-selectable app accent. `.system` opts out of overriding the macOS
+/// accent (no `.tint` applied at the scene root); the named cases override
+/// it with a fixed swatch matching the standard AppKit accent presets.
+enum AppAccentColor: String, CaseIterable, Identifiable {
+    case system
+    case blue
+    case purple
+    case pink
+    case red
+    case orange
+    case yellow
+    case green
+    case graphite
+
+    static let storageKey = "appAccentColor"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .system: "Match System"
+        case .blue: "Blue"
+        case .purple: "Purple"
+        case .pink: "Pink"
+        case .red: "Red"
+        case .orange: "Orange"
+        case .yellow: "Yellow"
+        case .green: "Green"
+        case .graphite: "Graphite"
+        }
+    }
+
+    /// `nil` means "don't override the system accent" — caller should skip
+    /// applying `.tint(...)` so views fall back to `NSColor.controlAccentColor`.
+    var color: Color? {
+        switch self {
+        case .system: nil
+        case .blue: .blue
+        case .purple: .purple
+        case .pink: .pink
+        case .red: .red
+        case .orange: .orange
+        case .yellow: .yellow
+        case .green: .green
+        case .graphite: Color(nsColor: .systemGray)
+        }
+    }
+}
+
+struct AppearanceSettings: View {
+    @AppStorage(AppAccentColor.storageKey) private var accentRaw: String = AppAccentColor.system.rawValue
+
+    private var accentBinding: Binding<AppAccentColor> {
+        Binding(
+            get: { AppAccentColor(rawValue: accentRaw) ?? .system },
+            set: { accentRaw = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        VStack {
+            Form {
+                Picker("Accent Color", selection: accentBinding) {
+                    ForEach(AppAccentColor.allCases) { accent in
+                        HStack {
+                            if let color = accent.color {
+                                Circle()
+                                    .fill(color)
+                                    .frame(width: 12, height: 12)
+                            } else {
+                                Circle()
+                                    .strokeBorder(Color.secondary, lineWidth: 1)
+                                    .frame(width: 12, height: 12)
+                            }
+                            Text(accent.displayName)
+                        }
+                        .tag(accent)
+                    }
+                }
+                .help("Overrides the macOS system accent within Macintora. Match System defers to your System Settings choice.")
+            }
+            Spacer()
+        }
+        .padding(20)
+    }
+}
+
+/// Reads the persisted `AppAccentColor` and applies `.tint(...)` when the
+/// user picked an explicit override. `.system` leaves the tint alone so
+/// SwiftUI falls back to `NSColor.controlAccentColor`.
+struct AppAccentTintModifier: ViewModifier {
+    @AppStorage(AppAccentColor.storageKey) private var accentRaw: String = AppAccentColor.system.rawValue
+
+    private var accent: AppAccentColor {
+        AppAccentColor(rawValue: accentRaw) ?? .system
+    }
+
+    func body(content: Content) -> some View {
+        if let color = accent.color {
+            content.tint(color)
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func macintoraAccentTint() -> some View {
+        modifier(AppAccentTintModifier())
     }
 }
 

--- a/Macintora/MainApp/SettingsView.swift
+++ b/Macintora/MainApp/SettingsView.swift
@@ -39,9 +39,7 @@ struct SettingsView: View {
     }
 }
 
-/// User-selectable app accent. `.system` opts out of overriding the macOS
-/// accent (no `.tint` applied at the scene root); the named cases override
-/// it with a fixed swatch matching the standard AppKit accent presets.
+/// User-selectable app accent; `.system` defers to the macOS system accent.
 enum AppAccentColor: String, CaseIterable, Identifiable {
     case system
     case blue
@@ -71,8 +69,7 @@ enum AppAccentColor: String, CaseIterable, Identifiable {
         }
     }
 
-    /// `nil` means "don't override the system accent" — caller should skip
-    /// applying `.tint(...)` so views fall back to `NSColor.controlAccentColor`.
+    /// `nil` means "skip `.tint(...)`" so SwiftUI falls back to the system accent.
     var color: Color? {
         switch self {
         case .system: nil
@@ -126,9 +123,7 @@ struct AppearanceSettings: View {
     }
 }
 
-/// Reads the persisted `AppAccentColor` and applies `.tint(...)` when the
-/// user picked an explicit override. `.system` leaves the tint alone so
-/// SwiftUI falls back to `NSColor.controlAccentColor`.
+/// Applies the persisted accent via `.tint(...)`; a no-op for `.system`.
 struct AppAccentTintModifier: ViewModifier {
     @AppStorage(AppAccentColor.storageKey) private var accentRaw: String = AppAccentColor.system.rawValue
 


### PR DESCRIPTION
Closes #39.

## Summary
- New **Appearance** tab in `SettingsView` with an accent picker — mirrors AppKit presets (blue, purple, pink, red, orange, yellow, green, graphite) plus *Match System*. Persisted as `@AppStorage("appAccentColor")`.
- New `AppAccentColor` enum + `macintoraAccentTint()` view modifier; applied at every Scene root (DocumentGroup, DBCache / SessionBrowser WindowGroups, Settings, Keyboard Shortcuts window) so existing `Color.accentColor` references in `DBBrowserSidebar`, `QuickFilterView`, `DBSearchPalette`, and `DBDetailView` pick up the override automatically.
- `CompletionItem.swift` row icon switched from `NSColor.controlAccentColor` to `Color.accentColor` so it follows the in-app accent; the modifier is re-applied at the `NSHostingView` site since hosting views sit outside the scene tree.

*Match System* leaves the tint alone, so views fall back to whatever the macOS system accent is.

## Test plan
- [x] `xcodebuild build` clean
- [ ] Open Settings → Appearance → cycle through every accent; verify DB Browser sidebar selection bar, Quick Filter chips, ⌘K search palette scope/highlight, completion popup icon, and connection-status dot all retint live
- [ ] *Match System* falls back to the macOS accent
- [ ] Selection persists across relaunch