### PR TITLE
DB Browser: consolidate inspector + sortable Columns grid (follow-up #35)

### DIFF
--- a/Macintora.xcodeproj/project.pbxproj
+++ b/Macintora.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		49B0C0DE0000000000000136 /* DBBrowserMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000036 /* DBBrowserMenuUITests.swift */; };
 		49B0C0DE0000000000000137 /* DBBrowserPinnedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000037 /* DBBrowserPinnedStoreTests.swift */; };
 		49B0C0DE0000000000000138 /* DBBrowserRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0C0DE0000000000000038 /* DBBrowserRecentsTests.swift */; };
+		49B1AAF82FBC1B9D00CDB57E /* TableTableColumnsSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B1AAF72FBC1B9D00CDB57E /* TableTableColumnsSortTests.swift */; };
 		49B55F32270ADD8B00CFB3C7 /* MacintoraApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B55F31270ADD8B00CFB3C7 /* MacintoraApp.swift */; };
 		49B55F36270ADD8B00CFB3C7 /* MainDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B55F35270ADD8B00CFB3C7 /* MainDocumentView.swift */; };
 		49B55F38270ADD8D00CFB3C7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49B55F37270ADD8D00CFB3C7 /* Assets.xcassets */; };
@@ -343,6 +344,7 @@
 		49B0C0DE0000000000000036 /* DBBrowserMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserMenuUITests.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000037 /* DBBrowserPinnedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserPinnedStoreTests.swift; sourceTree = "<group>"; };
 		49B0C0DE0000000000000038 /* DBBrowserRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBBrowserRecentsTests.swift; sourceTree = "<group>"; };
+		49B1AAF72FBC1B9D00CDB57E /* TableTableColumnsSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableTableColumnsSortTests.swift; sourceTree = "<group>"; };
 		49B55F2E270ADD8B00CFB3C7 /* Macintora.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Macintora.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		49B55F31270ADD8B00CFB3C7 /* MacintoraApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MacintoraApp.swift; sourceTree = "<group>"; };
 		49B55F35270ADD8B00CFB3C7 /* MainDocumentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDocumentView.swift; sourceTree = "<group>"; };
@@ -665,6 +667,7 @@
 				49B0C0DE0000000000000035 /* DBCacheObjectFetchRequestTests.swift */,
 				49B0C0DE0000000000000037 /* DBBrowserPinnedStoreTests.swift */,
 				49B0C0DE0000000000000038 /* DBBrowserRecentsTests.swift */,
+				49B1AAF72FBC1B9D00CDB57E /* TableTableColumnsSortTests.swift */,
 			);
 			path = DBBrowser;
 			sourceTree = "<group>";
@@ -1081,6 +1084,7 @@
 				AA00001D0000000000000000 /* DocumentFlowTests.swift in Sources */,
 				AA0000380000000000000000 /* SavedConnectionTests.swift in Sources */,
 				490E96D22FA4256F00DDF37F /* ScriptOutputModelTests.swift in Sources */,
+				49B1AAF82FBC1B9D00CDB57E /* TableTableColumnsSortTests.swift in Sources */,
 				AA00003A0000000000000000 /* JDBCURLParserTests.swift in Sources */,
 				490E96E22FA429FB00DDF37F /* ScriptLoaderTests.swift in Sources */,
 				AA00003C0000000000000000 /* KeychainServiceTests.swift in Sources */,

--- a/Macintora/DBObjectsBrowser/DBBrowserWindowRegistry.swift
+++ b/Macintora/DBObjectsBrowser/DBBrowserWindowRegistry.swift
@@ -107,7 +107,9 @@ struct WindowObserver: NSViewRepresentable {
     }
 
     func updateNSView(_ view: _WindowObserverView, context: Context) {
-        if let window = view.window {
+        // `NSView.window` is bridged as `unowned(unsafe)`; the explicit
+        // `unsafe` is Swift 6.2's required acknowledgment, not a silencer.
+        if let window = unsafe view.window {
             onWindowResolved(window)
         }
     }
@@ -128,13 +130,10 @@ final class _WindowObserverView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if let window, !hasReported {
+        // See `WindowObserver.updateNSView` for why `unsafe` is required.
+        if let window = unsafe window, !hasReported {
             hasReported = true
-            // Fire on the next run-loop turn so SwiftUI's layout pass has
-            // completed and the window hierarchy is stable.
-            MainActor.assumeIsolated {
-                onWindowResolved(window)
-            }
+            onWindowResolved(window)
         }
     }
 }

