### PR TITLE
DB Browser: align Index detail with Tables

### DIFF
--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -244,6 +244,9 @@ private struct AccordionSummary: View {
             if let ddl = dbObject.lastDDLDate {
                 SummaryItem(label: "Last DDL", value: ddl.formatted(date: .abbreviated, time: .omitted))
             }
+            if OracleObjectType(rawValue: dbObject.type) == .index {
+                IndexAccordionSummaryExtras(dbObject: dbObject)
+            }
             HStack(spacing: 4) {
                 Circle()
                     .fill(dbObject.isValid ? Color.green : Color.red)
@@ -254,6 +257,32 @@ private struct AccordionSummary: View {
             }
         }
         .font(.caption)
+    }
+}
+
+private struct IndexAccordionSummaryExtras: View {
+    @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
+
+    init(dbObject: DBCacheObject) {
+        _indexes = FetchRequest<DBCacheIndex>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", dbObject.name, dbObject.owner)
+        )
+    }
+
+    var body: some View {
+        if let idx = indexes.first {
+            SummaryItem(label: "Rows", value: idx.numRows.formatted())
+            if let analyzed = idx.lastAnalyzed {
+                SummaryItem(label: "Analyzed", value: analyzed.formatted(date: .abbreviated, time: .omitted))
+            }
+            HStack(spacing: 4) {
+                Text("Partitioned")
+                    .foregroundStyle(.tertiary)
+                BoolIndicator(value: idx.isPartitioned)
+                    .font(.caption)
+            }
+        }
     }
 }
 
@@ -294,10 +323,36 @@ private struct AccordionExpanded: View {
             Field(label: "Valid") {
                 BoolIndicator(value: dbObject.isValid, trueColor: .green, falseColor: .red)
             }
+            if OracleObjectType(rawValue: dbObject.type) == .index {
+                IndexAccordionExpandedExtras(dbObject: dbObject)
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .background(Color.secondary.opacity(0.04))
+    }
+}
+
+private struct IndexAccordionExpandedExtras: View {
+    @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
+
+    init(dbObject: DBCacheObject) {
+        _indexes = FetchRequest<DBCacheIndex>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", dbObject.name, dbObject.owner)
+        )
+    }
+
+    var body: some View {
+        if let idx = indexes.first {
+            Field(label: "Partitioned") {
+                BoolIndicator(value: idx.isPartitioned)
+            }
+            Field(label: "Row Count", value: idx.numRows.formatted())
+            Field(label: "Last Analyzed",
+                  value: idx.lastAnalyzed?
+                    .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
+        }
     }
 }
 

--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -201,6 +201,9 @@ struct DBDetailAccordion: View {
                         if oracleType == .trigger {
                             TriggerAccordionSummary(name: dbObject.name, owner: dbObject.owner)
                         }
+                        if oracleType == .index {
+                            IndexAccordionSummary(name: dbObject.name, owner: dbObject.owner)
+                        }
                     }
                     Spacer(minLength: 0)
                     Text("⌘I")
