### PR TITLE
Settings: enforce minimum window size across tabs (closes #46)

### DIFF
--- a/Macintora/MainApp/SettingsView.swift
+++ b/Macintora/MainApp/SettingsView.swift
@@ -12,6 +12,13 @@ struct SettingsView: View {
     private enum Tabs: Hashable {
         case editor, browser, appearance, connections
     }
+
+    // Keep the Settings window at a consistent, usable size across tabs.
+    // Without this, the window resizes to fit the active pane (e.g. the
+    // single-picker Appearance tab) and the tab strip becomes hard to use.
+    private static let minPaneWidth: CGFloat = 760
+    private static let minPaneHeight: CGFloat = 500
+
     var body: some View {
         TabView {
             EditorSettings()
@@ -36,6 +43,7 @@ struct SettingsView: View {
                 }
                 .tag(Tabs.connections)
         }
+        .frame(minWidth: Self.minPaneWidth, minHeight: Self.minPaneHeight)
     }
 }
 


### PR DESCRIPTION
## Summary
- Pin a `minWidth: 760, minHeight: 500` frame on the Settings `TabView` so the window doesn't shrink to the active pane's natural size.
- Matches the existing minimum that `ConnectionsManagerView` already declares, keeping the window stable as the user switches between Editor / DB Browser / Appearance / Connections.

## Why
Reported in #46: with only an accent picker, the Appearance pane is very narrow. Because `TabView` sizes to its active child, opening Settings on Appearance left the window too small for the tab strip to be comfortably usable, making it hard to reach Connections.

## Test plan
- [ ] Open Settings — window opens at ≥ 760×500 regardless of last-active tab.
- [ ] Switch between Editor, DB Browser, Appearance, Connections — window does not shrink; tab strip stays readable.
- [ ] Resize window larger, switch tabs — user's size is preserved (the frame is a minimum, not fixed).

https://claude.ai/code/session_01HTL2MkeyqXYDJyHXUf49wz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTL2MkeyqXYDJyHXUf49wz)_