--- a/Macintora/DBObjectsBrowser/DBCacheMainView.swift
+++ b/Macintora/DBObjectsBrowser/DBCacheMainView.swift
@@ -30,7 +30,7 @@ struct DBCacheInputValue: Hashable, Codable, Equatable {
 
     /// Backward-compatible decoding: scenes persisted before this version lack
     /// the new fields; treat absent keys as nil rather than throwing.
-    init(from decoder: Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         mainConnection     = try  c.decode(MainConnection.self,   forKey: .mainConnection)
         selectedOwner      = try? c.decodeIfPresent(String.self,   forKey: .selectedOwner)      ?? nil
@@ -241,7 +241,7 @@ struct DBCacheMainView: View {
         case .editSource:
             Task(priority: .background) {
                 if let url = await cache.editSource(dbObject: obj) {
-                    await MainActor.run { NSWorkspace.shared.open(url) }
+                    NSWorkspace.shared.open(url)
                 }
             }
         }

--- a/Macintora/DBObjectsBrowser/DBDetailInspectorView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailInspectorView.swift
@@ -2,36 +2,59 @@
 //  DBDetailInspectorView.swift
 //  Macintora
 //
-//  Right-side `.inspector` companion for the object detail. Surfaces
-//  statistics, storage, dependencies, privileges and comments without
-//  consuming primary content area. Sections that have nothing to show
-//  collapse silently — the inspector should not display empty "—" rows
-//  just to look busy.
+//  Right-side inspector companion for the object detail. Dispatches:
+//   - child selected in a sub-tab (column/index/trigger) → child-specific
+//     inspector body
+//   - else → object-level inspector (general + type-specific sections)
+//  Sections with nothing to show stay collapsed silently.
 //
 
 import SwiftUI
 import CoreData
 
-/// Dispatches to a type-specific inspector body. Returning `nil` when there's
-/// nothing meaningful to show lets the parent collapse the inspector via
-/// `.inspector(isPresented:)` rather than rendering an empty pane.
 struct DBDetailInspectorView: View {
+    @Binding var dbObject: DBCacheObject
+    @Binding var childSelection: DBChildSelection?
+
+    var body: some View {
+        switch childSelection {
+        case .column(let c):
+            ColumnInspector(column: c)
+        case .index(let i):
+            IndexInspector(index: i)
+        case .trigger(let t):
+            TriggerInspector(trigger: t)
+        case .none:
+            ObjectInspector(dbObject: $dbObject)
+        }
+    }
+}
+
+// MARK: - Object-level inspector
+
+private struct ObjectInspector: View {
     @Binding var dbObject: DBCacheObject
 
     var body: some View {
         Form {
-            Section("Object") {
+            Section("Identification") {
                 LabeledContent("Owner", value: dbObject.owner)
-                LabeledContent("Object ID",
-                               value: dbObject.objectId.formatted(.number.grouping(.never)))
+                LabeledContent("Name", value: dbObject.name)
                 LabeledContent("Type",
                                value: (OracleObjectType(rawValue: dbObject.type) ?? .unknown).label)
+                LabeledContent("Object ID",
+                               value: dbObject.objectId.formatted(.number.grouping(.never)))
+            }
+
+            Section("Lifecycle") {
                 LabeledContent("Created",
                                value: dbObject.createDate?
                                 .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
                 LabeledContent("Last DDL",
                                value: dbObject.lastDDLDate?
                                 .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
+                LabeledContent("Edition", value: dbObject.editionName ?? Constants.nullValue)
+                LabeledContent("Editionable", value: dbObject.isEditionable ? "Yes" : "No")
                 LabeledContent("Valid") {
                     BoolIndicator(value: dbObject.isValid, trueColor: .green, falseColor: .red)
                 }
@@ -40,13 +63,159 @@ struct DBDetailInspectorView: View {
             switch OracleObjectType(rawValue: dbObject.type) {
             case .table, .view:
                 DBTableInspectorSections(dbObject: $dbObject)
+            case .trigger:
+                DBTriggerLookupSections(name: dbObject.name, owner: dbObject.owner)
+            case .index:
+                DBIndexLookupSections(name: dbObject.name, owner: dbObject.owner)
             default:
                 EmptyView()
             }
         }
         .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
     }
 }
+
+// MARK: - Column-level inspector
+
+private struct ColumnInspector: View {
+    let column: DBCacheTableColumn
+
+    var body: some View {
+        Form {
+            Section("Identification") {
+                LabeledContent("Column ID", value: (column.columnID as? Int)?.formatted() ?? "")
+                LabeledContent("Internal ID", value: column.internalColumnID.formatted())
+                LabeledContent("Column Name", value: column.columnName)
+            }
+
+            Section("Type") {
+                LabeledContent("Datatype", value: column.dataType)
+                LabeledContent("Datatype Owner", value: column.dataTypeOwner)
+                LabeledContent("Length", value: column.length.formatted())
+                LabeledContent("Precision", value: (column.precision as? Int)?.formatted() ?? "")
+                LabeledContent("Scale", value: (column.scale as? Int)?.formatted() ?? "")
+            }
+
+            Section("Nulls") {
+                LabeledContent("Nullable", value: column.isNullable ? "Yes" : "No")
+                LabeledContent("Nulls", value: column.numNulls.formatted())
+                LabeledContent("Distinct", value: column.numDistinct.formatted())
+            }
+
+            Section("Attributes") {
+                LabeledContent("Identity", value: column.isIdentity ? "Yes" : "No")
+                LabeledContent("Hidden", value: column.isHidden ? "Yes" : "No")
+                LabeledContent("Virtual", value: column.isVirtual ? "Yes" : "No")
+                LabeledContent("Sys Gen", value: column.isSysGen ? "Yes" : "No")
+            }
+
+            Section("Default") {
+                Text(column.defaultValue ?? "")
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .lineLimit(nil)
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+// MARK: - Index-level inspector
+
+private struct IndexInspector: View {
+    let index: DBCacheIndex
+
+    var body: some View {
+        Form {
+            Section("Identification") {
+                LabeledContent("Owner", value: index.owner)
+                LabeledContent("Name", value: index.name)
+                LabeledContent("Type", value: index.type)
+                LabeledContent("Tablespace", value: index.tablespaceName)
+                LabeledContent("Degree", value: index.degree)
+            }
+
+            Section("Table") {
+                LabeledContent("Owner", value: index.tableOwner)
+                LabeledContent("Name", value: index.tableName)
+            }
+
+            Section("Statistics") {
+                LabeledContent("Rows", value: index.numRows.formatted())
+                LabeledContent("Distinct Keys", value: index.distinctKeys.formatted())
+                LabeledContent("Leaf Blocks", value: index.leafBlocks.formatted())
+                LabeledContent("Clustering Factor", value: index.clusteringFactor.formatted())
+                LabeledContent("Avg Leaf / Key", value: index.avgLeafBlocksPerKey.formatted(.number.precision(.fractionLength(2))))
+                LabeledContent("Avg Data / Key", value: index.avgDataBlocksPerKey.formatted(.number.precision(.fractionLength(2))))
+                LabeledContent("Sample Size", value: index.sampleSize.formatted())
+                LabeledContent("Last Analyzed",
+                               value: index.lastAnalyzed?
+                                .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
+            }
+
+            Section("Attributes") {
+                LabeledContent("Unique") { BoolIndicator(value: index.isUnique) }
+                LabeledContent("Visible") { BoolIndicator(value: index.isVisible) }
+                LabeledContent("Partitioned") { BoolIndicator(value: index.isPartitioned) }
+                LabeledContent("Valid") {
+                    BoolIndicator(value: index.isValid, trueColor: .green, falseColor: .red)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+// MARK: - Trigger-level inspector
+
+private struct TriggerInspector: View {
+    let trigger: DBCacheTrigger
+
+    var body: some View {
+        Form {
+            Section("Identification") {
+                LabeledContent("Owner", value: trigger.owner)
+                LabeledContent("Name", value: trigger.name)
+                LabeledContent("Type", value: trigger.type)
+                LabeledContent("Action Type", value: trigger.actionType)
+                LabeledContent("Event", value: trigger.event)
+            }
+
+            Section("Trigger") {
+                LabeledContent("When", value: trigger.whenClause ?? Constants.nullValue)
+                LabeledContent("Column", value: trigger.columnName ?? Constants.nullValue)
+                LabeledContent("Referencing", value: trigger.referencingNames ?? Constants.nullValue)
+                LabeledContent("Description", value: trigger.descr ?? Constants.nullValue)
+            }
+
+            Section("Base Object") {
+                LabeledContent("Type", value: trigger.objectType)
+                LabeledContent("Owner", value: trigger.objectOwner ?? Constants.nullValue)
+                LabeledContent("Name", value: trigger.objectName ?? Constants.nullValue)
+            }
+
+            Section("Firing") {
+                LabeledContent("Before Row") { BoolIndicator(value: trigger.isBeforeRow) }
+                LabeledContent("After Row") { BoolIndicator(value: trigger.isAfterRow) }
+                LabeledContent("Before Statement") { BoolIndicator(value: trigger.isBeforeStatement) }
+                LabeledContent("After Statement") { BoolIndicator(value: trigger.isAfterStatement) }
+                LabeledContent("Instead Of") { BoolIndicator(value: trigger.isInsteadOfRow) }
+                LabeledContent("Cross Edition") { BoolIndicator(value: trigger.isCrossEdition) }
+                LabeledContent("Fire Once") { BoolIndicator(value: trigger.isFireOnce) }
+                LabeledContent("Enabled") {
+                    BoolIndicator(value: trigger.isEnabled, trueColor: .green, falseColor: .red)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+// MARK: - Type-specific sections for ObjectInspector
 
 /// Statistics + storage rows pulled from `DBCacheTable`. Hidden when no
 /// matching row exists yet (cache hasn't fetched details for this object).
@@ -86,6 +255,70 @@ struct DBTableInspectorSections: View {
                     LabeledContent("Read Only") {
                         BoolIndicator(value: tbl.isReadOnly)
                     }
+                }
+            }
+        }
+    }
+}
+
+/// When the sidebar selection is an Index object directly (not a child row
+/// of a table), look it up by name+owner and surface the same fields as
+/// `IndexInspector`.
+private struct DBIndexLookupSections: View {
+    @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
+
+    init(name: String, owner: String) {
+        _indexes = FetchRequest<DBCacheIndex>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
+        )
+    }
+
+    var body: some View {
+        if let idx = indexes.first {
+            Section("Statistics") {
+                LabeledContent("Rows", value: idx.numRows.formatted())
+                LabeledContent("Last Analyzed",
+                               value: idx.lastAnalyzed?
+                                .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
+            }
+            Section("Attributes") {
+                LabeledContent("Partitioned") { BoolIndicator(value: idx.isPartitioned) }
+                LabeledContent("Unique") { BoolIndicator(value: idx.isUnique) }
+                LabeledContent("Visible") { BoolIndicator(value: idx.isVisible) }
+            }
+        }
+    }
+}
+
+/// When the sidebar selection is a Trigger object directly (not a child row
+/// of a table), look it up by name+owner and surface key fields.
+private struct DBTriggerLookupSections: View {
+    @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
+
+    init(name: String, owner: String) {
+        _triggers = FetchRequest<DBCacheTrigger>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
+        )
+    }
+
+    var body: some View {
+        if let trigger = triggers.first {
+            Section("Trigger") {
+                LabeledContent("Type", value: trigger.type)
+                LabeledContent("Action Type", value: trigger.actionType)
+                LabeledContent("Event", value: trigger.event)
+                LabeledContent("When", value: trigger.whenClause ?? Constants.nullValue)
+            }
+            Section("Base Object") {
+                LabeledContent("Type", value: trigger.objectType)
+                LabeledContent("Owner", value: trigger.objectOwner ?? Constants.nullValue)
+                LabeledContent("Name", value: trigger.objectName ?? Constants.nullValue)
+            }
+            Section("Firing") {
+                LabeledContent("Enabled") {
+                    BoolIndicator(value: trigger.isEnabled, trueColor: .green, falseColor: .red)
                 }
             }
         }

--- a/Macintora/DBObjectsBrowser/DBDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBDetailView.swift
@@ -4,21 +4,25 @@
 //
 //  Created by Ilia Sazonov on 8/31/22.
 //
-//  v2 layout (design B picks consolidated):
+//  Layout:
 //   ┌──────────────────────────────────────────────────────────┐
-//   │  icon + qualified name              [Edit Source][↻][⌘I] │  ← header strip
-//   ├──────────────────────────────────────────────────────────┤
-//   │  ▶  Object details · Owner / ID / Last DDL · ● Valid      │  ← collapsed accordion
+//   │  icon + qualified name      [Edit Source][↻][Inspector ⌘I]│  ← header strip
 //   ├──────────────────────────────────────────────────────────┤
 //   │  ┌──────────────────────────┐  Tabs:                      │
-//   │  │ Columns content         │   Columns · Indexes ·        │  ← top-level tabs
-//   │  │ (gets the room)         │   Triggers · SQL             │
-//   │  └──────────────────────────┘                              │
+//   │  │ Content                  │   Columns · Indexes ·       │
+//   │  │ (gets the room)          │   Triggers · SQL            │
+//   │  └──────────────────────────┘                             │
 //   └──────────────────────────────────────────────────────────┘
 //                                              + right Inspector
+//   The inspector is the single home for object-level metadata
+//   (replacing the older collapsible "Object details" accordion).
+//   When a row is selected inside a sub-tab (Columns, Indexes,
+//   Triggers), the inspector swaps to that child's detail.
+//
 
 import SwiftUI
 import os
+import AppKit
 
 /// `Tab` retained as a type for back-compat with persisted `DBCacheInputValue`
 /// payloads but the dual Main/Details tab split is gone.
@@ -27,11 +31,20 @@ enum DBDetailTab: String, Codable, Hashable, CaseIterable, Sendable {
     case details
 }
 
+/// Unified child-row selection for table sub-tabs. The inspector dispatches on
+/// this to show a row-specific detail; when `nil` it shows object-level info
+/// for the current `dbObject`.
+enum DBChildSelection {
+    case column(DBCacheTableColumn)
+    case index(DBCacheIndex)
+    case trigger(DBCacheTrigger)
+}
+
 struct DBDetailView: View {
     @Binding var dbObject: DBCacheObject
     @EnvironmentObject private var cache: DBCacheVM
-    @AppStorage("dbDetailAccordionOpen") private var accordionOpen = false
     @AppStorage("dbDetailInspectorOpen") private var inspectorOpen = true
+    @State private var childSelection: DBChildSelection?
 
     var body: some View {
         // Inline right-rail composition. We're not using `.inspector` here
@@ -42,29 +55,27 @@ struct DBDetailView: View {
             VStack(alignment: .leading, spacing: 0) {
                 DBDetailViewHeader(
                     dbObject: $dbObject,
-                    inspectorOpen: $inspectorOpen,
-                    accordionOpen: $accordionOpen
+                    inspectorOpen: $inspectorOpen
                 )
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
 
                 Divider()
 
-                DBDetailAccordion(dbObject: $dbObject, isOpen: $accordionOpen)
-
-                DBDetailContent(dbObject: $dbObject)
+                DBDetailContent(dbObject: $dbObject, childSelection: $childSelection)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if inspectorOpen {
                 Divider()
-                DBDetailInspectorView(dbObject: $dbObject)
+                DBDetailInspectorView(dbObject: $dbObject, childSelection: $childSelection)
                     .frame(width: 280)
-                    .background(.regularMaterial)
+                    .background(SidebarVisualEffect())
                     .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
         .animation(.easeInOut(duration: 0.18), value: inspectorOpen)
+        .onChange(of: dbObject.objectId) { childSelection = nil }
     }
 }
 
@@ -73,7 +84,6 @@ struct DBDetailView: View {
 struct DBDetailViewHeader: View {
     @Binding var dbObject: DBCacheObject
     @Binding var inspectorOpen: Bool
-    @Binding var accordionOpen: Bool
     @State private var isRefreshing = false
     @State private var isLoadingSource = false
     @EnvironmentObject private var cache: DBCacheVM
@@ -132,12 +142,18 @@ struct DBDetailViewHeader: View {
                 ProgressView().controlSize(.small)
             }
 
-            Button("Inspector", systemImage: "sidebar.right") {
+            Button {
                 inspectorOpen.toggle()
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "sidebar.right")
+                    Text("Inspector")
+                    KeyBadge(label: "\u{2318}I")
+                }
             }
             .buttonStyle(.borderless)
-            .keyboardShortcut("i", modifiers: [.option, .command])
-            .help("Toggle Inspector (⌥⌘I)")
+            .keyboardShortcut("i", modifiers: [.command])
+            .help("Toggle Inspector (\u{2318}I)")
         }
     }
 
@@ -169,315 +185,49 @@ struct DBDetailViewHeader: View {
     }
 }
 
-// MARK: - Accordion ("Object details")
-
-/// Collapsed: one-line summary strip. Expanded: 4-column grid of metadata.
-/// Default state is collapsed because Columns/Source typically deserves the
-/// space; users open the accordion when they specifically want metadata.
-struct DBDetailAccordion: View {
-    @Binding var dbObject: DBCacheObject
-    @Binding var isOpen: Bool
-
-    private var oracleType: OracleObjectType {
-        OracleObjectType(rawValue: dbObject.type) ?? .unknown
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            Button {
-                withAnimation(.easeInOut(duration: 0.18)) { isOpen.toggle() }
-            } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: isOpen ? "chevron.down" : "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 12)
-                    Text("Object details")
-                        .font(.callout)
-                        .bold()
-                    if !isOpen {
-                        AccordionSummary(dbObject: dbObject)
-                            .padding(.leading, 6)
-                        if oracleType == .trigger {
-                            TriggerAccordionSummary(name: dbObject.name, owner: dbObject.owner)
-                        }
-                        if oracleType == .index {
-                            IndexAccordionSummary(name: dbObject.name, owner: dbObject.owner)
-                        }
-                    }
-                    Spacer(minLength: 0)
-                    Text("⌘I")
-                        .font(.system(size: 10, design: .monospaced))
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(RoundedRectangle(cornerRadius: 3).fill(Color.secondary.opacity(0.12)))
-                        .foregroundStyle(.tertiary)
-                }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 6)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
-            .keyboardShortcut("i", modifiers: [.command])
-            .background(Color.secondary.opacity(0.06))
-
-            if isOpen {
-                VStack(spacing: 0) {
-                    AccordionExpanded(dbObject: dbObject)
-                    if oracleType == .trigger {
-                        TriggerAccordionExpanded(name: dbObject.name, owner: dbObject.owner)
-                    }
-                    if oracleType == .index {
-                        IndexAccordionExpanded(name: dbObject.name, owner: dbObject.owner)
-                    }
-                }
-                .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-
-            Divider()
-        }
-    }
-}
-
-private struct AccordionSummary: View {
-    let dbObject: DBCacheObject
-
-    var body: some View {
-        HStack(spacing: 14) {
-            SummaryItem(label: "Owner", value: dbObject.owner)
-            SummaryItem(label: "ID", value: dbObject.objectId.formatted(.number.grouping(.never)))
-            if let ddl = dbObject.lastDDLDate {
-                SummaryItem(label: "Last DDL", value: ddl.formatted(date: .abbreviated, time: .omitted))
-            }
-            HStack(spacing: 4) {
-                Circle()
-                    .fill(dbObject.isValid ? Color.green : Color.red)
-                    .frame(width: 6, height: 6)
-                Text(dbObject.isValid ? "Valid" : "Invalid")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .font(.caption)
-    }
-}
-
-private struct IndexAccordionSummary: View {
-    @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
-
-    init(name: String, owner: String) {
-        _indexes = FetchRequest<DBCacheIndex>(
-            sortDescriptors: [],
-            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
-        )
-    }
-
-    var body: some View {
-        let idx = indexes.first
-        HStack(spacing: 14) {
-            SummaryItem(label: "Rows", value: idx?.numRows.formatted() ?? Constants.nullValue)
-            if let analyzed = idx?.lastAnalyzed {
-                SummaryItem(label: "Analyzed", value: analyzed.formatted(date: .abbreviated, time: .omitted))
-            }
-            HStack(spacing: 4) {
-                Text("Partitioned")
-                    .foregroundStyle(.tertiary)
-                BoolIndicator(value: idx?.isPartitioned ?? false)
-            }
-        }
-        .font(.caption)
-    }
-}
-
-private struct SummaryItem: View {
+/// Compact monospaced key-shortcut badge (e.g. "⌘I"). Renders the same chip
+/// styling that used to live next to the dropped "Object details" accordion.
+struct KeyBadge: View {
     let label: String
-    let value: String
 
     var body: some View {
-        HStack(spacing: 4) {
-            Text(label)
-                .foregroundStyle(.tertiary)
-            Text(value)
-                .foregroundStyle(.secondary)
-        }
+        Text(label)
+            .font(.system(size: 10, design: .monospaced))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(RoundedRectangle(cornerRadius: 3).fill(Color.secondary.opacity(0.12)))
+            .foregroundStyle(.tertiary)
     }
 }
 
-private struct AccordionExpanded: View {
-    let dbObject: DBCacheObject
-
-    private let columns = [GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading)]
-
-    var body: some View {
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
-            Field(label: "Owner", value: dbObject.owner)
-            Field(label: "Object ID", value: dbObject.objectId.formatted(.number.grouping(.never)))
-            Field(label: "Created",
-                  value: dbObject.createDate?
-                    .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
-            Field(label: "Last DDL",
-                  value: dbObject.lastDDLDate?
-                    .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
-            Field(label: "Edition", value: dbObject.editionName ?? Constants.nullValue)
-            Field(label: "Editionable", value: dbObject.isEditionable ? "Yes" : "No")
-            Field(label: "Valid") {
-                BoolIndicator(value: dbObject.isValid, trueColor: .green, falseColor: .red)
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(Color.secondary.opacity(0.04))
-    }
-}
-
-private struct IndexAccordionExpanded: View {
-    @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
-
-    init(name: String, owner: String) {
-        _indexes = FetchRequest<DBCacheIndex>(
-            sortDescriptors: [],
-            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
-        )
+/// `.sidebar` material backed by NSVisualEffectView so the inspector matches
+/// the translucent vibrancy of the navigation sidebar instead of the flat
+/// `.regularMaterial` panel look. `Material.bar` is the closest SwiftUI-native
+/// option but reads as a toolbar; the sidebar material is what we actually
+/// want here.
+struct SidebarVisualEffect: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let v = NSVisualEffectView()
+        v.material = .sidebar
+        v.blendingMode = .behindWindow
+        v.state = .followsWindowActiveState
+        return v
     }
 
-    private let columns = [GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading)]
-
-    var body: some View {
-        let idx = indexes.first
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
-            Field(label: "Partitioned") {
-                BoolIndicator(value: idx?.isPartitioned ?? false)
-            }
-            Field(label: "Row Count", value: idx?.numRows.formatted() ?? Constants.nullValue)
-            Field(label: "Last Analyzed",
-                  value: idx?.lastAnalyzed?
-                    .formatted(date: .abbreviated, time: .shortened) ?? Constants.nullValue)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(Color.secondary.opacity(0.04))
-    }
-}
-
-private struct Field<Content: View>: View {
-    let label: String
-    @ViewBuilder let content: () -> Content
-
-    init(label: String, @ViewBuilder content: @escaping () -> Content) {
-        self.label = label
-        self.content = content
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(label.uppercased())
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(.tertiary)
-                .kerning(0.4)
-            content()
-                .font(.callout)
-        }
-    }
-}
-
-private extension Field where Content == Text {
-    init(label: String, value: String) {
-        self.init(label: label) { Text(value) }
-    }
-}
-
-// MARK: - Trigger accordion extras
-
-private struct TriggerAccordionSummary: View {
-    @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
-
-    init(name: String, owner: String) {
-        _triggers = FetchRequest<DBCacheTrigger>(
-            sortDescriptors: [],
-            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
-        )
-    }
-
-    var body: some View {
-        let trigger = triggers.first
-        HStack(spacing: 14) {
-            SummaryItem(label: "Type", value: trigger?.type ?? Constants.nullValue)
-            HStack(spacing: 4) {
-                Circle()
-                    .fill((trigger?.isEnabled ?? false) ? Color.green : Color.red)
-                    .frame(width: 6, height: 6)
-                Text((trigger?.isEnabled ?? false) ? "Enabled" : "Disabled")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .font(.caption)
-    }
-}
-
-private struct TriggerAccordionExpanded: View {
-    @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
-
-    init(name: String, owner: String) {
-        _triggers = FetchRequest<DBCacheTrigger>(
-            sortDescriptors: [],
-            predicate: NSPredicate(format: "name_ = %@ and owner_ = %@", name, owner)
-        )
-    }
-
-    private let columns = [GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading),
-                           GridItem(.flexible(), alignment: .topLeading)]
-
-    var body: some View {
-        let trigger = triggers.first
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
-            Field(label: "Type", value: trigger?.type ?? Constants.nullValue)
-            Field(label: "When", value: trigger?.whenClause ?? Constants.nullValue)
-            Field(label: "Column", value: trigger?.columnName ?? Constants.nullValue)
-            Field(label: "Base Type", value: trigger?.objectType ?? Constants.nullValue)
-            Field(label: "Base Owner", value: trigger?.objectOwner ?? Constants.nullValue)
-            Field(label: "Base Name", value: trigger?.objectName ?? Constants.nullValue)
-            Field(label: "Referencing", value: trigger?.referencingNames ?? Constants.nullValue)
-            Field(label: "Description", value: trigger?.descr ?? Constants.nullValue)
-
-            Field(label: "Before Row") { BoolIndicator(value: trigger?.isBeforeRow ?? false) }
-            Field(label: "After Row") { BoolIndicator(value: trigger?.isAfterRow ?? false) }
-            Field(label: "Before Statement") { BoolIndicator(value: trigger?.isBeforeStatement ?? false) }
-            Field(label: "After Statement") { BoolIndicator(value: trigger?.isAfterStatement ?? false) }
-            Field(label: "Instead Of") { BoolIndicator(value: trigger?.isInsteadOfRow ?? false) }
-            Field(label: "Cross Edition") { BoolIndicator(value: trigger?.isCrossEdition ?? false) }
-            Field(label: "Fire Once") { BoolIndicator(value: trigger?.isFireOnce ?? false) }
-            Field(label: "Enabled") {
-                BoolIndicator(value: trigger?.isEnabled ?? false, trueColor: .green, falseColor: .red)
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(Color.secondary.opacity(0.04))
-    }
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
 }
 
 // MARK: - Content router
 
-/// Routes to the right detail body for the selected object's type. Drops the
-/// old `Main` (form-style overview) tab — its content now lives in the
-/// accordion + inspector.
+/// Routes to the right detail body for the selected object's type.
 struct DBDetailContent: View {
     @Binding var dbObject: DBCacheObject
+    @Binding var childSelection: DBChildSelection?
 
     var body: some View {
         switch OracleObjectType(rawValue: dbObject.type) ?? .unknown {
         case .table, .view:
-            DBTableDetailView(dbObject: $dbObject)
+            DBTableDetailView(dbObject: $dbObject, childSelection: $childSelection)
         case .type, .package, .procedure, .function:
             CodeDetailContent(dbObject: $dbObject)
         case .trigger:

--- a/Macintora/DBObjectsBrowser/DBSearchPalette.swift
+++ b/Macintora/DBObjectsBrowser/DBSearchPalette.swift
@@ -296,18 +296,18 @@ private struct SearchResultRow: View {
         return parts.joined(separator: " · ")
     }
 
-    /// Object name with the matched substring emphasised.
+    /// Object name with the matched substring emphasised. Builds an
+    /// `AttributedString` rather than concatenating `Text` values — the
+    /// `Text + Text` operator was deprecated in macOS 26 in favour of
+    /// attributed strings / Text interpolation.
     private var highlightedName: Text {
-        let name = object.name
-        guard !query.isEmpty,
-              let range = name.range(of: query, options: [.caseInsensitive])
-        else { return Text(name) }
-        let pre = String(name[name.startIndex..<range.lowerBound])
-        let mid = String(name[range])
-        let post = String(name[range.upperBound...])
-        return Text(pre)
-            + Text(mid).foregroundStyle(.tint).fontWeight(.semibold)
-            + Text(post)
+        var attr = AttributedString(object.name)
+        if !query.isEmpty,
+           let range = attr.range(of: query, options: [.caseInsensitive]) {
+            attr[range].foregroundColor = .accentColor
+            attr[range].font = .body.weight(.semibold)
+        }
+        return Text(attr)
     }
 }
 

--- a/Macintora/DBObjectsBrowser/DBTableDetailView.swift
+++ b/Macintora/DBObjectsBrowser/DBTableDetailView.swift
@@ -22,11 +22,13 @@ struct DBTableDetailView: View {
     @AppStorage("dbTableDetailSelectedTab") private var selectedTab: DBTableDetailTab = .columns
     @FetchRequest private var tables: FetchedResults<DBCacheTable>
     @Binding var dbObject: DBCacheObject
+    @Binding var childSelection: DBChildSelection?
     @State var cursorPosition = (0,0)
     @State private var selection: NSRange?
 
-    init(dbObject: Binding<DBCacheObject>) {
+    init(dbObject: Binding<DBCacheObject>, childSelection: Binding<DBChildSelection?>) {
         self._dbObject = dbObject
+        self._childSelection = childSelection
         _tables = FetchRequest<DBCacheTable>(sortDescriptors: [], predicate: NSPredicate.init(format: "name_ = %@ and owner_ = %@", dbObject.name.wrappedValue, dbObject.owner.wrappedValue))
     }
 
@@ -35,18 +37,18 @@ struct DBTableDetailView: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Columns", systemImage: "rectangle.split.3x1", value: DBTableDetailTab.columns) {
-                TableTableColumnsView(dbObject: dbObject)
+                TableTableColumnsView(dbObject: dbObject, childSelection: $childSelection)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
 
             if !(tables.first?.isView ?? false) {
                 Tab("Indexes", systemImage: "list.bullet.indent", value: DBTableDetailTab.indexes) {
-                    TableIndexListView(dbObject: dbObject)
+                    TableIndexListView(dbObject: dbObject, childSelection: $childSelection)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
 
                 Tab("Triggers", systemImage: "bolt", value: DBTableDetailTab.triggers) {
-                    TableTriggerListView(dbObject: dbObject)
+                    TableTriggerListView(dbObject: dbObject, childSelection: $childSelection)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
             }
@@ -57,6 +59,7 @@ struct DBTableDetailView: View {
                 }
             }
         }
+        .onChange(of: selectedTab) { childSelection = nil }
     }
 
     private var viewSqlTab: some View {
@@ -89,16 +92,3 @@ struct DBTableDetailView: View {
         }
     }
 }
-
-//struct DBTableDetailView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        var cache = DBCacheVM.init(preview: true)
-//        let objCache = DBCacheObject(context: cache.persistenceController.container.viewContext)
-//        objCache.owner = "OWNER"
-//        objCache.name = "NAME"
-//        objCache.type = "TABLE"
-//        objCache.lastDDLDate = .now
-//        return DBTableDetailView(dbObject: objCache)
-//            .environment(\.managedObjectContext, cache.persistenceController.container.viewContext)
-//    }
-//}

--- a/Macintora/DBObjectsBrowser/TableIndexListView.swift
+++ b/Macintora/DBObjectsBrowser/TableIndexListView.swift
@@ -12,12 +12,13 @@ struct TableIndexListView: View {
     @Environment(\.managedObjectContext) var context
     @FetchRequest private var indexes: FetchedResults<DBCacheIndex>
     private var dbObject: DBCacheObject
+    @Binding var childSelection: DBChildSelection?
     @State private var selectedIndexRow: DBCacheIndex.ID?
 
-
-    init(dbObject: DBCacheObject) {
+    init(dbObject: DBCacheObject, childSelection: Binding<DBChildSelection?>) {
         self.dbObject = dbObject
         _indexes = FetchRequest<DBCacheIndex>(sortDescriptors: [NSSortDescriptor(key: "name_", ascending: true)], predicate: NSPredicate.init(format: "tableName_ = %@ and tableOwner_ = %@", dbObject.name, dbObject.owner))
+        _childSelection = childSelection
     }
 
     var body: some View {
@@ -41,12 +42,10 @@ struct TableIndexListView: View {
             TableColumn("Degree", value: \.degree )
         }
         .font(.system(.body, design: .monospaced))
+        .onChange(of: selectedIndexRow) { _, newID in
+            childSelection = newID
+                .flatMap { id in indexes.first { $0.id == id } }
+                .map(DBChildSelection.index)
+        }
     }
-
 }
-
-//struct TableIndexListView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        TableIndexListView()
-//    }
-//}

--- a/Macintora/DBObjectsBrowser/TableTableColumnsView.swift
+++ b/Macintora/DBObjectsBrowser/TableTableColumnsView.swift
@@ -9,99 +9,85 @@ import SwiftUI
 struct TableTableColumnsView: View {
     @Environment(\.managedObjectContext) var context
     @FetchRequest private var columns: FetchedResults<DBCacheTableColumn>
+    @Binding var childSelection: DBChildSelection?
     @State private var selectedRow: DBCacheTableColumn.ID?
-    @State private var showInspector = false
+    // Default to the fetch-order sort (internal column id). Per Apple docs the
+    // Table itself needs a `sortOrder` binding for header-click sorts to flow;
+    // without it, `value:` columns *look* sortable but clicks do nothing.
+    @State private var sortOrder: [KeyPathComparator<DBCacheTableColumn>] = [
+        KeyPathComparator(\DBCacheTableColumn.internalColumnID)
+    ]
 
-    init(dbObject: DBCacheObject) {
+    init(dbObject: DBCacheObject, childSelection: Binding<DBChildSelection?>) {
         _columns = FetchRequest<DBCacheTableColumn>(
             sortDescriptors: [NSSortDescriptor(keyPath: \DBCacheTableColumn.internalColumnID, ascending: true)],
             predicate: NSPredicate(format: "tableName_ = %@ and owner_ = %@", dbObject.name, dbObject.owner)
         )
-    }
-
-    @ViewBuilder
-    fileprivate var selectedColumn: DBCacheTableColumn? {
-        guard let id = selectedRow else { return nil }
-        return columns.first { $0.id == id }
+        _childSelection = childSelection
     }
 
     var body: some View {
-        Table(columns, selection: $selectedRow) {
-            TableColumn("Internal ID") { value in
-                Text(value.internalColumnID.formatted())
+        // String columns combine `value:` (sort key) with a content closure
+        // via the `(_, value:, comparator:, content:)` initializer (default
+        // `.localizedStandard` comparator). Non-String columns use the
+        // `(_, sortUsing:, content:)` form with an explicit
+        // `KeyPathComparator`. Both forms erase to
+        // `KeyPathComparator<DBCacheTableColumn>` so they share a single
+        // `sortOrder` array.
+        let sorted = columns.sorted(using: sortOrder)
+        Table(sorted, selection: $selectedRow, sortOrder: $sortOrder) {
+            TableColumn("Column ID", sortUsing: KeyPathComparator(\DBCacheTableColumn.columnIDSortKey)) { value in
+                cellText((value.columnID as? Int)?.formatted() ?? "", hidden: value.isHidden)
             }
-            TableColumn("Column Name", value: \.columnName)
-            TableColumn("Data Type", value: \.dataType)
-            TableColumn("Data Type Mod", value: \.dataTypeMod)
-            TableColumn("Length") { value in
-                Text(value.length.formatted())
+            TableColumn("Column Name", value: \.columnName) { value in
+                cellText(value.columnName, hidden: value.isHidden)
             }
-            TableColumn("Nullable") { value in
+            TableColumn("Datatype", value: \.dataType) { value in
+                cellText(value.dataType, hidden: value.isHidden)
+            }
+            TableColumn("Length", sortUsing: KeyPathComparator(\DBCacheTableColumn.length)) { value in
+                cellText(value.length.formatted(), hidden: value.isHidden)
+            }
+            TableColumn("Nullable", sortUsing: KeyPathComparator(\DBCacheTableColumn.isNullableSortKey)) { value in
                 BoolIndicator(value: value.isNullable)
+                    .opacity(value.isHidden ? 0.6 : 1)
             }
-            TableColumn("Identity") { value in
+            TableColumn("Identity", sortUsing: KeyPathComparator(\DBCacheTableColumn.isIdentitySortKey)) { value in
                 BoolIndicator(value: value.isIdentity)
+                    .opacity(value.isHidden ? 0.6 : 1)
             }
-            TableColumn("Hidden") { value in
-                BoolIndicator(value: value.isHidden)
-            }
-            TableColumn("Default") { value in
-                Text(value.defaultValue ?? "")
+            TableColumn("Default", sortUsing: KeyPathComparator(\DBCacheTableColumn.defaultValueSortKey)) { value in
+                cellText(value.defaultValue ?? "", hidden: value.isHidden)
             }
         }
         .font(.system(.body, design: .monospaced))
-        .onChange(of: selectedRow) { showInspector = $0 != nil }
-        .inspector(isPresented: $showInspector) {
-            if let col = selectedColumn {
-                ColumnInspector(column: col)
-            } else {
-                ContentUnavailableView("No column selected", systemImage: "rectangle.split.3x1")
-            }
-        }
-        .inspectorColumnWidth(ideal: 280)
-    }
-
-    private struct ColumnInspector: View {
-        let column: DBCacheTableColumn
-
-        var body: some View {
-            Form {
-                Section("Identification") {
-                    LabeledContent("Column ID", value: (column.columnID as? Int)?.formatted() ?? "")
-                    LabeledContent("Internal ID", value: column.internalColumnID.formatted())
-                    LabeledContent("Column Name", value: column.columnName)
-                }
-
-                Section("Type") {
-                    LabeledContent("Data Type", value: column.dataType)
-                    LabeledContent("Data Type Mod", value: column.dataTypeMod)
-                    LabeledContent("Data Type Owner", value: column.dataTypeOwner)
-                    LabeledContent("Length", value: column.length.formatted())
-                    LabeledContent("Precision", value: (column.precision as? Int)?.formatted() ?? "")
-                    LabeledContent("Scale", value: (column.scale as? Int)?.formatted() ?? "")
-                }
-
-                Section("Nulls") {
-                    LabeledContent("Nullable", value: column.isNullable ? "Yes" : "No")
-                    LabeledContent("Nulls", value: column.numNulls.formatted())
-                    LabeledContent("Distinct", value: column.numDistinct.formatted())
-                }
-
-                Section("Attributes") {
-                    LabeledContent("Identity", value: column.isIdentity ? "Yes" : "No")
-                    LabeledContent("Hidden", value: column.isHidden ? "Yes" : "No")
-                    LabeledContent("Virtual", value: column.isVirtual ? "Yes" : "No")
-                    LabeledContent("Sys Gen", value: column.isSysGen ? "Yes" : "No")
-                }
-
-                Section("Default") {
-                    Text(column.defaultValue ?? "")
-                        .font(.system(.body, design: .monospaced))
-                        .textSelection(.enabled)
-                        .lineLimit(nil)
-                }
-            }
-            .formStyle(.grouped)
+        .onChange(of: selectedRow) { _, newID in
+            childSelection = newID
+                .flatMap { id in columns.first { $0.id == id } }
+                .map(DBChildSelection.column)
         }
     }
+
+    @ViewBuilder
+    private func cellText(_ s: String, hidden: Bool) -> some View {
+        if hidden {
+            Text(s).italic().foregroundStyle(.secondary)
+        } else {
+            Text(s)
+        }
+    }
+}
+
+// Sort-key shims for properties that aren't directly Comparable.
+// `KeyPathComparator` requires `Value: Comparable & Sendable`; NSNumber? and
+// Optional<String> don't qualify. Columns without a value (hidden/system
+// columns whose `columnID` is null) sort after the rest by collapsing nil
+// to `Int.max` / `""`.
+extension DBCacheTableColumn {
+    @objc var columnIDSortKey: Int { (columnID as? Int) ?? .max }
+    @objc var defaultValueSortKey: String { defaultValue ?? "" }
+    // Bool isn't Comparable, so `KeyPathComparator(\.isFoo)` won't compile;
+    // promote to Int (0 = false, 1 = true) so unticked rows sort first.
+    @objc var isNullableSortKey: Int { isNullable ? 1 : 0 }
+    @objc var isIdentitySortKey: Int { isIdentity ? 1 : 0 }
 }

--- a/Macintora/DBObjectsBrowser/TableTriggerListView.swift
+++ b/Macintora/DBObjectsBrowser/TableTriggerListView.swift
@@ -12,16 +12,17 @@ struct TableTriggerListView: View {
     @Environment(\.managedObjectContext) var context
     @FetchRequest private var triggers: FetchedResults<DBCacheTrigger>
     private var dbObject: DBCacheObject
-    @State private var selectedIndexRow: DBCacheTrigger.ID?
+    @Binding var childSelection: DBChildSelection?
+    @State private var selectedTriggerRow: DBCacheTrigger.ID?
 
-
-    init(dbObject: DBCacheObject) {
+    init(dbObject: DBCacheObject, childSelection: Binding<DBChildSelection?>) {
         self.dbObject = dbObject
         _triggers = FetchRequest<DBCacheTrigger>(sortDescriptors: [], predicate: NSPredicate.init(format: "objectName = %@ and objectOwner = %@", dbObject.name, dbObject.owner))
+        _childSelection = childSelection
     }
 
     var body: some View {
-        Table(triggers, selection: $selectedIndexRow) {
+        Table(triggers, selection: $selectedTriggerRow) {
             TableColumn("Trigger Name", value: \.name )
             TableColumn("Trigger Owner", value: \.owner )
             TableColumn("Enabled?") { value in
@@ -32,12 +33,10 @@ struct TableTriggerListView: View {
             TableColumn("Event", value: \.event )
         }
         .font(.system(.body, design: .monospaced))
+        .onChange(of: selectedTriggerRow) { _, newID in
+            childSelection = newID
+                .flatMap { id in triggers.first { $0.id == id } }
+                .map(DBChildSelection.trigger)
+        }
     }
-
 }
-
-//struct TableIndexListView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        TableIndexListView()
-//    }
-//}

--- a/MacintoraTests/DBBrowser/TableTableColumnsSortTests.swift
+++ b/MacintoraTests/DBBrowser/TableTableColumnsSortTests.swift
@@ -1,0 +1,189 @@
+//
+//  TableTableColumnsSortTests.swift
+//  MacintoraTests
+//
+//  Pins the column-header sort behaviour of TableTableColumnsView. The view
+//  binds Table's `sortOrder:` to a `[KeyPathComparator<DBCacheTableColumn>]`
+//  and sorts the FetchedResults via `Array.sorted(using:)` before handing
+//  them to Table. These tests exercise that same sort against an in-memory
+//  Core Data store, so a regression that breaks the sort pipeline (wrong
+//  comparator target, missing sortOrder binding, etc.) fails here without
+//  needing a real UI harness.
+//
+
+import XCTest
+import CoreData
+@testable import Macintora
+
+final class TableTableColumnsSortTests: XCTestCase {
+
+    private var persistence: PersistenceController!
+    private var context: NSManagedObjectContext { persistence.container.viewContext }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistence = PersistenceController(inMemory: true)
+    }
+
+    override func tearDown() async throws {
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func makeColumn(name: String,
+                            dataType: String,
+                            internalID: Int16,
+                            columnID: Int? = nil,
+                            length: Int32 = 0,
+                            isNullable: Bool = false,
+                            isIdentity: Bool = false,
+                            defaultValue: String? = nil,
+                            isHidden: Bool = false) -> DBCacheTableColumn {
+        let c = DBCacheTableColumn(context: context)
+        c.owner_ = "SCOTT"
+        c.tableName_ = "EMP"
+        c.columnName_ = name
+        c.dataType_ = dataType
+        c.internalColumnID = internalID
+        c.columnID = columnID.map { NSNumber(value: $0) }
+        c.length = length
+        c.isNullable = isNullable
+        c.isIdentity = isIdentity
+        c.defaultValue = defaultValue
+        c.isHidden = isHidden
+        return c
+    }
+
+    // MARK: - Sort by Column Name
+
+    func test_sortByColumnName_ascending_ordersAlphabetically() {
+        let charlie = makeColumn(name: "CHARLIE", dataType: "VARCHAR2", internalID: 1)
+        let alpha = makeColumn(name: "ALPHA", dataType: "NUMBER", internalID: 2)
+        let bravo = makeColumn(name: "BRAVO", dataType: "DATE", internalID: 3)
+
+        let sorted = [charlie, alpha, bravo].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.columnName, order: .forward)
+        ])
+
+        XCTAssertEqual(sorted.map(\.columnName), ["ALPHA", "BRAVO", "CHARLIE"])
+    }
+
+    func test_sortByColumnName_descending_reversesOrder() {
+        let alpha = makeColumn(name: "ALPHA", dataType: "NUMBER", internalID: 1)
+        let bravo = makeColumn(name: "BRAVO", dataType: "DATE", internalID: 2)
+        let charlie = makeColumn(name: "CHARLIE", dataType: "VARCHAR2", internalID: 3)
+
+        let sorted = [alpha, bravo, charlie].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.columnName, order: .reverse)
+        ])
+
+        XCTAssertEqual(sorted.map(\.columnName), ["CHARLIE", "BRAVO", "ALPHA"])
+    }
+
+    // MARK: - Sort by Datatype
+
+    func test_sortByDatatype_ascending_groupsLikeTypes() {
+        let a = makeColumn(name: "A", dataType: "VARCHAR2", internalID: 1)
+        let b = makeColumn(name: "B", dataType: "NUMBER", internalID: 2)
+        let c = makeColumn(name: "C", dataType: "DATE", internalID: 3)
+        let d = makeColumn(name: "D", dataType: "NUMBER", internalID: 4)
+
+        let sorted = [a, b, c, d].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.dataType, order: .forward)
+        ])
+
+        XCTAssertEqual(sorted.map(\.dataType), ["DATE", "NUMBER", "NUMBER", "VARCHAR2"])
+    }
+
+    // MARK: - Default fetch-order comparator
+
+    func test_defaultComparator_byInternalID_matchesFetchOrder() {
+        let third = makeColumn(name: "THIRD", dataType: "VARCHAR2", internalID: 3)
+        let first = makeColumn(name: "FIRST", dataType: "NUMBER", internalID: 1)
+        let second = makeColumn(name: "SECOND", dataType: "DATE", internalID: 2)
+
+        let sorted = [third, first, second].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.internalColumnID)
+        ])
+
+        XCTAssertEqual(sorted.map(\.internalColumnID), [1, 2, 3])
+    }
+
+    // MARK: - Empty sort order is a no-op
+
+    func test_emptySortOrder_preservesInputOrder() {
+        let c1 = makeColumn(name: "ZULU", dataType: "VARCHAR2", internalID: 9)
+        let c2 = makeColumn(name: "ALPHA", dataType: "NUMBER", internalID: 1)
+        let c3 = makeColumn(name: "MIKE", dataType: "DATE", internalID: 5)
+
+        let sorted = [c1, c2, c3].sorted(using: [KeyPathComparator<DBCacheTableColumn>]())
+
+        XCTAssertEqual(sorted.map(\.columnName), ["ZULU", "ALPHA", "MIKE"])
+    }
+
+    // MARK: - Sort-key shims for non-Comparable storage
+
+    func test_sortByColumnID_putsNilLast() {
+        // Hidden / system columns have a nil COLUMN_ID; the shim maps nil to
+        // Int.max so they sort after numbered columns regardless of order.
+        let one = makeColumn(name: "A", dataType: "NUMBER", internalID: 1, columnID: 1)
+        let two = makeColumn(name: "B", dataType: "VARCHAR2", internalID: 2, columnID: 2)
+        let hidden = makeColumn(name: "SYS$X", dataType: "RAW", internalID: 3, columnID: nil)
+
+        let sorted = [hidden, two, one].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.columnIDSortKey, order: .forward)
+        ])
+
+        XCTAssertEqual(sorted.map(\.columnName), ["A", "B", "SYS$X"])
+    }
+
+    func test_sortByLength_ascendingByLength() {
+        let short = makeColumn(name: "A", dataType: "VARCHAR2", internalID: 1, length: 10)
+        let long = makeColumn(name: "B", dataType: "VARCHAR2", internalID: 2, length: 4000)
+        let mid = makeColumn(name: "C", dataType: "VARCHAR2", internalID: 3, length: 100)
+
+        let sorted = [long, short, mid].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.length, order: .forward)
+        ])
+
+        XCTAssertEqual(sorted.map(\.length), [10, 100, 4000])
+    }
+
+    func test_sortByNullable_falseBeforeTrue() {
+        let nullable = makeColumn(name: "A", dataType: "NUMBER", internalID: 1, isNullable: true)
+        let notNull = makeColumn(name: "B", dataType: "NUMBER", internalID: 2, isNullable: false)
+
+        let sorted = [nullable, notNull].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.isNullableSortKey, order: .forward)
+        ])
+
+        XCTAssertEqual(sorted.map(\.isNullable), [false, true])
+    }
+
+    func test_sortByIdentity_falseBeforeTrue() {
+        let identity = makeColumn(name: "A", dataType: "NUMBER", internalID: 1, isIdentity: true)
+        let plain = makeColumn(name: "B", dataType: "NUMBER", internalID: 2, isIdentity: false)
+
+        let sorted = [identity, plain].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.isIdentitySortKey, order: .forward)
+        ])
+
+        XCTAssertEqual(sorted.map(\.isIdentity), [false, true])
+    }
+
+    func test_sortByDefault_treatsNilAsEmptyString() {
+        let withDefault = makeColumn(name: "A", dataType: "NUMBER", internalID: 1, defaultValue: "0")
+        let noDefault = makeColumn(name: "B", dataType: "NUMBER", internalID: 2, defaultValue: nil)
+        let longDefault = makeColumn(name: "C", dataType: "VARCHAR2", internalID: 3, defaultValue: "hello")
+
+        let sorted = [withDefault, longDefault, noDefault].sorted(using: [
+            KeyPathComparator(\DBCacheTableColumn.defaultValueSortKey, order: .forward)
+        ])
+
+        // nil ("") < "0" < "hello"
+        XCTAssertEqual(sorted.map(\.defaultValueSortKey), ["", "0", "hello"])
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #35, addressing review notes on the new SwiftUI Columns grid and the right-side detail panel.

- **Inspector consolidation** — drop the collapsible "Object details" accordion. The right-side Inspector is now the single home for object-level metadata and swaps to child-row detail when a column / index / trigger is selected in the corresponding sub-tab. Rebind ⌘I to toggle the Inspector and surface the shortcut as a key badge next to the button label.
- **Inspector styling** — back the panel with `NSVisualEffectView(material: .sidebar, blendingMode: .behindWindow)` so it picks up the same vibrancy as the navigation sidebar instead of the flat `.regularMaterial` panel.
- **Columns grid** — drop the redundant `Data Type Mod` column and the `Internal ID` column (still surfaced in the Inspector); render `HIDDEN_COLUMN = Y` rows in italic / `.secondary`. Make every visible header sortable: String columns use `init(_:value:comparator:content:)`; non-String columns use `init(_:sortUsing:content:)` with `KeyPathComparator`. The Table is wired up with a `sortOrder:` binding and `Array.sorted(using:)` so clicks actually flow. Added small sort-key shims for the NSNumber? / String? / Bool properties that aren't directly `Comparable`.
- **Child selection** — lifted row selection out of each list view into a `DBChildSelection` enum owned by `DBDetailView`. Cleared on `dbObject` change or sub-tab change.
- **Warnings** — addressed macOS 26 SDK warnings at the root: existential `Decoder` → `any Decoder`; dropped redundant `MainActor.run` / `MainActor.assumeIsolated` blocks (Task body and NSView already inherit `@MainActor`); acknowledged `NSView.window`'s `unowned(unsafe)` bridge with the `unsafe` keyword; replaced deprecated `Text + Text` highlight with `AttributedString`.

## Test plan

- [x] `xcodebuild -scheme Macintora build` — clean, zero warnings.
- [x] `TableTableColumnsSortTests` (10 cases) — pins `Array.sorted(using:)` against an in-memory `PersistenceController` for every sortable column (Column ID nil-last, Column Name asc/desc, Datatype, Length, Nullable, Identity, Default nil-as-empty, default fetch-order comparator, empty-sort no-op).
- [ ] Manual smoke: open a table in DB Browser; verify every column header sorts; select a column → Inspector shows column detail; switch to Indexes/Triggers tab and select a row → Inspector shows that row's detail; ⌘I toggles the Inspector.