@@ -225,6 +228,9 @@ struct DBDetailAccordion: View {
                     if oracleType == .trigger {
                         TriggerAccordionExpanded(name: dbObject.name, owner: dbObject.owner)
                     }
+                    if oracleType == .index {
+                        IndexAccordionExpanded(name: dbObject.name, owner: dbObject.owner)
+                    }
                 }
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
@@ -244,9 +250,6 @@ private struct AccordionSummary: View {
             if let ddl = dbObject.lastDDLDate {
                 SummaryItem(label: "Last DDL", value: ddl.formatted(date: .abbreviated, time: .omitted))
             }
-            if OracleObjectType(rawValue: dbObject.type) == .index {
-                IndexAccordionSummaryExtras(dbObject: dbObject)
-            }
             HStack(spacing: 4) {
                 Circle()
                     .fill(dbObject.isValid ? Color.green : Color.red)
@@ -260,29 +263,30 @@ private struct AccordionSummary: View {
     }
 }
 
-private struct IndexAccordionSummaryExtras: View {
+private struct IndexAccordionSummary: View {
     @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
 
-    init(dbObject: DBCacheObject) {
+    init(name: String, owner: String) {
         _indexes = FetchRequest<DBCacheIndex>(
             sortDescriptors: [],
-            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", dbObject.name, dbObject.owner)
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
         )
     }
 
     var body: some View {
-        if let idx = indexes.first {
-            SummaryItem(label: "Rows", value: idx.numRows.formatted())
-            if let analyzed = idx.lastAnalyzed {
+        let idx = indexes.first
+        HStack(spacing: 14) {
+            SummaryItem(label: "Rows", value: idx?.numRows.formatted() ?? Constants.nullValue)
+            if let analyzed = idx?.lastAnalyzed {
                 SummaryItem(label: "Analyzed", value: analyzed.formatted(date: .abbreviated, time: .omitted))
             }
             HStack(spacing: 4) {
                 Text("Partitioned")
                     .foregroundStyle(.tertiary)
-                BoolIndicator(value: idx.isPartitioned)
-                    .font(.caption)
+                BoolIndicator(value: idx?.isPartitioned ?? false)
             }
         }
+        .font(.caption)
     }
 }
 
@@ -323,9 +327,6 @@ private struct AccordionExpanded: View {
             Field(label: "Valid") {
                 BoolIndicator(value: dbObject.isValid, trueColor: .green, falseColor: .red)
             }
-            if OracleObjectType(rawValue: dbObject.type) == .index {
-                IndexAccordionExpandedExtras(dbObject: dbObject)
-            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -333,26 +334,35 @@ private struct AccordionExpanded: View {
     }
 }
 
-private struct IndexAccordionExpandedExtras: View {
+private struct IndexAccordionExpanded: View {
     @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
 
-    init(dbObject: DBCacheObject) {
+    init(name: String, owner: String) {
         _indexes = FetchRequest<DBCacheIndex>(
             sortDescriptors: [],
-            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", dbObject.name, dbObject.owner)
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
         )
     }
 
+    private let columns = [GridItem(.flexible(), alignment: .topLeading),
+                           GridItem(.flexible(), alignment: .topLeading),
+                           GridItem(.flexible(), alignment: .topLeading),
+                           GridItem(.flexible(), alignment: .topLeading)]
+
     var body: some View {
-        if let idx = indexes.first {
+        let idx = indexes.first
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
             Field(label: "Partitioned") {
-                BoolIndicator(value: idx.isPartitioned)
+                BoolIndicator(value: idx?.isPartitioned ?? false)
             }
-            Field(label: "Row Count", value: idx.numRows.formatted())
+            Field(label: "Row Count", value: idx?.numRows.formatted() ?? Constants.nullValue)
             Field(label: "Last Analyzed",
-                  value: idx.lastAnalyzed?
+                  value: idx?.lastAnalyzed?
                     .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
         }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Color.secondary.opacity(0.04))
     }
 }
 

--- a/Macintora/DBObjectsBrowser/DBIndexDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBIndexDetailView.swift
@@ -16,7 +16,6 @@ private enum DBIndexTab: String, CaseIterable, Codable {
 struct DBIndexDetailView: View {
     @Environment(\.managedObjectContext) var context
     @AppStorage("dbIndexDetailSelectedTab") private var selectedTab: DBIndexTab = .columns
-    @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
     @FetchRequest private var columns: FetchedResults<DBCacheIndexColumn>
     @Binding var dbObject: DBCacheObject
 
@@ -26,43 +25,25 @@ struct DBIndexDetailView: View {
 
     init(dbObject: Binding<DBCacheObject>) {
         self._dbObject = dbObject
-        _indexes = FetchRequest<DBCacheIndex>(sortDescriptors: [], predicate: NSPredicate.init(format: "name_ = %@ and owner_ = %@", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
         _columns = FetchRequest<DBCacheIndexColumn>(sortDescriptors: [], predicate: NSPredicate.init(format: "indexName_ = %@ and owner_ = %@", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
     }
 
-    private var indexForm: some View {
-        Form {
-            LabeledContent("Partitioned") {
-                BoolIndicator(value: indexes.first?.isPartitioned ?? false)
-            }
-            LabeledContent("Row Count", value: indexes.first?.numRows.formatted() ?? Constants.nullValue)
-            LabeledContent("Last Analyzed", value: indexes.first?.lastAnalyzed?.formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
-        }
-        .formStyle(.grouped)
-    }
-
     var body: some View {
-        VStack {
-            indexForm
+        TabView(selection: $selectedTab) {
+            Tab("Columns", systemImage: "rectangle.split.3x1", value: DBIndexTab.columns) {
+                DetailGridView(rows: Array(columns).sorted(by: columnSortFn), columnLabels: columnLabels, booleanColumnLabels: booleanColumnLabels, rowSortFn: columnSortFn)
+                    .id(dbObject.id)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
 
-            TabView(selection: $selectedTab) {
-                Tab("Columns", systemImage: "rectangle.split.3x1", value: DBIndexTab.columns) {
-                    DetailGridView(rows: Array(columns).sorted(by: columnSortFn), columnLabels: columnLabels, booleanColumnLabels: booleanColumnLabels, rowSortFn: columnSortFn)
-                        .id(dbObject.id)
-                        .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 300, maxHeight: .infinity, alignment: .topLeading)
-                }
-
-                Tab("SQL", systemImage: "doc.text", value: DBIndexTab.sql) {
-                    ContentUnavailableView(
-                        "Index DDL Not Available",
-                        systemImage: "doc.text",
-                        description: Text("DDL preview for indexes is not yet implemented.")
-                    )
-                }
+            Tab("SQL", systemImage: "doc.text", value: DBIndexTab.sql) {
+                ContentUnavailableView(
+                    "Index DDL Not Available",
+                    systemImage: "doc.text",
+                    description: Text("DDL preview for indexes is not yet implemented.")
+                )
             }
         }
-        .frame(minWidth: 200, idealWidth: 400, maxWidth: .infinity)
-        .padding()
     }
 }
 


### PR DESCRIPTION
Closes #40.

## Summary
- Drop the standalone `Form` strip above the Index tabs (`DBIndexDetailView`); the body now matches `DBTableDetailView` shape — just the tab view.
- Surface **Partitioned**, **Row Count**, **Last Analyzed** in the shared `DBDetailAccordion` header (both collapsed `AccordionSummary` and expanded `AccordionExpanded`), gated on `OracleObjectType == .index`, via two new private fetcher views.

## Test plan
- [x] `xcodebuild` clean on macOS
- [x] App launches without crash
- [ ] Visual: open an index in DB Browser — header shows Partitioned / Rows / Analyzed in the collapsed strip; the accordion expanded grid includes them too; Columns / SQL tabs render edge-to-edge with no intermediate form
- [ ] Non-index objects (table, view, package, trigger, …) are unaffected